### PR TITLE
feat: add shared browser-profile package and improve selector stability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,8 @@ actionbook/
 ├── services/
 │   ├── db/                 # @actionbookdev/db - Database Schema + Types (Drizzle ORM)
 │   ├── action-builder/     # Action recording, validation, Eval (local)
-│   └── knowledge-builder/  # Scenario knowledge extraction, Eval (local)
+│   ├── knowledge-builder/  # Scenario knowledge extraction, Eval (local)
+│   └── common/             # Shared internal packages for services
 ├── playground/             # Demo and example projects
 └── old_projects/           # Legacy/archived projects
 ```

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,7 +41,8 @@ actionbook/
 ├── services/
 │   ├── db/                 # @actionbookdev/db - Database Schema + Types (Drizzle ORM)
 │   ├── action-builder/     # Action recording, validation, Eval (local)
-│   └── knowledge-builder/  # Scenario knowledge extraction, Eval (local)
+│   ├── knowledge-builder/  # Scenario knowledge extraction, Eval (local)
+│   └── common/             # Shared internal packages for services
 ├── playground/             # Experimental code and quickstarts
 └── old_projects/           # Legacy/archived projects
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,6 +184,9 @@ importers:
 
   services/action-builder:
     dependencies:
+      '@actionbookdev/browser-profile':
+        specifier: workspace:*
+        version: link:../common/browser-profile
       '@actionbookdev/db':
         specifier: workspace:*
         version: link:../db
@@ -249,36 +252,29 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.3)(lightningcss@1.30.2)
 
-  services/action-builder/eval:
-    dependencies:
-      braintrust:
-        specifier: ^0.0.182
-        version: 0.0.182(openai@4.104.0(ws@8.18.3(bufferutil@4.1.0))(zod@3.25.76))(react@19.2.3)(sswr@2.2.0(svelte@5.46.1))(svelte@5.46.1)(vue@3.5.26(typescript@5.9.3))(zod@3.25.76)
-      dotenv:
-        specifier: ^17.2.3
-        version: 17.2.3
-      playwright:
-        specifier: ^1.57.0
-        version: 1.57.0
-      yaml:
-        specifier: ^2.7.0
-        version: 2.8.2
+  services/common/browser-profile:
     devDependencies:
-      tsx:
-        specifier: ^4.21.0
-        version: 4.21.0
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
-        specifier: ^5.9.3
+        specifier: ^5.7.2
         version: 5.9.3
 
   services/db:
     dependencies:
+      '@neondatabase/serverless':
+        specifier: ^0.10.4
+        version: 0.10.4
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.44.7
-        version: 0.44.7(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
+        version: 0.44.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3)
       pg:
         specifier: ^8.16.3
         version: 8.16.3
@@ -304,6 +300,9 @@ importers:
 
   services/knowledge-builder:
     dependencies:
+      '@actionbookdev/browser-profile':
+        specifier: workspace:*
+        version: link:../common/browser-profile
       '@actionbookdev/db':
         specifier: workspace:*
         version: link:../db
@@ -1223,89 +1222,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1387,6 +1402,9 @@ packages:
     resolution: {integrity: sha512-Z+CZ3QaosfFaTqvhQsIktyGrjFjSC0Fa4EMph4mqKnWhmyoGICsV/8QK+8HpXut6zV7zwfWwqDmEjtk1Qf6EgQ==}
     engines: {node: '>=14.0.0'}
 
+  '@neondatabase/serverless@0.10.4':
+    resolution: {integrity: sha512-2nZuh3VUO9voBauuh+IGYRhGU/MskWHt1IuZvHcJw6GLjDgtqj/KViKo7SIrLdGLdot7vFbiRRw+BgEy3wT9HA==}
+
   '@neondatabase/serverless@1.0.2':
     resolution: {integrity: sha512-I5sbpSIAHiB+b6UttofhrN/UJXII+4tZPAq1qugzwCwLIL8EZLV7F/JyHUrEIiGgQpEXzpnjlJ+zwcEhheGvCw==}
     engines: {node: '>=19.0.0'}
@@ -1414,24 +1432,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.1':
     resolution: {integrity: sha512-MFHrgL4TXNQbBPzkKKur4Fb5ICEJa87HM7fczFs2+HWblM7mMLdco3dvyTI+QmLBU9xgns/EeeINSZD6Ar+oLg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.1':
     resolution: {integrity: sha512-20bYDfgOQAPUkkKBnyP9PTuHiJGM7HzNBbuqmD0jiFVZ0aOldz+VnJhbxzjcSabYsnNjMPsE0cyzEudpYxsrUQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.1':
     resolution: {integrity: sha512-9pRbK3M4asAHQRkwaXwu601oPZHghuSC8IXNENgbBSyImHv/zY4K5udBusgdHkvJ/Tcr96jJwQYOll0qU8+fPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.1':
     resolution: {integrity: sha512-bdfQkggaLgnmYrFkSQfsHfOhk/mCYmjnrbRCGgkMcoOBZ4n+TRRSLmT/CU5SATzlBJ9TpioUyBW/vWFXTqQRiA==}
@@ -1505,56 +1527,67 @@ packages:
     resolution: {integrity: sha512-EHMUcDwhtdRGlXZsGSIuXSYwD5kOT9NVnx9sqzYiwAc91wfYOE1g1djOEDseZJKKqtHAHGwnGPQu3kytmfaXLQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.54.0':
     resolution: {integrity: sha512-+pBrqEjaakN2ySv5RVrj/qLytYhPKEUwk+e3SFU5jTLHIcAtqh2rLrd/OkbNuHJpsBgxsD8ccJt5ga/SeG0JmA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.54.0':
     resolution: {integrity: sha512-NSqc7rE9wuUaRBsBp5ckQ5CVz5aIRKCwsoa6WMF7G01sX3/qHUw/z4pv+D+ahL1EIKy6Enpcnz1RY8pf7bjwng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.54.0':
     resolution: {integrity: sha512-gr5vDbg3Bakga5kbdpqx81m2n9IX8M6gIMlQQIXiLTNeQW6CucvuInJ91EuCJ/JYvc+rcLLsDFcfAD1K7fMofg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.54.0':
     resolution: {integrity: sha512-gsrtB1NA3ZYj2vq0Rzkylo9ylCtW/PhpLEivlgWe0bpgtX5+9j9EZa0wtZiCjgu6zmSeZWyI/e2YRX1URozpIw==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.54.0':
     resolution: {integrity: sha512-y3qNOfTBStmFNq+t4s7Tmc9hW2ENtPg8FeUD/VShI7rKxNW7O4fFeaYbMsd3tpFlIg1Q8IapFgy7Q9i2BqeBvA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.54.0':
     resolution: {integrity: sha512-89sepv7h2lIVPsFma8iwmccN7Yjjtgz0Rj/Ou6fEqg3HDhpCa+Et+YSufy27i6b0Wav69Qv4WBNl3Rs6pwhebQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.54.0':
     resolution: {integrity: sha512-ZcU77ieh0M2Q8Ur7D5X7KvK+UxbXeDHwiOt/CPSBTI1fBmeDMivW0dPkdqkT4rOgDjrDDBUed9x4EgraIKoR2A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.54.0':
     resolution: {integrity: sha512-2AdWy5RdDF5+4YfG/YesGDDtbyJlC9LHmL6rZw6FurBJ5n4vFGupsOBGfwMRjBYH7qRQowT8D/U4LoSvVwOhSQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.54.0':
     resolution: {integrity: sha512-WGt5J8Ij/rvyqpFexxk3ffKqqbLf9AqrTBbWDk7ApGUzaIs6V+s2s84kAxklFwmMF/vBNGrVdYgbblCOFFezMQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.54.0':
     resolution: {integrity: sha512-JzQmb38ATzHjxlPHuTH6tE7ojnMKM2kYNzt44LO/jJi8BpceEC8QuXYA908n8r3CNuG/B3BV8VR3Hi1rYtmPiw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.54.0':
     resolution: {integrity: sha512-huT3fd0iC7jigGh7n3q/+lfPcXxBi+om/Rs3yiFxjvSxbSB6aohDFXbWvlspaqjeOh+hx7DDHS+5Es5qRkWkZg==}
@@ -1654,6 +1687,9 @@ packages:
 
   '@types/node@24.10.4':
     resolution: {integrity: sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==}
+
+  '@types/pg@8.11.6':
+    resolution: {integrity: sha512-/2WmmBXHLsfRqzfHW7BNZ8SbYzE8OSk7i3WjFYvfgRHj7S1xj+16Je5fUKv3lVdVzk/zn9TXOqf+avFCFIE0yQ==}
 
   '@types/pg@8.16.0':
     resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
@@ -2856,24 +2892,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3073,6 +3113,9 @@ packages:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
 
+  obuf@1.1.2:
+    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
+
   ollama-ai-provider-v2@1.5.5:
     resolution: {integrity: sha512-1YwTFdPjhPNHny/DrOHO+s8oVGGIE5Jib61/KnnjPRNWQhVVimrJJdaAX3e6nNRRDXrY5zbb9cfm2+yVvgsrqw==}
     engines: {node: '>=18'}
@@ -3207,6 +3250,10 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
+  pg-numeric@1.0.2:
+    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
+    engines: {node: '>=4'}
+
   pg-pool@3.10.1:
     resolution: {integrity: sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==}
     peerDependencies:
@@ -3218,6 +3265,10 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
+
+  pg-types@4.1.0:
+    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
+    engines: {node: '>=10'}
 
   pg@8.16.3:
     resolution: {integrity: sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==}
@@ -3310,17 +3361,36 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
+  postgres-array@3.0.4:
+    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
+    engines: {node: '>=12'}
+
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-bytea@3.0.0:
+    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
+    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
+  postgres-date@2.1.0:
+    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
+    engines: {node: '>=12'}
+
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres-interval@3.0.0:
+    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
+    engines: {node: '>=12'}
+
+  postgres-range@1.1.4:
+    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -4875,6 +4945,10 @@ snapshots:
 
   '@mozilla/readability@0.5.0': {}
 
+  '@neondatabase/serverless@0.10.4':
+    dependencies:
+      '@types/pg': 8.11.6
+
   '@neondatabase/serverless@1.0.2':
     dependencies:
       '@types/node': 22.19.3
@@ -5091,6 +5165,12 @@ snapshots:
   '@types/node@24.10.4':
     dependencies:
       undici-types: 7.16.0
+
+  '@types/pg@8.11.6':
+    dependencies:
+      '@types/node': 20.19.27
+      pg-protocol: 1.10.3
+      pg-types: 4.1.0
 
   '@types/pg@8.16.0':
     dependencies:
@@ -5736,6 +5816,13 @@ snapshots:
       esbuild-register: 3.6.0(esbuild@0.25.12)
     transitivePeerDependencies:
       - supports-color
+
+  drizzle-orm@0.44.7(@neondatabase/serverless@0.10.4)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3):
+    optionalDependencies:
+      '@neondatabase/serverless': 0.10.4
+      '@opentelemetry/api': 1.9.0
+      '@types/pg': 8.16.0
+      pg: 8.16.3
 
   drizzle-orm@0.44.7(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(pg@8.16.3):
     optionalDependencies:
@@ -6570,6 +6657,8 @@ snapshots:
 
   object-inspect@1.13.4: {}
 
+  obuf@1.1.2: {}
+
   ollama-ai-provider-v2@1.5.5(zod@3.25.76):
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -6706,6 +6795,8 @@ snapshots:
 
   pg-int8@1.0.1: {}
 
+  pg-numeric@1.0.2: {}
+
   pg-pool@3.10.1(pg@8.16.3):
     dependencies:
       pg: 8.16.3
@@ -6719,6 +6810,16 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
+
+  pg-types@4.1.0:
+    dependencies:
+      pg-int8: 1.0.1
+      pg-numeric: 1.0.2
+      postgres-array: 3.0.4
+      postgres-bytea: 3.0.0
+      postgres-date: 2.1.0
+      postgres-interval: 3.0.0
+      postgres-range: 1.1.4
 
   pg@8.16.3:
     dependencies:
@@ -6821,13 +6922,25 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
+  postgres-array@3.0.4: {}
+
   postgres-bytea@1.0.1: {}
 
+  postgres-bytea@3.0.0:
+    dependencies:
+      obuf: 1.1.2
+
   postgres-date@1.0.7: {}
+
+  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres-interval@3.0.0: {}
+
+  postgres-range@1.1.4: {}
 
   pretty-format@29.7.0:
     dependencies:

--- a/services/action-builder/package.json
+++ b/services/action-builder/package.json
@@ -36,6 +36,7 @@
     "login": "npx tsx scripts/login.ts"
   },
   "dependencies": {
+    "@actionbookdev/browser-profile": "workspace:*",
     "@actionbookdev/db": "workspace:*",
     "@actionbookdev/mcp": "workspace:*",
     "@ai-sdk/amazon-bedrock": "^3.0.70",

--- a/services/action-builder/scripts/login.ts
+++ b/services/action-builder/scripts/login.ts
@@ -12,7 +12,7 @@
  */
 
 import { Stagehand } from "@browserbasehq/stagehand";
-import { BrowserProfileManager, DEFAULT_PROFILE_DIR } from "../src/browser/BrowserProfileManager.js";
+import { BrowserProfileManager, DEFAULT_PROFILE_DIR, ANTI_DETECTION_ARGS, IGNORE_DEFAULT_ARGS } from "../src/browser/BrowserProfileManager.js";
 import readline from "readline";
 
 // Parse command line arguments
@@ -88,16 +88,13 @@ async function main() {
     console.log(`🌐 Using proxy: ${proxyUrl}`);
   }
 
-  // Build browser launch options
+  // Build browser launch options using common constants
   const localBrowserLaunchOptions: Record<string, unknown> = {
     headless: false,
     userDataDir: profileManager.getProfilePath(),
     preserveUserDataDir: true,
-    args: [
-      "--disable-blink-features=AutomationControlled",
-      "--no-first-run",
-    ],
-    ignoreDefaultArgs: ["--enable-automation"],
+    args: ANTI_DETECTION_ARGS,
+    ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
   };
 
   // Add proxy if configured

--- a/services/action-builder/src/browser/BrowserProfileManager.ts
+++ b/services/action-builder/src/browser/BrowserProfileManager.ts
@@ -1,149 +1,16 @@
-import fs from "fs";
-import path from "path";
-import { log } from "../utils/logger.js";
-
 /**
- * Profile configuration options
+ * Re-export BrowserProfileManager from @actionbookdev/browser-profile
+ *
+ * This file maintains backward compatibility for existing imports.
+ * New code should import directly from "@actionbookdev/browser-profile".
  */
-export interface ProfileConfig {
-  /** Base directory for profile storage, default: '.browser-profile' */
-  baseDir?: string;
-}
 
-/**
- * Default profile directory path (relative to project root)
- */
-export const DEFAULT_PROFILE_DIR = ".browser-profile";
-
-/**
- * BrowserProfileManager - Manages browser profile for persistent login state
- *
- * Uses Playwright's userDataDir feature to persist browser state (cookies, localStorage, etc.)
- * across sessions. This enables "login once, reuse many times" workflow.
- *
- * @example
- * ```typescript
- * const manager = new BrowserProfileManager();
- *
- * // Check if profile exists
- * if (!manager.exists()) {
- *   console.log('Run: pnpm login');
- * }
- *
- * // Get profile path for Stagehand
- * const profilePath = manager.getProfilePath();
- * ```
- */
-export class BrowserProfileManager {
-  private readonly baseDir: string;
-
-  constructor(config?: ProfileConfig) {
-    this.baseDir = config?.baseDir || DEFAULT_PROFILE_DIR;
-  }
-
-  /**
-   * Get the absolute path to the browser profile directory
-   */
-  getProfilePath(): string {
-    return path.resolve(process.cwd(), this.baseDir);
-  }
-
-  /**
-   * Check if the browser profile exists
-   */
-  exists(): boolean {
-    const profilePath = this.getProfilePath();
-    return fs.existsSync(profilePath);
-  }
-
-  /**
-   * Ensure the profile directory exists
-   */
-  ensureDir(): void {
-    const profilePath = this.getProfilePath();
-    if (!fs.existsSync(profilePath)) {
-      fs.mkdirSync(profilePath, { recursive: true });
-      log("info", `[BrowserProfileManager] Created profile directory: ${profilePath}`);
-    }
-  }
-
-  /**
-   * Clear the browser profile (delete all data)
-   */
-  clear(): void {
-    const profilePath = this.getProfilePath();
-    if (fs.existsSync(profilePath)) {
-      fs.rmSync(profilePath, { recursive: true, force: true });
-      log("info", `[BrowserProfileManager] Cleared profile directory: ${profilePath}`);
-    }
-  }
-
-  /**
-   * Clean up stale lock files left behind by crashed browser instances
-   * Chrome creates SingletonLock to prevent multiple instances from using the same profile.
-   * If Chrome crashes or is killed, this file may not be deleted, causing startup issues.
-   */
-  cleanupStaleLocks(): void {
-    const profilePath = this.getProfilePath();
-    const lockFiles = ["SingletonLock", "SingletonSocket", "SingletonCookie"];
-
-    for (const lockFile of lockFiles) {
-      const lockPath = path.join(profilePath, lockFile);
-      if (fs.existsSync(lockPath)) {
-        try {
-          fs.unlinkSync(lockPath);
-          log("info", `[BrowserProfileManager] Cleaned up stale lock file: ${lockFile}`);
-        } catch (error) {
-          log("warn", `[BrowserProfileManager] Failed to remove ${lockFile}: ${error}`);
-        }
-      }
-    }
-  }
-
-  /**
-   * Get profile info for display
-   */
-  getInfo(): { exists: boolean; path: string; size?: string } {
-    const profilePath = this.getProfilePath();
-    const exists = this.exists();
-
-    if (!exists) {
-      return { exists, path: profilePath };
-    }
-
-    // Calculate directory size
-    let totalSize = 0;
-    try {
-      const calculateSize = (dir: string): number => {
-        let size = 0;
-        const files = fs.readdirSync(dir);
-        for (const file of files) {
-          const filePath = path.join(dir, file);
-          const stat = fs.statSync(filePath);
-          if (stat.isDirectory()) {
-            size += calculateSize(filePath);
-          } else {
-            size += stat.size;
-          }
-        }
-        return size;
-      };
-      totalSize = calculateSize(profilePath);
-    } catch {
-      // Ignore size calculation errors
-    }
-
-    // Format size
-    const formatSize = (bytes: number): string => {
-      if (bytes < 1024) return `${bytes} B`;
-      if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-    };
-
-    return {
-      exists,
-      path: profilePath,
-      size: formatSize(totalSize),
-    };
-  }
-}
+export {
+  BrowserProfileManager,
+  DEFAULT_PROFILE_DIR,
+  ANTI_DETECTION_ARGS,
+  IGNORE_DEFAULT_ARGS,
+  type ProfileConfig,
+  type ProfileInfo,
+  type ProfileLogger,
+} from "@actionbookdev/browser-profile";

--- a/services/action-builder/src/optimizer/SelectorOptimizer.ts
+++ b/services/action-builder/src/optimizer/SelectorOptimizer.ts
@@ -292,19 +292,26 @@ UNSTABLE patterns to detect:
 - User-specific: Contains usernames, IDs like "user-12345"
 - Session-specific: Random tokens, session IDs
 - Framework-generated IDs: "#ember123", "#react-xxx", ".ng-c123", ":r0:", ":r1:", "#radix-123"
+- Hash-based CSS classes (change on each build):
+  - CSS Modules: ".styles_button__x7y8z", ".Component_name__hash"
+  - styled-components: ".sc-1a2b3c", ".sc-aBcDeF"
+  - Emotion: ".css-1a2b3c", ".css-xxxxxx"
+  - Generic hash patterns: classes ending with "_[a-z0-9]{5,}", "__[a-z0-9]{5,}", or "-[a-z0-9]{6,}"
 
 STABLE patterns (prefer these):
 - data-testid: Always stable, designed for testing
+- data-* attributes: data-id, data-component, data-element, data-action, data-section (semantic, stable)
 - Static aria-label: "Submit", "Close", "Search" (no dynamic content)
 - Semantic IDs: "main-nav", "search-button"
 - BEM class names: "header__nav-item", "btn--primary"
 
 SELECTOR PRIORITY (when all are stable):
 1. data-testid (most stable)
-2. id selector (#id)
-3. Static aria-label
-4. Semantic CSS class
-5. XPath (least preferred)
+2. Other semantic data-* attributes (data-id, data-component, etc.)
+3. id selector (#id)
+4. Static aria-label
+5. Semantic CSS class
+6. XPath (least preferred)
 
 Return JSON array with your analysis.`
 

