### PR TITLE
feat: add stealth mode, snapshot format improvements, and API key sup…

### DIFF
--- a/packages/actionbook-rs/src/browser/launcher.rs
+++ b/packages/actionbook-rs/src/browser/launcher.rs
@@ -13,6 +13,7 @@ pub struct BrowserLauncher {
     browser_info: BrowserInfo,
     cdp_port: u16,
     headless: bool,
+    stealth: bool,
     user_data_dir: PathBuf,
     extra_args: Vec<String>,
 }
@@ -31,6 +32,7 @@ impl BrowserLauncher {
             browser_info,
             cdp_port: 9222,
             headless: false,
+            stealth: false,
             user_data_dir: data_dir,
             extra_args: Vec::new(),
         })
@@ -60,6 +62,7 @@ impl BrowserLauncher {
             browser_info,
             cdp_port: 9222,
             headless: false,
+            stealth: false,
             user_data_dir: data_dir,
             extra_args: Vec::new(),
         })
@@ -81,6 +84,12 @@ impl BrowserLauncher {
         }
 
         Ok(launcher)
+    }
+
+    /// Enable stealth mode (anti-detection Chrome flags)
+    pub fn with_stealth(mut self, stealth: bool) -> Self {
+        self.stealth = stealth;
+        self
     }
 
     /// Set CDP port
@@ -115,6 +124,13 @@ impl BrowserLauncher {
             "--no-first-run".to_string(),
             "--no-default-browser-check".to_string(),
         ];
