### PR TITLE
feat:migrate skill from MCP to Rust CLI

### DIFF
--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -5,6 +5,16 @@ description: This skill should be used when the user needs to automate multi-ste
 
 When the user needs to automate website tasks, use Actionbook to fetch complete action manuals instead of figuring out the steps yourself.
 
+## Prerequisites
+
+Before using any `actionbook` commands, verify the CLI is installed:
+
+```bash
+which actionbook || npm install -g @actionbookdev/actionbook-rs
+```
+
+If npm install fails, inform the user and suggest `cargo install actionbook` as an alternative.
+
 ## When to Use This Skill
 
 Activate this skill when the user:
@@ -13,31 +23,28 @@ Activate this skill when the user:
 - Asks how to interact with a website ("How do I post a tweet?")
 - Builds browser-based AI agents or web scrapers
 - Writes E2E tests for external websites
-- Navigate to any new page during browser automation
-
+- Navigates to any new page during browser automation
 
 ## How to Use
 
-### Method 1: CLI (Recommended)
-
-**Phase 1: Get Action Manual**
+### Phase 1: Get Action Manual
 
 ```bash
 # Step 1: Search for action manuals
 actionbook search "arxiv search papers"
-# Returns: action IDs with scores
+# Returns: area IDs with descriptions
 
-# Step 2: Get the full manual
-actionbook get "https://arxiv.org/search/advanced"
+# Step 2: Get the full manual (use area_id from search results)
+actionbook get "arxiv.org:/search/advanced:default"
 # Returns: Page structure, UI Elements with CSS/XPath selectors
 ```
 
-**Phase 2: Execute with Browser**
+### Phase 2: Execute with Browser
 
 ```bash
 # Step 3: Open browser
 actionbook browser open "https://arxiv.org/search/advanced"
-actionbook browser wait --load networkidle
+actionbook browser wait-nav
 
 # Step 4: Use CSS selectors from Action Manual directly
 actionbook browser fill "#terms-0-term" "Neural Network"
@@ -47,23 +54,14 @@ actionbook browser fill "#date-year" "2025"
 actionbook browser click "form[action='/search/advanced'] button.is-link"
 
 # Step 5: Wait for results
-actionbook browser wait --load networkidle
+actionbook browser wait-nav
 
-# Step 6: Extract data (snapshot only when needed for data extraction)
-actionbook browser snapshot
+# Step 6: Extract data
+actionbook browser text
+actionbook browser screenshot results.png
 
 # Step 7: Close browser
 actionbook browser close
-```
-
-### Method 2: MCP Server
-
-```typescript
-// Step 1: Search
-search_actions({ query: "arxiv search papers" })
-
-// Step 2: Get manual
-get_action_by_id({ actionId: "https://arxiv.org/search/advanced" })
 ```
 
 ## Action Manual Format