--- a/services/action-builder/src/recorder/ActionRecorder.ts
+++ b/services/action-builder/src/recorder/ActionRecorder.ts
@@ -282,9 +282,11 @@ export class ActionRecorder {
     }
 
     // 4. data-* attributes (including date strings)
+    const addedDataAttrs = new Set<string>();
     if (additionalInfo?.dataAttributes) {
       for (const [attrName, attrValue] of Object.entries(additionalInfo.dataAttributes)) {
         const attrSelector = `[${attrName}="${attrValue}"]`;
+        addedDataAttrs.add(attrSelector);
         const templateInfo = this.detectTemplatePattern(attrSelector);
         selectors.push({
           type: 'css' as SelectorType,
@@ -297,8 +299,8 @@ export class ActionRecorder {
       }
     }
 
-    // 5. CSS selector
-    if (cssSelector) {
+    // 5. CSS selector (skip if already added as data-* attribute)
+    if (cssSelector && !addedDataAttrs.has(cssSelector)) {
       const templateInfo = this.detectTemplatePattern(cssSelector);
       if (templateInfo) {
         selectors.push({

--- a/services/common/browser-profile/package.json
+++ b/services/common/browser-profile/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@actionbookdev/browser-profile",
+  "version": "0.1.0",
+  "description": "Browser profile management for persistent login state",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.2"
+  },
+  "files": [
+    "dist"
+  ],
+  "keywords": [
+    "actionbook",
+    "browser",
+    "profile",
+    "playwright"
+  ]
+}

--- a/services/common/browser-profile/src/BrowserProfileManager.ts
+++ b/services/common/browser-profile/src/BrowserProfileManager.ts
@@ -1,0 +1,239 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Logger function type for BrowserProfileManager
+ */
+export type ProfileLogger = (
+  level: "info" | "warn" | "error" | "debug",
+  message: string
+) => void;
+
+/**
+ * Default console logger
+ */
+const defaultLogger: ProfileLogger = (level, message) => {
+  const prefix = `[BrowserProfileManager]`;
+  switch (level) {
+    case "error":
+      console.error(`${prefix} ${message}`);
+      break;
+    case "warn":
+      console.warn(`${prefix} ${message}`);
+      break;
+    case "debug":
+      // Only log debug in development
+      if (process.env.DEBUG) {
+        console.debug(`${prefix} ${message}`);
+      }
+      break;
+    default:
+      console.log(`${prefix} ${message}`);
+  }
+};
+
+/**
+ * Profile configuration options
+ */
+export interface ProfileConfig {
+  /** Base directory for profile storage, default: '.browser-profile' */
+  baseDir?: string;
+  /** Custom logger function */
+  logger?: ProfileLogger;
+}
+
+/**
+ * Profile information returned by getInfo()
+ */
+export interface ProfileInfo {
+  exists: boolean;
+  path: string;
+  size?: string;
+}
+
+/**
+ * Default profile directory path (relative to project root)
+ */
+export const DEFAULT_PROFILE_DIR = ".browser-profile";
+
+/**
+ * Anti-detection browser arguments for Chromium
+ * Use these when launching browser with persistent profile
+ */
+export const ANTI_DETECTION_ARGS = [
+  "--disable-blink-features=AutomationControlled",
+  "--no-first-run",
+];
+
+/**
+ * Default args to ignore when launching with anti-detection
+ */
+export const IGNORE_DEFAULT_ARGS = ["--enable-automation"];
+
+/**
+ * BrowserProfileManager - Manages browser profile for persistent login state
+ *
+ * Uses Playwright's userDataDir feature to persist browser state (cookies, localStorage, etc.)
+ * across sessions. This enables "login once, reuse many times" workflow.
+ *
+ * @example
+ * ```typescript
+ * const manager = new BrowserProfileManager();
+ *
+ * // Check if profile exists
+ * if (!manager.exists()) {
+ *   console.log('Run: pnpm login');
+ * }
+ *
+ * // Get profile path for Playwright/Stagehand
+ * const profilePath = manager.getProfilePath();
+ *
+ * // Configure browser launch options
+ * const launchOptions = {
+ *   userDataDir: profilePath,
+ *   preserveUserDataDir: true,
+ *   args: ANTI_DETECTION_ARGS,
+ *   ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
+ * };
+ * ```
+ */
+export class BrowserProfileManager {
+  private readonly baseDir: string;
+  private readonly logger: ProfileLogger;
+
+  constructor(config?: ProfileConfig) {
+    this.baseDir = config?.baseDir || DEFAULT_PROFILE_DIR;
+    this.logger = config?.logger || defaultLogger;
+  }
+
+  /**
+   * Get the absolute path to the browser profile directory
+   */
+  getProfilePath(): string {
+    return path.resolve(process.cwd(), this.baseDir);
+  }
+
+  /**
+   * Check if the browser profile exists
+   */
+  exists(): boolean {
+    const profilePath = this.getProfilePath();
+    return fs.existsSync(profilePath);
+  }
+
+  /**
+   * Ensure the profile directory exists
+   */
+  ensureDir(): void {
+    const profilePath = this.getProfilePath();
+    if (!fs.existsSync(profilePath)) {
+      fs.mkdirSync(profilePath, { recursive: true });
+      this.logger("info", `Created profile directory: ${profilePath}`);
+    }
+  }
+
+  /**
+   * Clear the browser profile (delete all data)
+   */
+  clear(): void {
+    const profilePath = this.getProfilePath();
+    if (fs.existsSync(profilePath)) {
+      fs.rmSync(profilePath, { recursive: true, force: true });
+      this.logger("info", `Cleared profile directory: ${profilePath}`);
+    }
+  }
+
+  /**
+   * Clean up stale lock files left behind by crashed browser instances
+   * Chrome creates SingletonLock to prevent multiple instances from using the same profile.
+   * If Chrome crashes or is killed, this file may not be deleted, causing startup issues.
+   */
+  cleanupStaleLocks(): void {
+    const profilePath = this.getProfilePath();
+    const lockFiles = ["SingletonLock", "SingletonSocket", "SingletonCookie"];
+
+    for (const lockFile of lockFiles) {
+      const lockPath = path.join(profilePath, lockFile);
+      if (fs.existsSync(lockPath)) {
+        try {
+          fs.unlinkSync(lockPath);
+          this.logger("info", `Cleaned up stale lock file: ${lockFile}`);
+        } catch (error) {
+          this.logger("warn", `Failed to remove ${lockFile}: ${error}`);
+        }
+      }
+    }
+  }
+
+  /**
+   * Get profile info for display
+   */
+  getInfo(): ProfileInfo {
+    const profilePath = this.getProfilePath();
+    const exists = this.exists();
+
+    if (!exists) {
+      return { exists, path: profilePath };
+    }
+
+    // Calculate directory size
+    let totalSize = 0;
+    try {
+      const calculateSize = (dir: string): number => {
+        let size = 0;
+        const files = fs.readdirSync(dir);
+        for (const file of files) {
+          const filePath = path.join(dir, file);
+          const stat = fs.statSync(filePath);
+          if (stat.isDirectory()) {
+            size += calculateSize(filePath);
+          } else {
+            size += stat.size;
+          }
+        }
+        return size;
+      };
+      totalSize = calculateSize(profilePath);
+    } catch {
+      // Ignore size calculation errors
+    }
+
+    // Format size
+    const formatSize = (bytes: number): string => {
+      if (bytes < 1024) return `${bytes} B`;
+      if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+      return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
+    return {
+      exists,
+      path: profilePath,
+      size: formatSize(totalSize),
+    };
+  }
+
+  /**
+   * Get browser launch options configured for persistent profile
+   * Returns options compatible with Playwright/Stagehand localBrowserLaunchOptions
+   */
+  getLaunchOptions(options?: {
+    headless?: boolean;
+    proxy?: { server: string };
+  }): Record<string, unknown> {
+    this.cleanupStaleLocks();
+
+    const launchOptions: Record<string, unknown> = {
+      headless: options?.headless ?? false,
+      userDataDir: this.getProfilePath(),
+      preserveUserDataDir: true,
+      args: ANTI_DETECTION_ARGS,
+      ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
+    };
+
+    if (options?.proxy) {
+      launchOptions.proxy = options.proxy;
+    }
+
+    return launchOptions;
+  }
+}

--- a/services/common/browser-profile/src/index.ts
+++ b/services/common/browser-profile/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @actionbookdev/browser-profile
+ *
+ * Browser profile management for persistent login state.
+ * Enables "login once, reuse many times" workflow.
+ */
+
+export {
+  BrowserProfileManager,
+  DEFAULT_PROFILE_DIR,
+  ANTI_DETECTION_ARGS,
+  IGNORE_DEFAULT_ARGS,
+  type ProfileConfig,
+  type ProfileInfo,
+  type ProfileLogger,
+} from "./BrowserProfileManager.js";

--- a/services/common/browser-profile/tsconfig.json
+++ b/services/common/browser-profile/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/services/common/browser-profile/tsup.config.ts
+++ b/services/common/browser-profile/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+});

--- a/services/db/package.json
+++ b/services/db/package.json
@@ -21,6 +21,7 @@
     "studio": "NODE_TLS_REJECT_UNAUTHORIZED=0 drizzle-kit studio"
   },
   "dependencies": {
+    "@neondatabase/serverless": "^0.10.4",
     "dotenv": "^16.4.7",
     "drizzle-orm": "^0.44.7",
     "pg": "^8.16.3"

--- a/services/db/src/connection.ts
+++ b/services/db/src/connection.ts
@@ -1,47 +1,82 @@
-import { drizzle } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzlePg } from 'drizzle-orm/node-postgres';
+import { drizzle as drizzleNeon } from 'drizzle-orm/neon-http';
+import { neon } from '@neondatabase/serverless';
 import { Pool } from 'pg';
 import * as schema from './schema';
 
-// Store pool reference for closing
-const poolMap = new WeakMap<ReturnType<typeof drizzle>, Pool>();
+// Store pool reference for closing (only used for pg connections)
+const poolMap = new WeakMap<ReturnType<typeof drizzlePg>, Pool>();
 
 /**
- * Create a database connection using the DATABASE_URL environment variable.
- * Uses node-postgres (pg) driver for local/standard PostgreSQL.
+ * Check if running in local environment.
+ * Local = not production AND not on Vercel.
+ */
+function isLocalEnv(): boolean {
+  return process.env.NODE_ENV !== 'production' && !process.env.VERCEL;
+}
+
+/**
+ * Create a database connection.
+ *
+ * Connection strategy:
+ * - Local environment + DATABASE_URL: Use node-postgres (pg) driver
+ * - Otherwise (Vercel/production): Use Neon serverless driver with POSTGRES_URL
  */
 export function createDb(databaseUrl?: string) {
-  const url = databaseUrl ?? process.env.DATABASE_URL;
-  if (!url) {
-    throw new Error('DATABASE_URL environment variable is required');
+  const isLocal = isLocalEnv();
+  const localDbUrl = databaseUrl ?? process.env.DATABASE_URL;
+
+  if (isLocal && localDbUrl) {
+    // Local environment with DATABASE_URL: use node-postgres
+    return createPgDb(localDbUrl);
   }
 
-  // Enable SSL if:
-  // 1. NODE_ENV is production, OR
-  // 2. URL contains sslmode parameter, OR
-  // 3. URL is not localhost/127.0.0.1
+  // Production/Vercel: use Neon serverless
+  const neonUrl = process.env.POSTGRES_URL;
+  if (!neonUrl) {
+    throw new Error(
+      'Database URL not found. Set DATABASE_URL for local or POSTGRES_URL for Neon.'
+    );
+  }
+  return createNeonDb(neonUrl);
+}
+
+/**
+ * Create a PostgreSQL connection using node-postgres driver.
+ * Used for local development.
+ */
+function createPgDb(url: string) {
   const isLocalhost = url.includes('localhost') || url.includes('127.0.0.1');
   const hasSslParam = url.includes('sslmode=');
-  const isProduction = process.env.NODE_ENV === 'production';
-  const needsSsl = isProduction || hasSslParam || !isLocalhost;
+  const needsSsl = hasSslParam || !isLocalhost;
 
   const pool = new Pool({
     connectionString: url,
-    // Enable SSL for remote databases, skip certificate verification
     ssl: needsSsl ? { rejectUnauthorized: false } : false,
   });
-  const db = drizzle(pool, { schema });
+  const db = drizzlePg(pool, { schema });
   poolMap.set(db, pool);
   return db;
 }
 
 /**
+ * Create a Neon serverless connection.
+ * Used for Vercel/production environment.
+ */
+function createNeonDb(url: string) {
+  const sql = neon(url);
+  return drizzleNeon(sql, { schema });
+}
+
+/**
  * Close a database connection and release the pool.
+ * Only works for pg connections; Neon connections are stateless.
  */
 export async function closeDb(db: ReturnType<typeof createDb>): Promise<void> {
-  const pool = poolMap.get(db);
+  const pool = poolMap.get(db as ReturnType<typeof drizzlePg>);
   if (pool) {
     await pool.end();
-    poolMap.delete(db);
+    poolMap.delete(db as ReturnType<typeof drizzlePg>);
   }
 }
 

--- a/services/knowledge-builder/package.json
+++ b/services/knowledge-builder/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "tsx src/cli/worker.ts",
-    "build": "tsup"
+    "build": "tsup",
+    "login": "tsx scripts/login.ts"
   },
   "dependencies": {
+    "@actionbookdev/browser-profile": "workspace:*",
     "@actionbookdev/db": "workspace:*",
     "@mozilla/readability": "^0.5.0",
     "cheerio": "^1.1.2",

--- a/services/knowledge-builder/scripts/login.ts
+++ b/services/knowledge-builder/scripts/login.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env tsx
+/**
+ * Interactive browser login script
+ *
+ * Opens a browser with persistent profile for manual login.
+ * After logging in, close the browser and the session will be saved.
+ *
+ * Usage:
+ *   pnpm run login [url]
+ *
+ * Examples:
+ *   pnpm run login                          # Opens blank page
+ *   pnpm run login https://example.com      # Opens specific URL
+ */
+
+import { chromium } from 'playwright'
+import {
+  BrowserProfileManager,
+  ANTI_DETECTION_ARGS,
+  IGNORE_DEFAULT_ARGS,
+} from '@actionbookdev/browser-profile'
+
+async function main() {
+  const url = process.argv[2] || 'about:blank'
+  const profileDir = process.env.BROWSER_PROFILE_DIR
+
+  const profileManager = new BrowserProfileManager({
+    baseDir: profileDir,
+  })
+
+  // Clean up stale locks from crashed sessions
+  profileManager.cleanupStaleLocks()
+
+  const info = profileManager.getInfo()
+  if (info.exists) {
+    console.log(`Using existing profile: ${info.path} (${info.size})`)
+  } else {
+    console.log(`Creating new profile: ${info.path}`)
+  }
+
+  console.log(`\nOpening browser...`)
+  console.log(`URL: ${url}`)
+  console.log(`\n👉 Please login manually, then close the browser to save the session.\n`)
+
+  const context = await chromium.launchPersistentContext(
+    profileManager.getProfilePath(),
+    {
+      headless: false,
+      args: ANTI_DETECTION_ARGS,
+      ignoreDefaultArgs: IGNORE_DEFAULT_ARGS,
+    }
+  )
+
+  const page = await context.newPage()
+  await page.goto(url)
+
+  // Wait for browser to be closed by user
+  await new Promise<void>((resolve) => {
+    context.on('close', () => resolve())
+  })
+
+  console.log(`\n✅ Browser closed. Profile saved to: ${info.path}`)
+}
+
+main().catch((error) => {
+  console.error('Error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Extract `BrowserProfileManager` to shared package `@actionbookdev/browser-profile` in `services/common/`
- Add Neon serverless database support with auto-detection for local vs Vercel environment
- Improve selector extraction with data-* attribute priority and state attribute filtering

## Changes

### New: services/common/browser-profile
- Shared browser profile management for action-builder and knowledge-builder
- Persistent browser context with anti-detection args
- Stale lock cleanup for crashed sessions

### Database (services/db)
- Add `@neondatabase/serverless` support
- Auto-detect: local + DATABASE_URL → pg driver, otherwise → Neon serverless

### Selector Optimization (services/action-builder)
- Add `data-*` attributes to selector priority (after `data-testid`)
- Add hash-based CSS class detection (CSS Modules, styled-components, Emotion)
- Filter state-related data attributes (`data-state`, `data-checked`, etc.)
- Prevent duplicate selectors in extraction

### Knowledge Builder (services/knowledge-builder)
- Add `pnpm run login` script for manual browser login
- Integrate shared browser-profile package
- Show warning when profile not found

### Docs
- Add `services/common/` to CLAUDE.md and GEMINI.md

## Test plan

- [ ] Run `pnpm install` and `pnpm build` to verify dependencies
- [ ] Test `pnpm run login` in knowledge-builder
- [ ] Verify selector extraction includes data-* attributes
- [ ] Verify state attributes like `data-state=closed` are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)