### PR TITLE
[packages/cli] Add CLI package (@actionbookdev/cli)

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,154 @@
+# @actionbookdev/cli
+
+CLI for Actionbook - Get website action manuals for AI agents.
+
+## Installation
+
+```bash
+npm install -g @actionbookdev/cli
+```
+
+## Quick Start
+
+```bash
+# Search for actions
+actionbook search "airbnb search"
+
+# Get action details
+actionbook get "https://www.airbnb.com/search"
+
+# List available sources
+actionbook sources
+
+# Search sources
+actionbook sources search "linkedin"
+```
+
+## Commands
+
+### `actionbook search <query>`
+
+Search for action manuals by keyword.
+
+```bash
+actionbook search "google login"
+actionbook search "airbnb" --type vector --limit 10
+actionbook search "login" --source-ids 1,2,3
+```
+
+**Options:**
+- `-t, --type <type>` - Search type: `vector`, `fulltext`, or `hybrid` (default: `hybrid`)
+- `-l, --limit <number>` - Maximum results 1-100 (default: `5`)
+- `-s, --source-ids <ids>` - Filter by source IDs (comma-separated)
+- `--min-score <score>` - Minimum similarity score 0-1
+- `-j, --json` - Output raw JSON
+
+**Alias:** `actionbook s`
+
+### `actionbook get <id>`
+
+Get complete action details by action ID.
+
+```bash
+actionbook get "https://www.airbnb.com/search"
+actionbook get "airbnb.com/search"  # fuzzy matching supported
+actionbook get "releases.rs"        # domain only
+```
+
+**Options:**
+- `-j, --json` - Output raw JSON
+
+**Alias:** `actionbook g`
+
+### `actionbook sources`
+
+List all available sources (websites).
+
+```bash
+actionbook sources
+actionbook sources --limit 100
+actionbook sources --json
+```
+
+**Options:**
+- `-l, --limit <number>` - Maximum results (default: `50`)
+- `-j, --json` - Output raw JSON
+
+### `actionbook sources search <query>`
+
+Search for sources by keyword.
+
+```bash
+actionbook sources search "airbnb"
+actionbook sources search "e-commerce" --limit 20
+```
+
+**Options:**
+- `-l, --limit <number>` - Maximum results (default: `10`)
+- `-j, --json` - Output raw JSON
+
+**Alias:** `actionbook sources s`
+
+## Authentication
+
+Set your API key via environment variable:
+
+```bash
+export ACTIONBOOK_API_KEY=your_api_key
+```
+
+Or pass it as an option:
+
+```bash
+actionbook --api-key your_api_key search "query"
+```
+
+## Output Formats
+
+By default, the CLI outputs formatted, colorized results for human readability.
+
+Use `--json` flag for raw JSON output, useful for piping to other tools:
+
+```bash
+actionbook search "login" --json | jq '.results[0].action_id'
+```
+
+## Examples
+
+### Typical Workflow
+
+```bash
+# 1. Search for actions
+actionbook search "airbnb search"
+
+# 2. Get details for a specific action
+actionbook get "https://www.airbnb.com/search"
+
+# 3. Use the selectors in your automation script
+```
+
+### Filter by Source
+
+```bash
+# List sources to find IDs
+actionbook sources
+
+# Search within specific sources
+actionbook search "login" --source-ids 1,2
+```
+
+### JSON Output for Scripts
+
+```bash
+# Get action and extract selectors
+actionbook get "booking.com" --json | jq '.elements'
+```
+
+## Related Packages
+
+- [`@actionbookdev/sdk`](https://www.npmjs.com/package/@actionbookdev/sdk) - JavaScript/TypeScript SDK
+- [`@actionbookdev/mcp`](https://www.npmjs.com/package/@actionbookdev/mcp) - MCP Server for AI agents
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@actionbookdev/cli",
+  "version": "0.1.0",
+  "description": "CLI for Actionbook - Get website action manuals for AI agents",
+  "private": false,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "actionbook": "dist/index.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "dev": "tsc -p tsconfig.build.json --watch",
+    "test": "vitest run",
+    "lint": "eslint . --ext .ts",
+    "clean": "rimraf dist",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@actionbookdev/sdk": "workspace:*",
+    "commander": "^12.1.0",
+    "chalk": "^5.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.6.3",
+    "vitest": "^1.6.0",
+    "rimraf": "^5.0.5"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "keywords": [
+    "actionbook",
+    "cli",
+    "ai-agent",
+    "browser-automation",
+    "web-scraping",
+    "selectors"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/actionbook/actionbook.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://actionbook.dev",
+  "author": "Actionbook Team",
+  "license": "MIT"
+}

--- a/packages/cli/src/commands/get.ts
+++ b/packages/cli/src/commands/get.ts
@@ -1,0 +1,71 @@
+import { Command } from 'commander'
+import { Actionbook, formatActionDetail } from '@actionbookdev/sdk'
+import chalk from 'chalk'
+import { getApiKey, handleError, outputResult } from '../output.js'
+
+export const getCommand = new Command('get')
+  .alias('g')
+  .description('Get complete action details by action ID')
+  .argument('<id>', 'Action ID (URL or domain, e.g., "https://example.com/page" or "example.com/page")')
+  .option('-j, --json', 'Output raw JSON')
+  .action(async (id: string, options) => {
+    try {
+      const apiKey = getApiKey(options)
+      const client = new Actionbook({ apiKey })
+
+      const result = await client.getActionById(id)
+
+      if (options.json) {
+        outputResult(result)
+      } else {
+        // Formatted output
+        console.log(chalk.bold.cyan(`\n${result.heading || result.documentTitle}\n`))
+
+        console.log(chalk.bold('Metadata'))
+        console.log(chalk.dim('─'.repeat(50)))
+        console.log(`${chalk.gray('Action ID:')}    ${result.action_id}`)
+        console.log(`${chalk.gray('Document:')}     ${result.documentTitle}`)
+        console.log(`${chalk.gray('URL:')}          ${result.documentUrl}`)
+        console.log(`${chalk.gray('Chunk Index:')}  ${result.chunkIndex}`)
+        console.log(`${chalk.gray('Token Count:')}  ${result.tokenCount}`)
+        console.log()
+
+        console.log(chalk.bold('Content'))
+        console.log(chalk.dim('─'.repeat(50)))
+        console.log(result.content)
+        console.log()
+
+        if (result.elements) {
+          try {
+            const elements = JSON.parse(result.elements)
+            console.log(chalk.bold('UI Elements'))
+            console.log(chalk.dim('─'.repeat(50)))
+
+            for (const [name, el] of Object.entries(elements as Record<string, any>)) {
+              console.log(chalk.yellow(`  ${name}:`))
+              if (el.css_selector) {
+                console.log(`    ${chalk.gray('CSS:')} ${el.css_selector}`)
+              }
+              if (el.xpath_selector) {
+                console.log(`    ${chalk.gray('XPath:')} ${el.xpath_selector}`)
+              }
+              if (el.description) {
+                console.log(`    ${chalk.gray('Description:')} ${el.description}`)
+              }
+              if (el.element_type) {
+                console.log(`    ${chalk.gray('Type:')} ${el.element_type}`)
+              }
+              if (el.allow_methods?.length) {
+                console.log(`    ${chalk.gray('Methods:')} ${el.allow_methods.join(', ')}`)
+              }
+            }
+            console.log()
+          } catch {
+            console.log(chalk.dim('(Failed to parse elements data)'))
+          }
+        }
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -1,0 +1,64 @@
+import { Command } from 'commander'
+import { Actionbook, formatSearchResults } from '@actionbookdev/sdk'
+import chalk from 'chalk'
+import { getApiKey, handleError, outputResult } from '../output.js'
+import type { SearchType } from '@actionbookdev/sdk'
+
+export const searchCommand = new Command('search')
+  .alias('s')
+  .description('Search for action manuals by keyword')
+  .argument('<query>', 'Search keyword (e.g., "airbnb search", "google login")')
+  .option('-t, --type <type>', 'Search type: vector, fulltext, or hybrid', 'hybrid')
+  .option('-l, --limit <number>', 'Maximum results (1-100)', '5')
+  .option('-s, --source-ids <ids>', 'Filter by source IDs (comma-separated)')
+  .option('--min-score <score>', 'Minimum similarity score (0-1)')
+  .option('-j, --json', 'Output raw JSON')
+  .action(async (query: string, options) => {
+    try {
+      const apiKey = getApiKey(options)
+      const client = new Actionbook({ apiKey })
+
+      const result = await client.searchActions({
+        query,
+        type: options.type as SearchType,
+        limit: parseInt(options.limit, 10),
+        sourceIds: options.sourceIds,
+        minScore: options.minScore ? parseFloat(options.minScore) : undefined,
+      })
+
+      if (options.json) {
+        outputResult(result)
+      } else {
+        // Formatted output
+        if (result.results.length === 0) {
+          console.log(chalk.yellow(`No actions found for "${query}"`))
+          console.log(chalk.dim('Try broader search terms or different search type'))
+        } else {
+          console.log(chalk.bold.cyan(`\nSearch Results for "${query}"\n`))
+          console.log(chalk.dim(`Found ${result.count} result(s)\n`))
+
+          result.results.forEach((action, index) => {
+            const num = index + 1
+            console.log(chalk.bold.white(`${num}. ${action.action_id}`))
+            console.log(chalk.dim(`   Score: ${(action.score ?? 0).toFixed(3)}`))
+            console.log(chalk.gray(`   ${truncate(action.content, 120)}`))
+            console.log()
+          })
+
+          if (result.hasMore) {
+            console.log(chalk.dim('More results available. Increase --limit to see more.\n'))
+          }
+
+          console.log(chalk.cyan('Next step: ') + chalk.white(`actionbook get "<action_id>"`))
+        }
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+function truncate(str: string, maxLen: number): string {
+  const cleaned = str.replace(/\n/g, ' ').trim()
+  if (cleaned.length <= maxLen) return cleaned
+  return cleaned.substring(0, maxLen) + '...'
+}

--- a/packages/cli/src/commands/sources.ts
+++ b/packages/cli/src/commands/sources.ts
@@ -1,0 +1,117 @@
+import { Command } from 'commander'
+import { Actionbook } from '@actionbookdev/sdk'
+import chalk from 'chalk'
+import { getApiKey, handleError, outputResult } from '../output.js'
+import type { SourceItem } from '@actionbookdev/sdk'
+
+export const sourcesCommand = new Command('sources')
+  .description('List or search available sources (websites)')
+  .option('-l, --limit <number>', 'Maximum results', '50')
+  .option('-j, --json', 'Output raw JSON')
+  .action(async (options) => {
+    try {
+      const apiKey = getApiKey(options)
+      const client = new Actionbook({ apiKey })
+
+      const result = await client.listSources({
+        limit: parseInt(options.limit, 10),
+      })
+
+      if (options.json) {
+        outputResult(result)
+      } else {
+        formatSourceList(result.results, result.count)
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+// Add search subcommand
+sourcesCommand
+  .command('search <query>')
+  .alias('s')
+  .description('Search for sources by keyword')
+  .option('-l, --limit <number>', 'Maximum results', '10')
+  .option('-j, --json', 'Output raw JSON')
+  .action(async (query: string, options) => {
+    try {
+      // Get parent command options
+      const parentOpts = sourcesCommand.opts()
+      const apiKey = getApiKey({ ...parentOpts, ...options })
+      const client = new Actionbook({ apiKey })
+
+      const result = await client.searchSources({
+        query,
+        limit: parseInt(options.limit, 10),
+      })
+
+      if (options.json) {
+        outputResult(result)
+      } else {
+        if (result.results.length === 0) {
+          console.log(chalk.yellow(`\nNo sources found for "${query}"`))
+        } else {
+          console.log(chalk.bold.cyan(`\nSources matching "${query}"\n`))
+          formatSourceList(result.results, result.count)
+        }
+      }
+    } catch (error) {
+      handleError(error)
+    }
+  })
+
+function formatSourceList(sources: SourceItem[], count: number): void {
+  if (sources.length === 0) {
+    console.log(chalk.yellow('No sources found'))
+    return
+  }
+
+  console.log(chalk.dim(`${count} source(s)\n`))
+
+  // Calculate column widths
+  const maxIdLen = Math.max(...sources.map((s) => String(s.id).length), 2)
+  const maxNameLen = Math.min(Math.max(...sources.map((s) => s.name.length), 4), 30)
+
+  // Header
+  console.log(
+    chalk.bold(
+      `${'ID'.padEnd(maxIdLen)}  ${'Name'.padEnd(maxNameLen)}  ${'URL'}`
+    )
+  )
+  console.log(chalk.dim('─'.repeat(80)))
+
+  // Rows
+  for (const source of sources) {
+    const id = String(source.id).padEnd(maxIdLen)
+    const name = truncate(source.name, maxNameLen).padEnd(maxNameLen)
+    const url = source.baseUrl
+
+    console.log(`${chalk.yellow(id)}  ${chalk.white(name)}  ${chalk.cyan(url)}`)
+
+    if (source.description) {
+      console.log(chalk.dim(`${''.padEnd(maxIdLen)}  ${truncate(source.description, 70)}`))
+    }
+
+    if (source.tags?.length) {
+      console.log(
+        chalk.dim(`${''.padEnd(maxIdLen)}  Tags: `) +
+          source.tags.map((t) => chalk.magenta(t)).join(', ')
+      )
+    }
+  }
+
+  console.log()
+  console.log(
+    chalk.cyan('Tip: ') +
+      chalk.white('Use --source-ids with search to filter by source')
+  )
+  console.log(
+    chalk.dim('Example: actionbook search "login" --source-ids 1,2')
+  )
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str
+  return str.substring(0, maxLen - 1) + '…'
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+
+import { Command } from 'commander'
+import { searchCommand } from './commands/search.js'
+import { getCommand } from './commands/get.js'
+import { sourcesCommand } from './commands/sources.js'
+
+const program = new Command()
+
+program
+  .name('actionbook')
+  .description('CLI for Actionbook - Get website action manuals for AI agents')
+  .version('0.1.0')
+  .option('--api-key <key>', 'API key (or set ACTIONBOOK_API_KEY env var)')
+
+program.addCommand(searchCommand)
+program.addCommand(getCommand)
+program.addCommand(sourcesCommand)
+
+program.parse()

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,34 @@
+import chalk from 'chalk'
+import { isActionbookError } from '@actionbookdev/sdk'
+
+/**
+ * Get API key from options or environment
+ */
+export function getApiKey(options: { apiKey?: string }): string | undefined {
+  return options.apiKey ?? process.env.ACTIONBOOK_API_KEY
+}
+
+/**
+ * Output result as JSON
+ */
+export function outputResult(data: unknown): void {
+  console.log(JSON.stringify(data, null, 2))
+}
+
+/**
+ * Handle and display errors
+ */
+export function handleError(error: unknown): void {
+  if (isActionbookError(error)) {
+    console.error(chalk.red(`\nError: ${error.code}`))
+    console.error(chalk.white(error.message))
+    if (error.suggestion) {
+      console.error(chalk.yellow(`\nSuggestion: ${error.suggestion}`))
+    }
+  } else if (error instanceof Error) {
+    console.error(chalk.red(`\nError: ${error.message}`))
+  } else {
+    console.error(chalk.red('\nUnknown error occurred'))
+  }
+  process.exit(1)
+}

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- Add new CLI package `@actionbookdev/cli` for command-line access to Actionbook API
- Commands: `actionbook search`, `actionbook get`, `actionbook sources`
- Supports formatted colorized output and JSON output mode (`--json`)
- Already published to npm as v0.1.0

## Usage

```bash
npm install -g @actionbookdev/cli

actionbook search "airbnb login"
actionbook get "booking.com"
actionbook sources
```

## Test plan

- [x] Build passes (`pnpm build --filter=@actionbookdev/cli`)
- [x] CLI help works (`actionbook --help`)
- [x] Search command works with real API
- [x] Get command works with fuzzy matching
- [x] Sources command lists and searches sources
- [x] Published to npm successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)