@@ -82,49 +80,184 @@ UI Elements:
     Methods: click, type, clear
 ```
 
-## Essential Commands
+## Action Search Commands
 
-| Category | Commands |
-|----------|----------|
-| Navigation | `open <url>`, `back`, `forward`, `reload`, `close` |
-| Snapshot | `snapshot`, `snapshot -i` (interactive only) |
-| Interaction | `click`, `fill`, `type`, `select`, `check`, `press` |
-| Wait | `wait <ms>`, `wait --load networkidle`, `wait --text "..."` |
-| Info | `get text @ref`, `get url`, `get value @ref` |
-| Capture | `screenshot`, `screenshot --full`, `pdf` |
+```bash
+actionbook search "<query>"                    # Basic search
+actionbook search "<query>" --domain site.com  # Filter by domain
+actionbook search "<query>" --url <url>        # Filter by URL
+actionbook search "<query>" -p 2 -s 20         # Page 2, 20 results
+
+actionbook get "<area_id>"                     # Full details with selectors
+# area_id format: "site.com:/path:area_name"
+
+actionbook sources list                        # List available sources
+actionbook sources search "<query>"            # Search sources by keyword
+```
+
+## Browser Commands
+
+### Navigation
+
+```bash
+actionbook browser open <url>                  # Open URL in new tab
+actionbook browser goto <url>                  # Navigate current page
+actionbook browser back                        # Go back
+actionbook browser forward                     # Go forward
+actionbook browser reload                      # Reload page
+actionbook browser pages                       # List open tabs
+actionbook browser switch <page_id>            # Switch tab
+actionbook browser close                       # Close browser
+actionbook browser restart                     # Restart browser
+actionbook browser connect <endpoint>          # Connect to existing browser (CDP port or URL)
+```
+
+### Interactions (use CSS selectors from Action Manual)
+
+```bash
+actionbook browser click "<selector>"                  # Click element
+actionbook browser click "<selector>" --wait 1000      # Wait then click
+actionbook browser fill "<selector>" "text"            # Clear and type
+actionbook browser type "<selector>" "text"            # Append text
+actionbook browser select "<selector>" "value"         # Select dropdown
+actionbook browser hover "<selector>"                  # Hover
+actionbook browser focus "<selector>"                  # Focus
+actionbook browser press Enter                         # Press key
+```
+
+### Get Information
+
+```bash
+actionbook browser text                        # Full page text
+actionbook browser text "<selector>"           # Element text
+actionbook browser html                        # Full page HTML
+actionbook browser html "<selector>"           # Element HTML
+actionbook browser snapshot                    # Accessibility tree
+actionbook browser viewport                    # Viewport dimensions
+actionbook browser status                      # Browser detection info
+```
+
+### Wait
+
+```bash
+actionbook browser wait "<selector>"                   # Wait for element
+actionbook browser wait "<selector>" --timeout 5000    # Custom timeout
+actionbook browser wait-nav                            # Wait for navigation
+```
+
+### Screenshots & Export
+
+```bash
+actionbook browser screenshot                  # Save screenshot.png
+actionbook browser screenshot output.png       # Custom path
+actionbook browser screenshot --full-page      # Full page
+actionbook browser pdf output.pdf              # Export as PDF
+```
+
+### JavaScript & Inspection
+
+```bash
+actionbook browser eval "document.title"               # Execute JS
+actionbook browser inspect 100 200                     # Inspect at coordinates
+actionbook browser inspect 100 200 --desc "login btn"  # With description
+```
+
+### Cookies
+
+```bash
+actionbook browser cookies list                # List all cookies
+actionbook browser cookies get "name"          # Get cookie
+actionbook browser cookies set "name" "value"  # Set cookie
+actionbook browser cookies set "name" "value" --domain ".example.com"
+actionbook browser cookies delete "name"       # Delete cookie
+actionbook browser cookies clear               # Clear all
+```
+
+## Global Flags
+
+```bash
+actionbook --json <command>           # JSON output
+actionbook --headless <command>       # Headless mode
+actionbook --verbose <command>        # Verbose logging
+actionbook -P <profile> <command>     # Use specific profile
+actionbook --cdp <port|url> <command> # CDP connection
+```
 
 ## Guidelines
 
 - Search by task description, not element name ("arxiv search papers" not "search button")
 - **Use Action Manual selectors first** - they are pre-verified and don't require snapshot
 - Prefer CSS ID selectors (`#id`) over XPath when both are provided
-- **Fallback to snapshot only when selectors fail** - use `snapshot -i` then @refs
-- Re-snapshot after navigation - DOM changes invalidate @refs
+- **Fallback to snapshot when selectors fail** - use `actionbook browser snapshot` then CSS selectors from the output
+- Re-snapshot after navigation - DOM changes invalidate previous state
 
 ## Fallback Strategy
 
-This section describes situations where Actionbook may not provide the required information and the available fallback approaches.
-
 ### When Fallback is Needed
 
-Actionbook stores pre-computed page data captured at indexing time. This data may become outdated as websites evolve. The following signals indicate that fallback may be necessary:
+Actionbook stores pre-computed page data captured at indexing time. This data may become outdated as websites evolve:
 