+
+        // Always apply anti-detection flags
+        args.push("--disable-blink-features=AutomationControlled".to_string());
+        args.push("--disable-infobars".to_string());
+        args.push("--window-size=1920,1080".to_string());
+        args.push("--disable-save-password-bubble".to_string());
+        args.push("--disable-translate".to_string());
 
         if self.headless {
             args.push("--headless=new".to_string());

--- a/packages/actionbook-rs/src/browser/mod.rs
+++ b/packages/actionbook-rs/src/browser/mod.rs
@@ -1,6 +1,13 @@
 mod discovery;
 mod launcher;
 mod session;
+pub mod stealth;
 
 pub use discovery::{discover_all_browsers, BrowserInfo};
-pub use session::{PageInfo, SessionManager, SessionStatus};
+pub use session::{PageInfo, SessionManager, SessionStatus, StealthConfig};
+pub use stealth::{stealth_status, build_stealth_profile, parse_stealth_os, parse_stealth_gpu};
+pub use stealth::{StealthGpu, StealthOs, StealthProfile};
+
+// Re-export stealth page application for external use
+#[cfg(feature = "stealth")]
+pub use stealth::apply_stealth_to_page;

--- a/packages/actionbook-rs/src/browser/stealth.rs
+++ b/packages/actionbook-rs/src/browser/stealth.rs
@@ -1,0 +1,275 @@
+//! Stealth browser automation support using chaser-oxide.
+//!
+//! Enable with `--features stealth` for:
+//! - No automation banner
+//! - Anti-detection measures
+//! - Hardware fingerprint spoofing
+//! - Human-like mouse/keyboard simulation
+
+#[cfg(feature = "stealth")]
+use chaser_oxide::profiles::{ChaserProfile, ChaserProfileBuilder, Gpu};
+
+#[cfg(feature = "stealth")]
+use crate::error::{ActionbookError, Result};
+
+/// Stealth profile configuration
+#[derive(Debug, Clone)]
+pub struct StealthProfile {
+    /// Operating system to emulate
+    pub os: StealthOs,
+    /// GPU to emulate
+    pub gpu: StealthGpu,
+    /// Chrome version to emulate
+    pub chrome_version: u32,
+    /// Memory in GB
+    pub memory_gb: u32,
+    /// CPU cores
+    pub cpu_cores: u32,
+    /// Locale (e.g., "en-US", "zh-CN")
+    pub locale: String,
+    /// Timezone (e.g., "America/New_York", "Asia/Shanghai")
+    pub timezone: String,
+}
+
+impl Default for StealthProfile {
+    fn default() -> Self {
+        Self {
+            os: StealthOs::MacOsArm,
+            gpu: StealthGpu::AppleM4Max,
+            chrome_version: 130,
+            memory_gb: 16,
+            cpu_cores: 8,
+            locale: "en-US".to_string(),
+            timezone: "America/Los_Angeles".to_string(),
+        }
+    }
+}
+
+/// Operating system options for stealth profile
+#[derive(Debug, Clone, Copy)]
+pub enum StealthOs {
+    Windows,
+    MacOsIntel,
+    MacOsArm,
+    Linux,
+}
+
+/// GPU options for stealth profile
+#[derive(Debug, Clone, Copy)]
+pub enum StealthGpu {
+    // NVIDIA
+    NvidiaRtx4080,
+    NvidiaRtx3080,
+    NvidiaGtx1660,
+    // AMD
+    AmdRadeonRx6800,
+    // Intel
+    IntelUhd630,
+    IntelIrisXe,
+    // Apple
+    AppleM1Pro,
+    AppleM2Max,
+    AppleM4Max,
+}
+
+#[cfg(feature = "stealth")]
+impl StealthProfile {
+    /// Build a chaser-oxide profile from this configuration
+    pub fn to_chaser_profile(&self) -> ChaserProfile {
+        let builder: ChaserProfileBuilder = match self.os {
+            StealthOs::Windows => ChaserProfile::windows(),
+            StealthOs::MacOsIntel => ChaserProfile::macos_intel(),
+            StealthOs::MacOsArm => ChaserProfile::macos_arm(),
+            StealthOs::Linux => ChaserProfile::linux(),
+        };
+
+        let gpu = match self.gpu {
+            StealthGpu::NvidiaRtx4080 => Gpu::NvidiaRTX4080,
+            StealthGpu::NvidiaRtx3080 => Gpu::NvidiaRTX3080,
+            StealthGpu::NvidiaGtx1660 => Gpu::NvidiaGTX1660,
+            StealthGpu::AmdRadeonRx6800 => Gpu::AmdRadeonRX6800,
+            StealthGpu::IntelUhd630 => Gpu::IntelUHD630,
+            StealthGpu::IntelIrisXe => Gpu::IntelIrisXe,
+            StealthGpu::AppleM1Pro => Gpu::AppleM1Pro,
+            StealthGpu::AppleM2Max => Gpu::AppleM2Max,
+            StealthGpu::AppleM4Max => Gpu::AppleM4Max,
+        };
+
+        builder
+            .chrome_version(self.chrome_version)
+            .gpu(gpu)
+            .memory_gb(self.memory_gb)
+            .cpu_cores(self.cpu_cores)
+            .locale(&self.locale)
+            .timezone(&self.timezone)
+            .build()
+    }
+}
+
+/// Apply stealth profile to a chromiumoxide page
+/// This wraps the page in ChaserPage and applies anti-detection measures
+#[cfg(feature = "stealth")]
+pub async fn apply_stealth_to_page(
+    page: &chromiumoxide::Page,
+    profile: &StealthProfile,
+) -> Result<()> {
+    use chromiumoxide::Page;
+
+    // Convert to ChaserPage and apply profile
+    // Note: ChaserPage requires ownership, so we clone the page handle
+    let chaser_profile = profile.to_chaser_profile();
+
+    // Apply stealth via CDP commands directly
+    // This is done via JavaScript injection to avoid ChaserPage ownership issues
+
+    // 1. Override navigator properties
+    let navigator_override = format!(
+        r#"
+        Object.defineProperty(navigator, 'webdriver', {{ get: () => undefined }});
+        Object.defineProperty(navigator, 'platform', {{ get: () => '{}' }});
+        Object.defineProperty(navigator, 'hardwareConcurrency', {{ get: () => {} }});
+        Object.defineProperty(navigator, 'deviceMemory', {{ get: () => {} }});
+        Object.defineProperty(navigator, 'language', {{ get: () => '{}' }});
+        Object.defineProperty(navigator, 'languages', {{ get: () => ['{}', 'en'] }});
+        "#,
+        match profile.os {
+            StealthOs::Windows => "Win32",
+            StealthOs::MacOsIntel | StealthOs::MacOsArm => "MacIntel",
+            StealthOs::Linux => "Linux x86_64",
+        },
+        profile.cpu_cores,
+        profile.memory_gb,
+        &profile.locale,
+        &profile.locale,
+    );
+
+    page.evaluate(navigator_override)
+        .await
+        .map_err(|e| ActionbookError::Other(format!("Failed to apply navigator override: {}", e)))?;
+
+    // 2. Override WebGL renderer
+    let webgl_override = format!(
+        r#"
+        const getParameter = WebGLRenderingContext.prototype.getParameter;
+        WebGLRenderingContext.prototype.getParameter = function(parameter) {{
+            if (parameter === 37445) return '{}';
+            if (parameter === 37446) return '{}';
+            return getParameter.apply(this, arguments);
+        }};
+        "#,
+        match profile.gpu {
+            StealthGpu::NvidiaRtx4080 | StealthGpu::NvidiaRtx3080 | StealthGpu::NvidiaGtx1660 => "NVIDIA Corporation",
+            StealthGpu::AmdRadeonRx6800 => "AMD",
+            StealthGpu::IntelUhd630 | StealthGpu::IntelIrisXe => "Intel Inc.",
+            StealthGpu::AppleM1Pro | StealthGpu::AppleM2Max | StealthGpu::AppleM4Max => "Apple Inc.",
+        },
+        match profile.gpu {
+            StealthGpu::NvidiaRtx4080 => "NVIDIA GeForce RTX 4080",
+            StealthGpu::NvidiaRtx3080 => "NVIDIA GeForce RTX 3080",
+            StealthGpu::NvidiaGtx1660 => "NVIDIA GeForce GTX 1660",
+            StealthGpu::AmdRadeonRx6800 => "AMD Radeon RX 6800",
+            StealthGpu::IntelUhd630 => "Intel UHD Graphics 630",
+            StealthGpu::IntelIrisXe => "Intel Iris Xe Graphics",
+            StealthGpu::AppleM1Pro => "Apple M1 Pro",
+            StealthGpu::AppleM2Max => "Apple M2 Max",
+            StealthGpu::AppleM4Max => "Apple M4 Max",
+        },
+    );
+
+    page.evaluate(webgl_override)
+        .await
+        .map_err(|e| ActionbookError::Other(format!("Failed to apply WebGL override: {}", e)))?;
+
+    // 3. Hide automation indicators
+    let automation_hide = r#"
+        // Remove webdriver property
+        delete navigator.__proto__.webdriver;
+
+        // Override permissions
+        const originalQuery = window.navigator.permissions.query;
+        window.navigator.permissions.query = (parameters) => (
+            parameters.name === 'notifications' ?
+                Promise.resolve({ state: Notification.permission }) :
+                originalQuery(parameters)
+        );
+
+        // Fix chrome object
+        window.chrome = { runtime: {} };
+
+        // Fix plugins
+        Object.defineProperty(navigator, 'plugins', {
+            get: () => [
+                { name: 'Chrome PDF Plugin', filename: 'internal-pdf-viewer' },
+                { name: 'Chrome PDF Viewer', filename: 'mhjfbmdgcfjbbpaeojofohoefgiehjai' },
+                { name: 'Native Client', filename: 'internal-nacl-plugin' }
+            ]
+        });
+    "#;
+
+    page.evaluate(automation_hide)
+        .await
+        .map_err(|e| ActionbookError::Other(format!("Failed to hide automation: {}", e)))?;
+
+    tracing::debug!("Applied stealth profile to page: {:?}", profile.os);
+    Ok(())
+}
+
+/// Check if stealth mode is enabled
+pub fn is_stealth_enabled() -> bool {
+    cfg!(feature = "stealth")
+}
+
+/// Get stealth mode status string
+pub fn stealth_status() -> &'static str {
+    if cfg!(feature = "stealth") {
+        "enabled (chaser-oxide)"
+    } else {
+        "disabled (use --features stealth to enable)"
+    }
+}
+
+/// Parse OS string from CLI into StealthOs
+pub fn parse_stealth_os(s: &str) -> Option<StealthOs> {
+    match s.to_lowercase().as_str() {
+        "windows" | "win" => Some(StealthOs::Windows),
+        "macos-intel" | "mac-intel" | "osx-intel" => Some(StealthOs::MacOsIntel),
+        "macos-arm" | "mac-arm" | "osx-arm" | "macos" | "mac" => Some(StealthOs::MacOsArm),
+        "linux" => Some(StealthOs::Linux),
+        _ => None,
+    }
+}
+
+/// Parse GPU string from CLI into StealthGpu
+pub fn parse_stealth_gpu(s: &str) -> Option<StealthGpu> {
+    match s.to_lowercase().replace(['-', '_', ' '], "").as_str() {
+        "nvidiartx4080" | "rtx4080" | "4080" => Some(StealthGpu::NvidiaRtx4080),
+        "nvidiartx3080" | "rtx3080" | "3080" => Some(StealthGpu::NvidiaRtx3080),
+        "nvidiagtx1660" | "gtx1660" | "1660" => Some(StealthGpu::NvidiaGtx1660),
+        "amdradeonrx6800" | "rx6800" | "6800" => Some(StealthGpu::AmdRadeonRx6800),
+        "inteluhd630" | "uhd630" => Some(StealthGpu::IntelUhd630),
+        "intelirisxe" | "irisxe" => Some(StealthGpu::IntelIrisXe),
+        "applem1pro" | "m1pro" | "m1" => Some(StealthGpu::AppleM1Pro),
+        "applem2max" | "m2max" | "m2" => Some(StealthGpu::AppleM2Max),
+        "applem4max" | "m4max" | "m4" => Some(StealthGpu::AppleM4Max),
+        _ => None,
+    }
+}
+
+/// Build a StealthProfile from optional CLI parameters
+pub fn build_stealth_profile(os: Option<&str>, gpu: Option<&str>) -> StealthProfile {
+    let mut profile = StealthProfile::default();
+
+    if let Some(os_str) = os {
+        if let Some(os_val) = parse_stealth_os(os_str) {
+            profile.os = os_val;
+        }
+    }
+
+    if let Some(gpu_str) = gpu {
+        if let Some(gpu_val) = parse_stealth_gpu(gpu_str) {
+            profile.gpu = gpu_val;
+        }
+    }
+
+    profile
+}

