### PR TITLE
Add request website link to Contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,7 +626,8 @@ pnpm dev
 
 ## Contributing
 
-We are currently in private beta. If you are interested in contributing or using Actionbook, please [join the waitlist](https://actionbook.dev).
+- **[Request a Website](https://actionbook.dev/request-website)** - Suggest websites you want Actionbook to index.
+- **[Join the Waitlist](https://actionbook.dev)** - We are currently in private beta. Join if you are interested in contributing or using Actionbook.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Add "Request a Website" item to Contributing section for users to suggest sites they want Actionbook to index
- Reformat existing waitlist content as a list item for consistency

## Test plan
- [x] Verify links work correctly in rendered README

🤖 Generated with [Claude Code](https://claude.com/claude-code)