-- **Selector execution failure** - The returned CSS/XPath selector does not match any element on the current page.
-- **Element mismatch** - The selector matches an element, but the element type or behavior does not match the expected interaction method.
-- **Multiple selector failures** - Several element selectors from the same action fail consecutively.
-
-These conditions are not signaled in Actionbook API responses. They can only be detected during browser automation execution when selectors fail to locate the expected elements.
+- **Selector execution failure** - The returned CSS/XPath selector does not match any element
+- **Element mismatch** - The selector matches an element with unexpected type or behavior
+- **Multiple selector failures** - Several selectors from the same action fail consecutively
 
 ### Fallback Approaches
 
-When Actionbook data does not work as expected, direct browser access to the target website allows for real-time retrieval of current page structure, element information, and interaction capabilities.
+When Action Manual selectors don't work:
 
-## Advanced Features
+1. **Snapshot the page** - `actionbook browser snapshot` to get the current accessibility tree
+2. **Inspect visually** - `actionbook browser screenshot` to see the current state
+3. **Inspect by coordinates** - `actionbook browser inspect <x> <y>` to find elements
+4. **Execute JS** - `actionbook browser eval "document.querySelector(...)"` for dynamic queries
 
-For complete command reference and advanced features, see:
-- [references/command-reference.md](references/command-reference.md) - All commands
-- [references/authentication.md](references/authentication.md) - Login flows, OAuth, 2FA
-- [references/session-management.md](references/session-management.md) - Parallel sessions
-- [references/snapshot-refs.md](references/snapshot-refs.md) - Ref lifecycle
-- [references/video-recording.md](references/video-recording.md) - Recording workflows
-- [references/proxy-support.md](references/proxy-support.md) - Proxy configuration
+## Examples
+
+### End-to-end with Action Manual
+
+```bash
+# 1. Find selectors
+actionbook search "airbnb search" --domain airbnb.com
+
+# 2. Get detailed selectors (area_id from search results)
+actionbook get "airbnb.com:/:default"
+
+# 3. Automate using pre-verified selectors
+actionbook browser open "https://www.airbnb.com"
+actionbook browser fill "input[data-testid='structured-search-input-field-query']" "Tokyo"
+actionbook browser click "button[data-testid='structured-search-input-search-button']"
+actionbook browser wait-nav
+actionbook browser screenshot results.png
+actionbook browser close
+```
+
+### Unknown site automation
+
+```bash
+# 1. Open and inspect
+actionbook browser open "https://example.com/login"
+actionbook browser snapshot
+
+# 2. Fill form using discovered selectors
+actionbook browser fill "#email" "user@example.com"
+actionbook browser fill "#password" "secret"
+actionbook browser click "button[type=submit]"
+actionbook browser wait-nav
+
+# 3. Verify result
+actionbook browser text "h1"
+actionbook browser screenshot result.png
+actionbook browser close
+```
+
+### Authentication flow
+
+```bash
+actionbook browser open "https://app.example.com/login"
+actionbook browser snapshot
+actionbook browser fill "#username" "user"
+actionbook browser fill "#password" "pass"
+actionbook browser click "button[type=submit]"
+actionbook browser wait-nav
+# Now authenticated - continue with protected pages
+actionbook browser goto "https://app.example.com/dashboard"
+```

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -1,235 +1,180 @@
-# actionbook browser Command Reference
+# actionbook Command Reference
 
-This document provides comprehensive documentation for all `actionbook browser` commands and features.
+Complete reference for all `actionbook` CLI commands.
 
