### PR TITLE
[skills/actionbook] feat: add Fallback Strategy section to SKILL.md

### DIFF
--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -236,3 +236,21 @@ Executable workflow scripts for common patterns:
 - **Search by task**: Describe what you want to accomplish, not just the element (e.g., "linkedin send message" not "linkedin message button")
 - **Follow the order**: Execute steps in sequence as provided in the manual
 - **Trust the selectors**: Actionbook selectors are verified and maintained
+
+## Fallback Strategy
+
+This section describes situations where Actionbook may not provide the required information and the available fallback approaches.
+
+### When Fallback is Needed
+
+Actionbook stores pre-computed page data captured at indexing time. This data may become outdated as websites evolve. The following signals indicate that fallback may be necessary:
+
+- **Selector execution failure** - The returned CSS/XPath selector does not match any element on the current page.
+- **Element mismatch** - The selector matches an element, but the element type or behavior does not match the expected interaction method.
+- **Multiple selector failures** - Several element selectors from the same action fail consecutively.
+
+These conditions are not signaled in Actionbook API responses. They can only be detected during browser automation execution when selectors fail to locate the expected elements.
+
+### Fallback Approaches
+
+When Actionbook data does not work as expected, direct browser access to the target website allows for real-time retrieval of current page structure, element information, and interaction capabilities.


### PR DESCRIPTION
## Summary

Add Fallback Strategy documentation to the actionbook skill, explaining when and how to handle situations where Actionbook data may not work as expected.

## Changes

### 📝 Updated SKILL.md
- Added **Fallback Strategy** section explaining recovery approaches when Actionbook selectors fail
- Documented three key failure signals:
  - Selector execution failure (CSS/XPath doesn't match)
  - Element mismatch (wrong element type or behavior)
  - Multiple consecutive selector failures
- Described fallback approach: direct browser access for real-time page structure retrieval

## Why This Change

Actionbook stores pre-computed page data that may become outdated as websites evolve. Users need clear guidance on:
1. Recognizing when Actionbook data is stale
2. Understanding that these issues are detected at runtime, not via API responses
3. Knowing the fallback option (direct browser automation)

## Testing

- [x] Verified markdown renders correctly
- [x] Content aligns with existing documentation style