--- a/packages/actionbook-rs/src/cli.rs
+++ b/packages/actionbook-rs/src/cli.rs
@@ -24,6 +24,22 @@ pub struct Cli {
     #[arg(long, env = "ACTIONBOOK_HEADLESS", global = true)]
     pub headless: bool,
 
+    /// Enable stealth mode (requires --features stealth)
+    #[arg(long, env = "ACTIONBOOK_STEALTH", global = true)]
+    pub stealth: bool,
+
+    /// Stealth OS profile: windows, macos-intel, macos-arm, linux
+    #[arg(long, env = "ACTIONBOOK_STEALTH_OS", global = true)]
+    pub stealth_os: Option<String>,
+
+    /// Stealth GPU profile (e.g., nvidia-rtx4080, apple-m4-max, intel-uhd630)
+    #[arg(long, env = "ACTIONBOOK_STEALTH_GPU", global = true)]
+    pub stealth_gpu: Option<String>,
+
+    /// API key for authenticated access
+    #[arg(long, env = "ACTIONBOOK_API_KEY", global = true)]
+    pub api_key: Option<String>,
+
     /// Output in JSON format
     #[arg(long, global = true)]
     pub json: bool,

--- a/packages/actionbook-rs/src/commands/get.rs
+++ b/packages/actionbook-rs/src/commands/get.rs
@@ -3,8 +3,11 @@ use crate::cli::Cli;
 use crate::config::Config;
 use crate::error::Result;
 
-pub async fn run(_cli: &Cli, area_id: &str) -> Result<()> {
-    let config = Config::load()?;
+pub async fn run(cli: &Cli, area_id: &str) -> Result<()> {
+    let mut config = Config::load()?;
+    if let Some(ref key) = cli.api_key {
+        config.api.api_key = Some(key.clone());
+    }
     let client = ApiClient::from_config(&config)?;
 
     let result = client.get_action_by_area_id(area_id).await?;

--- a/packages/actionbook-rs/src/commands/search.rs
+++ b/packages/actionbook-rs/src/commands/search.rs
@@ -6,14 +6,17 @@ use crate::config::Config;
 use crate::error::Result;
 
 pub async fn run(
-    _cli: &Cli,
+    cli: &Cli,
     query: &str,
     domain: Option<&str>,
     url: Option<&str>,
     page: u32,
     page_size: u32,
 ) -> Result<()> {
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    if let Some(ref key) = cli.api_key {
+        config.api.api_key = Some(key.clone());
+    }
     let client = ApiClient::from_config(&config)?;
 
     let params = SearchActionsParams {

--- a/packages/actionbook-rs/src/commands/sources.rs
+++ b/packages/actionbook-rs/src/commands/sources.rs
@@ -13,7 +13,10 @@ pub async fn run(cli: &Cli, command: &SourcesCommands) -> Result<()> {
 }
 
 async fn list(cli: &Cli) -> Result<()> {
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    if let Some(ref key) = cli.api_key {
+        config.api.api_key = Some(key.clone());
+    }
     let client = ApiClient::from_config(&config)?;
 
     let response = client.list_sources(Some(50)).await?;
@@ -71,7 +74,10 @@ async fn list(cli: &Cli) -> Result<()> {
 }
 
 async fn search(cli: &Cli, query: &str) -> Result<()> {
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    if let Some(ref key) = cli.api_key {
+        config.api.api_key = Some(key.clone());
+    }
     let client = ApiClient::from_config(&config)?;
 
     let response = client.search_sources(query, Some(20)).await?;

--- a/packages/actionbook-rs/tests/cli_test.rs
+++ b/packages/actionbook-rs/tests/cli_test.rs
@@ -243,6 +243,54 @@ mod browser_command {
     }
 
     #[test]
+    fn browser_connect_requires_endpoint() {
+        actionbook()
+            .args(["browser", "connect"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("ENDPOINT"));
+    }
+
+    #[test]
+    fn browser_connect_help() {
+        actionbook()
+            .args(["browser", "connect", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Connect"));
+    }
+
+    #[test]
+    fn browser_connect_invalid_endpoint_fails() {
+        // "not-a-port" is neither a number nor ws:// URL
+        actionbook()
+            .args(["browser", "connect", "not-a-port"])
+            .timeout(std::time::Duration::from_secs(5))
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("Invalid endpoint"));
+    }
+
+    #[test]
+    fn browser_connect_unreachable_port_fails() {
+        // Port 19999 should have nothing listening
+        actionbook()
+            .args(["browser", "connect", "19999"])
+            .timeout(std::time::Duration::from_secs(10))
+            .assert()
+            .failure();
+    }
+
+    #[test]
+    fn browser_snapshot_help() {
+        actionbook()
+            .args(["browser", "snapshot", "--help"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("snapshot"));
+    }
+
+    #[test]
     fn browser_cookies_subcommands() {
         actionbook()
             .args(["browser", "cookies", "--help"])


### PR DESCRIPTION
Summary

- Stealth mode: Add anti-detection browser automation with --stealth flag, supporting OS/GPU profile emulation via `--stealth-os` and `--stealth-gpu`. Includes `navigator/WebGL/plugin` fingerprint spoofing and Page.addScriptToEvaluateOnNewDocument persistence.
- Snapshot format: Rewrite snapshot to match agent-browser output format - walk childNodes for text node capture (`-
 text: content`), add `/url`: for links, support inline element roles (strong, em, code, etc.), and proper `[ref=eN]` references.
- API key support: Add `--api-key` CLI flag with `ACTIONBOOK_API_KEY` env var for future authenticated API access.
Backward compatible - no API key required for current usage.
- Session manager: Add `try_connect_to_port()` for auto-discovery of running browsers on ports 9222-9224, skip Arc
browser via CDP version check.