-## Navigation Commands
+## Action Search & Retrieval
+
+### search - Search for action manuals
 
 ```bash
-actionbook browser open <url>      # Navigate to URL (aliases: goto, navigate)
-                                   # Supports: https://, http://, file://, about:, data://
-                                   # Auto-prepends https:// if no protocol given
-actionbook browser back            # Go back
-actionbook browser forward         # Go forward
-actionbook browser reload          # Reload page
-actionbook browser close           # Close browser (aliases: quit, exit)
-actionbook browser connect 9222    # Connect to browser via CDP port
+actionbook search "<query>"                    # Basic keyword search
+actionbook search "<query>" --domain site.com  # Filter by domain
+actionbook search "<query>" --url <url>        # Filter by specific URL
+actionbook search "<query>" -p 2               # Page 2 (default: 1)
+actionbook search "<query>" -s 20              # 20 results per page (default: 10, max: 100)
+actionbook search "<query>" --domain site.com --url <url> -p 1 -s 5  # Combined
 ```
 
-## Snapshot & Element References
+Returns area IDs with descriptions and relevance scores. Use the area_id with `actionbook get` to fetch full details.
+
+### get - Get action details by area ID
 
 ```bash
-actionbook browser snapshot            # Full accessibility tree
-actionbook browser snapshot -i         # Interactive elements only (recommended)
-actionbook browser snapshot -c         # Compact output
-actionbook browser snapshot -d 3       # Limit depth to 3
-actionbook browser snapshot -s "#main" # Scope to CSS selector
+actionbook get "<area_id>"
+# area_id format: "site.com:/path:area_name"
+# Examples:
+#   actionbook get "airbnb.com:/:default"
+#   actionbook get "github.com:/login:form"
+#   actionbook get "arxiv.org:/search/advanced:default"
 ```
 
-**Understanding @refs**: Snapshots assign numbered references (@e1, @e2, etc.) to interactive elements. Use these refs in subsequent commands instead of CSS selectors.
+Returns complete action manual with CSS/XPath selectors, element types, and allowed methods.
 
-**Critical Rules**:
-1. Always snapshot before interacting - refs don't exist until you capture them
-2. Re-snapshot after navigation - page changes invalidate existing refs
-3. Re-snapshot after dynamic changes - dropdowns, modals, or content updates require fresh refs
-
-## Interaction Commands
+### sources - List and search sources
 
 ```bash
-actionbook browser click @e1           # Click
-actionbook browser dblclick @e1        # Double-click
-actionbook browser focus @e1           # Focus element
-actionbook browser fill @e2 "text"     # Clear and type
-actionbook browser type @e2 "text"     # Type without clearing
-actionbook browser press Enter         # Press key (alias: key)
-actionbook browser press Control+a     # Key combination
-actionbook browser keydown Shift       # Hold key down
-actionbook browser keyup Shift         # Release key
-actionbook browser hover @e1           # Hover
-actionbook browser check @e1           # Check checkbox
-actionbook browser uncheck @e1         # Uncheck checkbox
-actionbook browser select @e1 "value"  # Select dropdown option
-actionbook browser select @e1 "a" "b"  # Select multiple options
-actionbook browser scroll down 500     # Scroll page (default: down 300px)
-actionbook browser scrollintoview @e1  # Scroll element into view
-actionbook browser drag @e1 @e2        # Drag and drop
-actionbook browser upload @e1 file.pdf # Upload files
+actionbook sources list                        # List all available sources
+actionbook sources search "<query>"            # Search sources by keyword
 ```
 
-## Information Retrieval
+## Browser Automation
+
+### Navigation
 
 ```bash
-actionbook browser get text @e1        # Get element text
-actionbook browser get html @e1        # Get innerHTML
-actionbook browser get value @e1       # Get input value
-actionbook browser get attr @e1 href   # Get attribute
-actionbook browser get title           # Get page title
-actionbook browser get url             # Get current URL
-actionbook browser get count ".item"   # Count matching elements
-actionbook browser get box @e1         # Get bounding box
-actionbook browser get styles @e1      # Get computed styles
+actionbook browser open <url>                  # Open URL in new tab
+actionbook browser goto <url>                  # Navigate current page to URL
+actionbook browser goto <url> --timeout 5000   # Custom navigation timeout (default: 30000ms)
+actionbook browser back                        # Go back in history
+actionbook browser forward                     # Go forward in history
+actionbook browser reload                      # Reload current page
+actionbook browser pages                       # List all open pages/tabs
+actionbook browser switch <page_id>            # Switch to specific page by ID
+actionbook browser close                       # Close the browser
+actionbook browser restart                     # Restart the browser
+actionbook browser connect <endpoint>          # Connect to existing browser (CDP port or ws:// URL)
+actionbook browser status                      # Show detected browsers and session status
 ```
 
-## State Verification
+### Element Interactions
+
+All interaction commands take CSS selectors. Use selectors from Action Manuals or from `snapshot` output.
 
 ```bash
-actionbook browser is visible @e1      # Check if visible
-actionbook browser is enabled @e1      # Check if enabled
-actionbook browser is checked @e1      # Check if checked
+actionbook browser click "<selector>"                  # Click element
+actionbook browser click "<selector>" --wait 1000      # Wait 1s for element, then click
+actionbook browser fill "<selector>" "text"            # Clear element, then type text
+actionbook browser fill "<selector>" "text" --wait 500 # Wait for element, then fill
+actionbook browser type "<selector>" "text"            # Type text (append, no clear)
+actionbook browser type "<selector>" "text" --wait 500 # Wait for element, then type
+actionbook browser select "<selector>" "value"         # Select dropdown option by value
+actionbook browser hover "<selector>"                  # Hover over element
+actionbook browser focus "<selector>"                  # Focus on element
+actionbook browser press <key>                         # Press keyboard key
+# Key examples: Enter, Tab, Escape, ArrowDown, ArrowUp, Backspace, Delete, Space
 ```
 
-## Wait Conditions
+### Information Retrieval
 
 ```bash
-actionbook browser wait @e1                     # Wait for element
-actionbook browser wait 2000                    # Wait milliseconds
-actionbook browser wait --text "Success"        # Wait for text (or -t)
-actionbook browser wait --url "**/dashboard"    # Wait for URL pattern (or -u)
-actionbook browser wait --load networkidle      # Wait for network idle (or -l)
-actionbook browser wait --fn "window.ready"     # Wait for JS condition (or -f)
+actionbook browser text                        # Get full page text content
+actionbook browser text "<selector>"           # Get text of specific element
+actionbook browser html                        # Get full page HTML
+actionbook browser html "<selector>"           # Get outer HTML of specific element
+actionbook browser snapshot                    # Get accessibility snapshot (tree structure)
+actionbook browser viewport                    # Get viewport dimensions
 ```
 
-## Screenshots & Recording
+### Wait Conditions
 
 ```bash
-actionbook browser screenshot          # Save to temporary directory
-actionbook browser screenshot path.png # Save to specific path
-actionbook browser screenshot --full   # Full page
-actionbook browser pdf output.pdf      # Save as PDF
-
-# Video recording
-actionbook browser record start ./demo.webm    # Start recording
-actionbook browser click @e1                   # Perform actions
-actionbook browser record stop                 # Stop and save video
-actionbook browser record restart ./take2.webm # Stop current + start new
+actionbook browser wait "<selector>"                   # Wait for element to appear
+actionbook browser wait "<selector>" --timeout 5000    # Custom timeout (default: 30000ms)
+actionbook browser wait-nav                            # Wait for navigation to complete
+actionbook browser wait-nav --timeout 10000            # Custom navigation timeout
 ```
 
-Recording creates a fresh context but preserves cookies/storage from your session. For smooth demos, explore first, then start recording.
-
-## Mouse Control
+### Screenshots & Export
 
 ```bash
-actionbook browser mouse move 100 200      # Move mouse
-actionbook browser mouse down left         # Press button
-actionbook browser mouse up left           # Release button
-actionbook browser mouse wheel 100         # Scroll wheel
+actionbook browser screenshot                  # Save as screenshot.png
+actionbook browser screenshot output.png       # Save to custom path
+actionbook browser screenshot --full-page      # Full page screenshot
+actionbook browser pdf output.pdf              # Export page as PDF
 ```
 
-## Semantic Locators
-
-Alternative to @refs - find elements by their semantic properties:
+### JavaScript & DOM Inspection
 
 ```bash
-actionbook browser find role button click --name "Submit"
-actionbook browser find text "Sign In" click
-actionbook browser find text "Sign In" click --exact      # Exact match only
-actionbook browser find label "Email" fill "user@test.com"
-actionbook browser find placeholder "Search" type "query"
-actionbook browser find alt "Logo" click
-actionbook browser find title "Close" click
-actionbook browser find testid "submit-btn" click
-actionbook browser find first ".item" click
-actionbook browser find last ".item" click
-actionbook browser find nth 2 "a" hover
+actionbook browser eval "document.title"               # Execute JavaScript, return result
+actionbook browser eval "document.querySelectorAll('a').length"
+actionbook browser inspect <x> <y>                     # Inspect DOM element at viewport coordinates
+actionbook browser inspect <x> <y> --desc "login btn"  # With description hint
 ```
 
-## Browser Settings
+### Cookie Management
 
 ```bash
-actionbook browser set viewport 1920 1080          # Set viewport size
-actionbook browser set device "iPhone 14"          # Emulate device
-actionbook browser set geo 37.7749 -122.4194       # Set geolocation
-actionbook browser set offline on                  # Toggle offline mode
-actionbook browser set headers '{"X-Key":"v"}'     # Extra HTTP headers
-actionbook browser set credentials user pass       # HTTP basic auth
-actionbook browser set media dark                  # Emulate color scheme
-actionbook browser set media light reduced-motion  # Light mode + reduced motion
+actionbook browser cookies                     # List all cookies (default)
+actionbook browser cookies list                # List all cookies
+actionbook browser cookies get "<name>"        # Get specific cookie by name
+actionbook browser cookies set "<name>" "<value>"              # Set cookie
+actionbook browser cookies set "<name>" "<value>" --domain ".example.com"  # Set with domain
+actionbook browser cookies delete "<name>"     # Delete specific cookie
+actionbook browser cookies clear               # Clear all cookies
 ```
 
-## Cookies & Storage
+## Configuration
+
+### config - Manage settings
 
 ```bash
-actionbook browser cookies                     # Get all cookies
-actionbook browser cookies set name value      # Set cookie
-actionbook browser cookies clear               # Clear cookies
-
-actionbook browser storage local               # Get all localStorage
-actionbook browser storage local key           # Get specific key
-actionbook browser storage local set k v       # Set value
-actionbook browser storage local clear         # Clear all
+actionbook config show                         # Display full configuration
+actionbook config get <key>                    # Get specific config value
+actionbook config set <key> <value>            # Set config value
+actionbook config edit                         # Open config in $EDITOR
+actionbook config path                         # Show config file location
 ```
 
-## Network Control
+**Config keys:**
+- `api.base_url` - API endpoint (default: https://api.actionbook.dev)
+- `api.api_key` - API authentication key
+- `browser.executable` - Browser path override
+- `browser.default_profile` - Default profile name
+- `browser.headless` - Headless mode (true/false)
+
+### profile - Manage browser profiles
 
 ```bash
-actionbook browser network route <url>              # Intercept requests
-actionbook browser network route <url> --abort      # Block requests
-actionbook browser network route <url> --body '{}'  # Mock response
-actionbook browser network unroute [url]            # Remove routes
-actionbook browser network requests                 # View tracked requests
-actionbook browser network requests --filter api    # Filter requests
+actionbook profile list                        # List all profiles
+actionbook profile create <name>               # Create new profile
+actionbook profile create <name> --cdp-port 9222  # With specific CDP port
+actionbook profile delete <name>               # Delete profile
+actionbook profile show <name>                 # Show profile details
 ```
 
-## Tabs & Windows
+## Global Flags
+
+These flags can be used with any command:
 
 ```bash
-actionbook browser tab                 # List tabs
-actionbook browser tab new [url]       # New tab
-actionbook browser tab 2               # Switch to tab by index
-actionbook browser tab close           # Close current tab
-actionbook browser tab close 2         # Close tab by index
-actionbook browser window new          # New window
-```
-
-## Frames & Dialogs
-
-```bash
-actionbook browser frame "#iframe"     # Switch to iframe
-actionbook browser frame main          # Back to main frame
-
-actionbook browser dialog accept [text]  # Accept dialog
-actionbook browser dialog dismiss        # Dismiss dialog
-```
-
-## JavaScript Execution
-
-```bash
-actionbook browser eval "document.title"   # Run JavaScript
-```
-
-## Global Options
-
-```bash
-actionbook browser --session <name> ...    # Isolated browser session
-actionbook browser --json ...              # JSON output for parsing
-actionbook browser --headed ...            # Show browser window (not headless)
-actionbook browser --full ...              # Full page screenshot (-f)
-actionbook browser --cdp <port> ...        # Connect via Chrome DevTools Protocol
-actionbook browser -p <provider> ...       # Cloud browser provider (--provider)
-actionbook browser --proxy <url> ...       # Use proxy server
-actionbook browser --headers <json> ...    # HTTP headers scoped to URL's origin
-actionbook browser --executable-path <p>   # Custom browser executable
-actionbook browser --extension <path> ...  # Load browser extension (repeatable)
-actionbook browser --help                  # Show help (-h)
-actionbook browser --version               # Show version (-V)
-actionbook browser <command> --help        # Show detailed help for a command
-```
-
-**Proxy Support**:
-```bash
-actionbook browser --proxy http://proxy.com:8080 open example.com
-actionbook browser --proxy http://user:pass@proxy.com:8080 open example.com
-actionbook browser --proxy socks5://proxy.com:1080 open example.com
+actionbook --json <command>                    # Output in JSON format
+actionbook --headless <command>                # Run browser in headless mode
+actionbook --verbose <command>                 # Enable verbose logging
+actionbook -P <profile> <command>              # Use specific browser profile
+actionbook --cdp <port|url> <command>          # Connect via CDP port or WebSocket URL
+actionbook --browser-path <path> <command>     # Override browser executable path
 ```
 
 ## Environment Variables
 
 ```bash
-AGENT_BROWSER_SESSION="mysession"            # Default session name
-AGENT_BROWSER_EXECUTABLE_PATH="/path/chrome" # Custom browser path
-AGENT_BROWSER_EXTENSIONS="/ext1,/ext2"       # Comma-separated extension paths
-AGENT_BROWSER_PROVIDER="your-cloud-browser-provider"  # Cloud browser provider
-AGENT_BROWSER_STREAM_PORT="9223"             # WebSocket streaming port
-AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
+ACTIONBOOK_API_URL="https://api.actionbook.dev"  # API endpoint
+ACTIONBOOK_API_KEY="your-key"                     # API authentication key
+ACTIONBOOK_BROWSER_PATH="/path/to/chrome"         # Browser executable
+ACTIONBOOK_CDP="9222"                             # CDP port or WebSocket URL
+ACTIONBOOK_PROFILE="default"                      # Default profile name
+ACTIONBOOK_HEADLESS="true"                        # Headless mode
 ```
 
 ## Practical Examples
@@ -237,80 +182,46 @@ AGENT_BROWSER_HOME="/path/to/agent-browser"  # Custom install location
 ### Form Submission
 
 ```bash
-actionbook browser open https://example.com/form
-actionbook browser snapshot -i
-# Output shows: textbox "Email" [ref=@e1], textbox "Password" [ref=@e2], button "Submit" [ref=@e3]
+actionbook browser open "https://example.com/form"
+actionbook browser snapshot
+# Read the snapshot to find selectors
 
-actionbook browser fill @e1 "user@example.com"
-actionbook browser fill @e2 "password123"
-actionbook browser click @e3
-actionbook browser wait --load networkidle
-actionbook browser snapshot -i  # Check result
+actionbook browser fill "#email" "user@example.com"
+actionbook browser fill "#password" "password123"
+actionbook browser click "button[type=submit]"
+actionbook browser wait-nav
+actionbook browser text "h1"  # Check result
 ```
 
-### Authentication with Saved State
+### Multi-page Navigation
 
 ```bash
-# Login once
-actionbook browser open https://app.example.com/login
-actionbook browser snapshot -i
-actionbook browser fill @e1 "username"
-actionbook browser fill @e2 "password"
-actionbook browser click @e3
-actionbook browser wait --url "**/dashboard"
-actionbook browser state save auth.json
-
-# Later sessions: load saved state
-actionbook browser state load auth.json
-actionbook browser open https://app.example.com/dashboard
+actionbook browser open "https://example.com"
+actionbook browser click "a[href='/products']"
+actionbook browser wait-nav
+actionbook browser click ".product-card:first-child a"
+actionbook browser wait-nav
+actionbook browser text ".product-details"
+actionbook browser screenshot product.png
 ```
 
-### Parallel Sessions
+### Data Extraction
 
 ```bash
-actionbook browser --session test1 open site-a.com
-actionbook browser --session test2 open site-b.com
-actionbook browser session list
+actionbook browser open "https://example.com/data"
+actionbook browser wait-nav
+actionbook browser text ".results-table"       # Get table text
+actionbook browser eval "JSON.stringify([...document.querySelectorAll('.item')].map(e => e.textContent))"
+actionbook browser close
 ```
 
-## Debugging
+### Connect to Existing Browser
 
 ```bash
-actionbook browser --headed open example.com   # Show browser window
-actionbook browser --cdp 9222 snapshot         # Connect via CDP port
-actionbook browser connect 9222                # Alternative: connect command
-actionbook browser console                     # View console messages
-actionbook browser console --clear             # Clear console
-actionbook browser errors                      # View page errors
-actionbook browser errors --clear              # Clear errors
-actionbook browser highlight @e1               # Highlight element
-actionbook browser trace start                 # Start recording trace
-actionbook browser trace stop trace.zip        # Stop and save trace
-actionbook browser record start ./debug.webm   # Record video from current page
-actionbook browser record stop                 # Save recording
+# Start Chrome with debugging port
+# google-chrome --remote-debugging-port=9222
+
+actionbook browser connect 9222
+actionbook browser pages
+actionbook browser snapshot
 ```
-
-## HTTPS Certificate Errors
-
-For sites with self-signed or invalid certificates:
-```bash
-actionbook browser open https://localhost:8443 --ignore-https-errors
-```
-
-## See Also
-
-For detailed patterns and best practices:
-
-- [snapshot-refs.md](snapshot-refs.md) - Ref lifecycle, invalidation rules, troubleshooting
-- [session-management.md](session-management.md) - Parallel sessions, state persistence, concurrent scraping
-- [authentication.md](authentication.md) - Login flows, OAuth, 2FA handling, state reuse
-- [video-recording.md](video-recording.md) - Recording workflows for debugging and documentation
-- [proxy-support.md](proxy-support.md) - Proxy configuration, geo-testing, rotating proxies
-
-## Ready-to-Use Templates
-
-Executable workflow scripts for common patterns:
-
-- [../templates/form-automation.sh](../templates/form-automation.sh) - Form filling with validation
-- [../templates/authenticated-session.sh](../templates/authenticated-session.sh) - Login once, reuse state
-- [../templates/capture-workflow.sh](../templates/capture-workflow.sh) - Content extraction with screenshots


### PR DESCRIPTION
- Rewrite actionbook skill to use the actionbook Rust CLI instead of MCP tools, following the same pattern as core-agent-browser                                   
- Remove MCP method documentation entirely - all operations now go through Bash(actionbook *)                                                                 
- Align all documented commands to what the Rust CLI  (packages/actionbook-rs/src/cli.rs) actually supports                              
- Add config and profile commands documentation (not available via MCP)  