### PR TITLE
Improve setup wizard UX and add config reset

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "chromiumoxide",
  "clap",
  "colored",
+ "dialoguer",
  "dirs",
  "figment",
  "futures",
@@ -380,6 +381,19 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
 
 [[package]]
 name = "difflib"
@@ -1259,7 +1273,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1562,6 +1576,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shellexpand"

--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -49,6 +49,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Utils
 dirs = "6"
+dialoguer = "0.11"
 which = "7"
 shellexpand = "3"
 base64 = "0.22"

--- a/packages/actionbook-rs/src/api/client.rs
+++ b/packages/actionbook-rs/src/api/client.rs
@@ -19,7 +19,9 @@ impl ApiClient {
         let client = Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
-            .map_err(|e| ActionbookError::ApiError(format!("Failed to create HTTP client: {}", e)))?;
+            .map_err(|e| {
+                ActionbookError::ApiError(format!("Failed to create HTTP client: {}", e))
+            })?;
 
         Ok(Self {
             client,
@@ -108,7 +110,11 @@ impl ApiClient {
 
     /// Search for actions (legacy JSON API)
     #[deprecated(note = "Use search_actions() instead")]
-    pub async fn search_actions_legacy(&self, params: SearchActionsLegacyParams) -> Result<SearchActionsResponse> {
+    #[allow(dead_code)]
+    pub async fn search_actions_legacy(
+        &self,
+        params: SearchActionsLegacyParams,
+    ) -> Result<SearchActionsResponse> {
         let mut query_params = vec![("q", params.query)];
 
         if let Some(search_type) = params.search_type {
@@ -139,6 +145,7 @@ impl ApiClient {
 
     /// Get action by ID (legacy JSON API)
     #[deprecated(note = "Use get_action_by_area_id() instead")]
+    #[allow(dead_code)]
     pub async fn get_action(&self, id: &str) -> Result<ActionDetail> {
         let response = self
             .request(reqwest::Method::GET, "/api/actions")
@@ -170,7 +177,11 @@ impl ApiClient {
     }
 
     /// Search sources
-    pub async fn search_sources(&self, query: &str, limit: Option<u32>) -> Result<SearchSourcesResponse> {
+    pub async fn search_sources(
+        &self,
+        query: &str,
+        limit: Option<u32>,
+    ) -> Result<SearchSourcesResponse> {
         let mut query_params = vec![("q", query.to_string())];
 
         if let Some(limit) = limit {
@@ -188,7 +199,10 @@ impl ApiClient {
     }
 
     /// Handle API response (JSON)
-    async fn handle_response<T: serde::de::DeserializeOwned>(&self, response: reqwest::Response) -> Result<T> {
+    async fn handle_response<T: serde::de::DeserializeOwned>(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<T> {
         let status = response.status();
 
         if status.is_success() {
@@ -199,7 +213,9 @@ impl ApiClient {
         } else {
             let error_msg = match status {
                 StatusCode::NOT_FOUND => "Resource not found".to_string(),
-                StatusCode::TOO_MANY_REQUESTS => "Rate limited. Please try again later.".to_string(),
+                StatusCode::TOO_MANY_REQUESTS => {
+                    "Rate limited. Please try again later.".to_string()
+                }
                 StatusCode::UNAUTHORIZED => "Invalid or missing API key".to_string(),
                 _ => {
                     // Try to parse error response
@@ -225,7 +241,9 @@ impl ApiClient {
         } else {
             let error_msg = match status {
                 StatusCode::NOT_FOUND => "Resource not found".to_string(),
-                StatusCode::TOO_MANY_REQUESTS => "Rate limited. Please try again later.".to_string(),
+                StatusCode::TOO_MANY_REQUESTS => {
+                    "Rate limited. Please try again later.".to_string()
+                }
                 StatusCode::UNAUTHORIZED => "Invalid or missing API key".to_string(),
                 _ => {
                     // Try to read error text

--- a/packages/actionbook-rs/src/api/types.rs
+++ b/packages/actionbook-rs/src/api/types.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -99,7 +101,9 @@ pub struct ActionDetail {
 }
 
 /// Deserialize elements from JSON string
-fn deserialize_elements<'de, D>(deserializer: D) -> Result<Option<HashMap<String, ElementInfo>>, D::Error>
+fn deserialize_elements<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, ElementInfo>>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {

--- a/packages/actionbook-rs/src/browser/launcher.rs
+++ b/packages/actionbook-rs/src/browser/launcher.rs
@@ -84,24 +84,28 @@ impl BrowserLauncher {
     }
 
     /// Set CDP port
+    #[allow(dead_code)]
     pub fn cdp_port(mut self, port: u16) -> Self {
         self.cdp_port = port;
         self
     }
 
     /// Set headless mode
+    #[allow(dead_code)]
     pub fn headless(mut self, headless: bool) -> Self {
         self.headless = headless;
         self
     }
 
     /// Set user data directory
+    #[allow(dead_code)]
     pub fn user_data_dir(mut self, dir: PathBuf) -> Self {
         self.user_data_dir = dir;
         self
     }
 
     /// Add extra browser arguments
+    #[allow(dead_code)]
     pub fn extra_args(mut self, args: Vec<String>) -> Self {
         self.extra_args = args;
         self
@@ -209,6 +213,7 @@ impl BrowserLauncher {
     }
 
     /// Get the CDP WebSocket URL for an already running browser
+    #[allow(dead_code)]
     pub async fn get_cdp_url(&self) -> Result<String> {
         let url = format!("http://127.0.0.1:{}/json/version", self.cdp_port);
 
@@ -239,6 +244,7 @@ impl BrowserLauncher {
     }
 
     /// Get browser info
+    #[allow(dead_code)]
     pub fn browser_info(&self) -> &BrowserInfo {
         &self.browser_info
     }

--- a/packages/actionbook-rs/src/browser/mod.rs
+++ b/packages/actionbook-rs/src/browser/mod.rs
@@ -2,5 +2,6 @@ mod discovery;
 mod launcher;
 mod session;
 
-pub use discovery::{discover_all_browsers, BrowserInfo};
-pub use session::{PageInfo, SessionManager, SessionStatus};
+#[allow(unused_imports)]
+pub use discovery::{discover_all_browsers, BrowserInfo, BrowserType};
+pub use session::{SessionManager, SessionStatus};

--- a/packages/actionbook-rs/src/commands/mod.rs
+++ b/packages/actionbook-rs/src/commands/mod.rs
@@ -3,4 +3,5 @@ pub mod config;
 pub mod get;
 pub mod profile;
 pub mod search;
+pub mod setup;
 pub mod sources;

--- a/packages/actionbook-rs/src/commands/setup/api_key.rs
+++ b/packages/actionbook-rs/src/commands/setup/api_key.rs
@@ -1,0 +1,281 @@
+use colored::Colorize;
+use dialoguer::{Confirm, Input};
+
+use super::detect::EnvironmentInfo;
+use crate::cli::Cli;
+use crate::config::Config;
+use crate::error::{ActionbookError, Result};
+
+/// Configure the API key with priority: flag > env > config > interactive input.
+///
+/// In non-interactive mode without a key, skips gracefully.
+/// When a key already exists, prompts the user to keep or replace it.
+/// Supports skipping — users can configure the key later.
+pub async fn configure_api_key(
+    cli: &Cli,
+    env: &EnvironmentInfo,
+    api_key_flag: Option<&str>,
+    non_interactive: bool,
+    config: &mut Config,
+) -> Result<()> {
+    if !cli.json {
+        println!("\n  {}\n", "API Key".cyan().bold());
+    }
+
+    // Priority: flag > env > existing config
+    let (existing_key, source) = resolve_existing_key(api_key_flag, env, config);
+
+    if let Some(ref key) = existing_key {
+        let masked = mask_key(key);
+
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "api_key",
+                    "status": "detected",
+                    "source": source,
+                    "masked_key": masked,
+                })
+            );
+        } else {
+            println!(
+                "  {} API key detected (from {}): {}",
+                "✓".green(),
+                source,
+                masked.dimmed()
+            );
+        }
+
+        // If from flag or non-interactive, just use it directly
+        if api_key_flag.is_some() || non_interactive {
+            config.api.api_key = existing_key;
+            return Ok(());
+        }
+
+        // Interactive: ask if they want to change
+        let keep = Confirm::new()
+            .with_prompt("  Keep this API key?")
+            .default(true)
+            .interact()
+            .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+        if keep {
+            config.api.api_key = existing_key;
+            return Ok(());
+        }
+    } else if non_interactive {
+        // No key in non-interactive mode — skip gracefully
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "api_key",
+                    "status": "skipped",
+                })
+            );
+        } else {
+            println!(
+                "  {} No API key configured. Use {} or set {} later.",
+                "−".yellow(),
+                "--api-key".cyan(),
+                "ACTIONBOOK_API_KEY".cyan()
+            );
+        }
+        return Ok(());
+    } else {
+        // No key — show helpful context before prompting
+        if !cli.json {
+            println!(
+                "  {}",
+                "Actionbook uses an API key to look up selectors and actions for you.".dimmed()
+            );
+            println!(
+                "  Don't have one yet? Grab it here: {}\n",
+                "https://actionbook.dev/dashboard".cyan().underline()
+            );
+        }
+    }
+
+    // Interactive input — leave blank to skip
+    let key: String = Input::new()
+        .with_prompt("  Enter your API key (leave blank to skip)")
+        .allow_empty(true)
+        .interact_text()
+        .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+    let key = key.trim().to_string();
+
+    if key.is_empty() {
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "api_key",
+                    "status": "skipped",
+                })
+            );
+        } else {
+            println!(
+                "  {} Skipped. You can configure it later with:",
+                "−".dimmed()
+            );
+            println!(
+                "    {}",
+                "actionbook config set api.api_key <your-key>".cyan()
+            );
+        }
+        return Ok(());
+    }
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "step": "api_key",
+                "status": "configured",
+                "masked_key": mask_key(&key),
+            })
+        );
+    } else {
+        println!(
+            "  {} API key configured: {}",
+            "✓".green(),
+            mask_key(&key).dimmed()
+        );
+    }
+
+    config.api.api_key = Some(key);
+    Ok(())
+}
+
+/// Resolve the best available key and its source name.
+fn resolve_existing_key(
+    flag: Option<&str>,
+    env: &EnvironmentInfo,
+    config: &Config,
+) -> (Option<String>, &'static str) {
+    if let Some(key) = flag {
+        return (Some(key.to_string()), "flag");
+    }
+    if let Some(ref key) = env.existing_api_key {
+        return (Some(key.clone()), "env");
+    }
+    if let Some(ref key) = config.api.api_key {
+        return (Some(key.clone()), "config");
+    }
+    (None, "none")
+}
+
+/// Mask an API key for display, showing only first 4 and last 4 chars.
+fn mask_key(key: &str) -> String {
+    let chars: Vec<char> = key.chars().collect();
+    if chars.len() <= 8 {
+        return "*".repeat(chars.len());
+    }
+    let prefix: String = chars[..4].iter().collect();
+    let suffix: String = chars[chars.len() - 4..].iter().collect();
+    format!("{}...{}", prefix, suffix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mask_key_long() {
+        assert_eq!(mask_key("abcdefghijklmnop"), "abcd...mnop");
+    }
+
+    #[test]
+    fn test_mask_key_short() {
+        assert_eq!(mask_key("abcd"), "****");
+    }
+
+    #[test]
+    fn test_mask_key_exactly_8() {
+        assert_eq!(mask_key("abcdefgh"), "********");
+    }
+
+    #[test]
+    fn test_resolve_flag_wins() {
+        let env = EnvironmentInfo {
+            os: String::new(),
+            arch: String::new(),
+            shell: None,
+            browsers: vec![],
+            claude_code: false,
+            cursor: false,
+            codex: false,
+            node_version: None,
+            existing_config: false,
+            existing_api_key: Some("env_key".to_string()),
+        };
+        let config = Config::default();
+        let (key, source) = resolve_existing_key(Some("flag_key"), &env, &config);
+        assert_eq!(key.unwrap(), "flag_key");
+        assert_eq!(source, "flag");
+    }
+
+    #[test]
+    fn test_resolve_env_wins_over_config() {
+        let env = EnvironmentInfo {
+            os: String::new(),
+            arch: String::new(),
+            shell: None,
+            browsers: vec![],
+            claude_code: false,
+            cursor: false,
+            codex: false,
+            node_version: None,
+            existing_config: false,
+            existing_api_key: Some("env_key".to_string()),
+        };
+        let mut config = Config::default();
+        config.api.api_key = Some("config_key".to_string());
+        let (key, source) = resolve_existing_key(None, &env, &config);
+        assert_eq!(key.unwrap(), "env_key");
+        assert_eq!(source, "env");
+    }
+
+    #[test]
+    fn test_resolve_config_fallback() {
+        let env = EnvironmentInfo {
+            os: String::new(),
+            arch: String::new(),
+            shell: None,
+            browsers: vec![],
+            claude_code: false,
+            cursor: false,
+            codex: false,
+            node_version: None,
+            existing_config: false,
+            existing_api_key: None,
+        };
+        let mut config = Config::default();
+        config.api.api_key = Some("config_key".to_string());
+        let (key, source) = resolve_existing_key(None, &env, &config);
+        assert_eq!(key.unwrap(), "config_key");
+        assert_eq!(source, "config");
+    }
+
+    #[test]
+    fn test_resolve_none() {
+        let env = EnvironmentInfo {
+            os: String::new(),
+            arch: String::new(),
+            shell: None,
+            browsers: vec![],
+            claude_code: false,
+            cursor: false,
+            codex: false,
+            node_version: None,
+            existing_config: false,
+            existing_api_key: None,
+        };
+        let config = Config::default();
+        let (key, source) = resolve_existing_key(None, &env, &config);
+        assert!(key.is_none());
+        assert_eq!(source, "none");
+    }
+}

--- a/packages/actionbook-rs/src/commands/setup/browser_cfg.rs
+++ b/packages/actionbook-rs/src/commands/setup/browser_cfg.rs
@@ -1,0 +1,288 @@
+use colored::Colorize;
+use dialoguer::Select;
+
+use super::detect::EnvironmentInfo;
+use crate::cli::{BrowserMode, Cli};
+use crate::config::Config;
+use crate::error::{ActionbookError, Result};
+
+/// Configure the browser mode (system vs builtin) and headless preference.
+///
+/// When browsers are detected, offers the user a choice.
+/// Respects --browser flag for non-interactive use.
+pub fn configure_browser(
+    cli: &Cli,
+    env: &EnvironmentInfo,
+    browser_flag: Option<BrowserMode>,
+    non_interactive: bool,
+    config: &mut Config,
+) -> Result<()> {
+    if !cli.json {
+        println!("\n  {}\n", "Browser".cyan().bold());
+    }
+
+    // If flag provided, apply directly
+    if let Some(mode) = browser_flag {
+        return apply_browser_mode(cli, env, mode, config);
+    }
+
+    // Non-interactive without flag: use best detected browser or keep current
+    if non_interactive {
+        if let Some(browser) = env.browsers.first() {
+            config.browser.executable = Some(browser.path.display().to_string());
+            config.browser.headless = true;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "step": "browser",
+                        "mode": "system",
+                        "browser": browser.browser_type.name(),
+                        "headless": true,
+                    })
+                );
+            } else {
+                println!(
+                    "  {} Using system browser: {}",
+                    "✓".green(),
+                    browser.browser_type.name()
+                );
+            }
+        } else {
+            config.browser.executable = None;
+            config.browser.headless = true;
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "step": "browser",
+                        "mode": "builtin",
+                        "headless": true,
+                    })
+                );
+            } else {
+                println!(
+                    "  {} No system browser detected, using built-in",
+                    "✓".green()
+                );
+            }
+        }
+        return Ok(());
+    }
+
+    // Interactive mode
+    if env.browsers.is_empty() {
+        if !cli.json {
+            println!("  {} No Chromium-based browsers detected.", "!".yellow());
+            println!("  Consider installing Chrome, Brave, or Edge.\n");
+        }
+        config.browser.executable = None;
+        return Ok(());
+    }
+
+    // Build selection options
+    let mut options: Vec<String> = env
+        .browsers
+        .iter()
+        .map(|b| {
+            let ver = b
+                .version
+                .as_deref()
+                .map(|v| format!(" v{}", v))
+                .unwrap_or_default();
+            format!("{}{} (detected)", b.browser_type.name(), ver)
+        })
+        .collect();
+    options.push("Built-in (recommended for agents)".to_string());
+
+    if !cli.json {
+        println!("  {}", "Select browser".dimmed());
+    }
+    let selection = Select::new()
+        .with_prompt("  →")
+        .items(&options)
+        .default(0)
+        .interact()
+        .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+    if selection < env.browsers.len() {
+        let browser = &env.browsers[selection];
+        config.browser.executable = Some(browser.path.display().to_string());
+    } else {
+        config.browser.executable = None;
+    }
+
+    if !cli.json {
+        println!();
+        println!("  {}", "Display mode".dimmed());
+    }
+    let headless_options = vec![
+        "Headless — no window, ideal for automation",
+        "Visible — opens a browser window you can see",
+    ];
+    let headless_selection = Select::new()
+        .with_prompt("  →")
+        .items(&headless_options)
+        .default(0)
+        .interact()
+        .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+    config.browser.headless = headless_selection == 0;
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "step": "browser",
+                "mode": if config.browser.executable.is_some() { "system" } else { "builtin" },
+                "executable": config.browser.executable,
+                "headless": config.browser.headless,
+            })
+        );
+    }
+
+    Ok(())
+}
+
+fn apply_browser_mode(
+    cli: &Cli,
+    env: &EnvironmentInfo,
+    mode: BrowserMode,
+    config: &mut Config,
+) -> Result<()> {
+    match mode {
+        BrowserMode::System => {
+            if let Some(browser) = env.browsers.first() {
+                config.browser.executable = Some(browser.path.display().to_string());
+                if !cli.json {
+                    println!(
+                        "  {} Using system browser: {}",
+                        "✓".green(),
+                        browser.browser_type.name()
+                    );
+                }
+            } else {
+                return Err(ActionbookError::SetupError(
+                    "No system browser detected. Install Chrome, Brave, or Edge.".to_string(),
+                ));
+            }
+        }
+        BrowserMode::Builtin => {
+            config.browser.executable = None;
+            if !cli.json {
+                println!("  {} Using built-in browser", "✓".green());
+            }
+        }
+    }
+
+    // Default to headless when using flags (agent scenario)
+    config.browser.headless = true;
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "step": "browser",
+                "mode": format!("{:?}", mode).to_lowercase(),
+                "executable": config.browser.executable,
+                "headless": config.browser.headless,
+            })
+        );
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::browser::{BrowserInfo, BrowserType};
+    use std::path::PathBuf;
+
+    fn make_env_with_browsers(browsers: Vec<BrowserInfo>) -> EnvironmentInfo {
+        EnvironmentInfo {
+            os: "macos".to_string(),
+            arch: "aarch64".to_string(),
+            shell: None,
+            browsers,
+            claude_code: false,
+            cursor: false,
+            codex: false,
+            node_version: None,
+            existing_config: false,
+            existing_api_key: None,
+        }
+    }
+
+    #[test]
+    fn test_apply_builtin_mode() {
+        let cli = Cli {
+            browser_path: None,
+            cdp: None,
+            profile: None,
+            headless: false,
+            json: false,
+            verbose: false,
+            command: crate::cli::Commands::Config {
+                command: crate::cli::ConfigCommands::Show,
+            },
+        };
+        let env = make_env_with_browsers(vec![]);
+        let mut config = Config::default();
+
+        let result = apply_browser_mode(&cli, &env, BrowserMode::Builtin, &mut config);
+        assert!(result.is_ok());
+        assert!(config.browser.executable.is_none());
+        assert!(config.browser.headless);
+    }
+
+    #[test]
+    fn test_apply_system_mode_no_browser() {
+        let cli = Cli {
+            browser_path: None,
+            cdp: None,
+            profile: None,
+            headless: false,
+            json: false,
+            verbose: false,
+            command: crate::cli::Commands::Config {
+                command: crate::cli::ConfigCommands::Show,
+            },
+        };
+        let env = make_env_with_browsers(vec![]);
+        let mut config = Config::default();
+
+        let result = apply_browser_mode(&cli, &env, BrowserMode::System, &mut config);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_system_mode_with_browser() {
+        let cli = Cli {
+            browser_path: None,
+            cdp: None,
+            profile: None,
+            headless: false,
+            json: false,
+            verbose: false,
+            command: crate::cli::Commands::Config {
+                command: crate::cli::ConfigCommands::Show,
+            },
+        };
+        let browser = BrowserInfo {
+            browser_type: BrowserType::Chrome,
+            path: PathBuf::from("/usr/bin/chrome"),
+            version: Some("131.0".to_string()),
+        };
+        let env = make_env_with_browsers(vec![browser]);
+        let mut config = Config::default();
+
+        let result = apply_browser_mode(&cli, &env, BrowserMode::System, &mut config);
+        assert!(result.is_ok());
+        assert_eq!(
+            config.browser.executable,
+            Some("/usr/bin/chrome".to_string())
+        );
+        assert!(config.browser.headless);
+    }
+}

--- a/packages/actionbook-rs/src/commands/setup/detect.rs
+++ b/packages/actionbook-rs/src/commands/setup/detect.rs
@@ -1,0 +1,214 @@
+use std::process::Command;
+
+use colored::Colorize;
+
+use crate::browser::{discover_all_browsers, BrowserInfo};
+use crate::config::Config;
+
+/// Detected environment information used to pre-fill setup defaults
+#[derive(Debug)]
+pub struct EnvironmentInfo {
+    pub os: String,
+    pub arch: String,
+    pub shell: Option<String>,
+    pub browsers: Vec<BrowserInfo>,
+    pub claude_code: bool,
+    pub cursor: bool,
+    pub codex: bool,
+    pub node_version: Option<String>,
+    pub existing_config: bool,
+    pub existing_api_key: Option<String>,
+}
+
+/// Scan the system environment and return detected info
+pub fn detect_environment() -> EnvironmentInfo {
+    let os = std::env::consts::OS.to_string();
+    let arch = std::env::consts::ARCH.to_string();
+    let shell = std::env::var("SHELL").ok();
+    let browsers = discover_all_browsers();
+    let claude_code = detect_claude_code();
+    let cursor = detect_cursor();
+    let codex = detect_codex();
+    let node_version = detect_node_version();
+    let existing_config = Config::config_path().exists();
+    let existing_api_key = std::env::var("ACTIONBOOK_API_KEY").ok();
+
+    EnvironmentInfo {
+        os,
+        arch,
+        shell,
+        browsers,
+        claude_code,
+        cursor,
+        codex,
+        node_version,
+        existing_config,
+        existing_api_key,
+    }
+}
+
+/// Print a formatted environment report to the terminal
+pub fn print_environment_report(env: &EnvironmentInfo, json: bool) {
+    if json {
+        let browsers_json: Vec<serde_json::Value> = env
+            .browsers
+            .iter()
+            .map(|b| {
+                serde_json::json!({
+                    "name": b.browser_type.name(),
+                    "version": b.version,
+                    "path": b.path.display().to_string(),
+                })
+            })
+            .collect();
+
+        let report = serde_json::json!({
+            "os": env.os,
+            "arch": env.arch,
+            "shell": env.shell,
+            "browsers": browsers_json,
+            "claude_code": env.claude_code,
+            "cursor": env.cursor,
+            "codex": env.codex,
+            "node": env.node_version,
+            "existing_config": env.existing_config,
+            "existing_api_key": env.existing_api_key.is_some(),
+        });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&report).unwrap_or_default()
+        );
+        return;
+    }
+
+    println!("\n  {} environment...\n", "Detecting".bold());
+
+    // OS
+    println!("  {} OS: {} ({})", check_mark(), env.os, env.arch);
+
+    // Shell
+    if let Some(ref shell) = env.shell {
+        let shell_name = shell.rsplit('/').next().unwrap_or(shell);
+        println!("  {} Shell: {}", check_mark(), shell_name);
+    } else {
+        println!("  {} Shell: {}", empty_mark(), "not detected".dimmed());
+    }
+
+    // Browsers
+    if env.browsers.is_empty() {
+        println!("  {} Browsers: {}", empty_mark(), "none detected".dimmed());
+    } else {
+        for browser in &env.browsers {
+            let version_str = browser
+                .version
+                .as_deref()
+                .map(|v| format!(" v{}", v))
+                .unwrap_or_default();
+            println!(
+                "  {} {}{}",
+                check_mark(),
+                browser.browser_type.name(),
+                version_str
+            );
+        }
+    }
+
+    // AI Tools
+    if env.claude_code {
+        println!("  {} Claude Code: {}", check_mark(), "detected".green());
+    } else {
+        println!(
+            "  {} Claude Code: {}",
+            empty_mark(),
+            "not detected".dimmed()
+        );
+    }
+
+    if env.cursor {
+        println!("  {} Cursor: {}", check_mark(), "detected".green());
+    } else {
+        println!("  {} Cursor: {}", empty_mark(), "not detected".dimmed());
+    }
+
+    if env.codex {
+        println!("  {} Codex: {}", check_mark(), "detected".green());
+    } else {
+        println!("  {} Codex: {}", empty_mark(), "not detected".dimmed());
+    }
+
+    // Node.js
+    if let Some(ref ver) = env.node_version {
+        println!("  {} Node.js: {}", check_mark(), ver);
+    } else {
+        println!("  {} Node.js: {}", empty_mark(), "not detected".dimmed());
+    }
+
+    println!();
+}
+
+fn check_mark() -> colored::ColoredString {
+    "✓".green()
+}
+
+fn empty_mark() -> colored::ColoredString {
+    "○".dimmed()
+}
+
+fn detect_claude_code() -> bool {
+    // Check if `claude` binary is in PATH
+    if which::which("claude").is_ok() {
+        return true;
+    }
+    // Check if ~/.claude/ directory exists
+    if let Some(home) = dirs::home_dir() {
+        if home.join(".claude").is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+fn detect_cursor() -> bool {
+    if let Some(home) = dirs::home_dir() {
+        return home.join(".cursor").is_dir();
+    }
+    false
+}
+
+fn detect_codex() -> bool {
+    which::which("codex").is_ok()
+}
+
+fn detect_node_version() -> Option<String> {
+    which::which("node").ok()?;
+    let output = Command::new("node").arg("--version").output().ok()?;
+    if output.status.success() {
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_environment_returns_valid_struct() {
+        let env = detect_environment();
+        assert!(!env.os.is_empty());
+        assert!(!env.arch.is_empty());
+    }
+
+    #[test]
+    fn test_print_environment_report_does_not_panic() {
+        let env = detect_environment();
+        print_environment_report(&env, false);
+    }
+
+    #[test]
+    fn test_print_environment_report_json_does_not_panic() {
+        let env = detect_environment();
+        print_environment_report(&env, true);
+    }
+}

--- a/packages/actionbook-rs/src/commands/setup/mod.rs
+++ b/packages/actionbook-rs/src/commands/setup/mod.rs
@@ -1,0 +1,371 @@
+pub mod api_key;
+pub mod browser_cfg;
+pub mod detect;
+pub mod mode;
+pub mod templates;
+
+use std::time::Instant;
+
+use colored::Colorize;
+use dialoguer::Select;
+
+use crate::api::ApiClient;
+use crate::cli::{BrowserMode, Cli, SetupTarget};
+use crate::config::Config;
+use crate::error::{ActionbookError, Result};
+
+/// Grouped arguments for the setup command.
+pub struct SetupArgs<'a> {
+    pub target: Option<SetupTarget>,
+    pub api_key: Option<&'a str>,
+    pub browser: Option<BrowserMode>,
+    pub mode: Option<&'a [SetupTarget]>,
+    pub non_interactive: bool,
+    pub force: bool,
+    pub reset: bool,
+}
+
+/// Run the setup wizard. Orchestrates all steps in order.
+///
+/// Quick mode: if `--target` is provided without other flags, only generate
+/// integration files for the specified target(s), skipping the full wizard.
+pub async fn run(cli: &Cli, args: SetupArgs<'_>) -> Result<()> {
+    // Quick mode: --target only → generate integration files and exit
+    if let Some(t) = args.target {
+        return run_target_only(cli, t, args.force, args.non_interactive).await;
+    }
+
+    // Handle existing config (re-run protection)
+    let mut config = handle_existing_config(cli, args.non_interactive, args.reset)?;
+
+    // Welcome + environment detection
+    if !cli.json {
+        print_welcome();
+    }
+    let env = detect::detect_environment();
+    detect::print_environment_report(&env, cli.json);
+
+    // API Key
+    api_key::configure_api_key(cli, &env, args.api_key, args.non_interactive, &mut config).await?;
+
+    // Browser
+    browser_cfg::configure_browser(cli, &env, args.browser, args.non_interactive, &mut config)?;
+
+    // Integration + file generation
+    let targets = mode::select_modes(cli, &env, args.mode, args.non_interactive)?;
+    let results =
+        mode::generate_integration_files(cli, &targets, args.force, args.non_interactive)?;
+
+    // Save configuration
+    config.save()?;
+    if !cli.json {
+        println!(
+            "\n  {} Configuration saved to {}",
+            "✓".green(),
+            Config::config_path().display()
+        );
+    }
+
+    // Health check (API connectivity)
+    run_health_check(cli, &config).await;
+
+    // Completion summary
+    print_completion(cli, &config, &results);
+
+    Ok(())
+}
+
+/// Quick mode: only generate integration files for the specified target.
+async fn run_target_only(
+    cli: &Cli,
+    target: SetupTarget,
+    force: bool,
+    non_interactive: bool,
+) -> Result<()> {
+    let targets = match target {
+        SetupTarget::All => vec![SetupTarget::Claude, SetupTarget::Cursor, SetupTarget::Codex],
+        other => vec![other],
+    };
+
+    if !cli.json {
+        println!("\n  {} Generating integration files...\n", "→".bold());
+    }
+
+    let results = mode::generate_integration_files(cli, &targets, force, non_interactive)?;
+
+    if cli.json {
+        let summary: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "target": mode::target_display_name(&r.target),
+                    "path": r.path.display().to_string(),
+                    "status": format!("{}", r.status),
+                })
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "command": "setup",
+                "mode": "target_only",
+                "results": summary,
+            })
+        );
+    } else {
+        println!("\n  {}", "Done!".green().bold());
+    }
+
+    Ok(())
+}
+
+/// Handle re-run protection: detect existing config and offer choices.
+fn handle_existing_config(cli: &Cli, non_interactive: bool, reset: bool) -> Result<Config> {
+    if reset {
+        if !cli.json {
+            println!("  {} Resetting configuration...", "→".bold());
+        }
+        return Ok(Config::default());
+    }
+
+    let config_exists = Config::config_path().exists();
+
+    if !config_exists {
+        return Ok(Config::default());
+    }
+
+    // Load existing config
+    let existing = Config::load()?;
+
+    if non_interactive {
+        // Non-interactive: reuse existing config as defaults
+        return Ok(existing);
+    }
+
+    if !cli.json {
+        println!("\n  {} Existing configuration found\n", "ℹ".blue());
+    }
+
+    let choices = vec![
+        "Re-run setup (current values as defaults)",
+        "Reset and start fresh",
+        "Cancel",
+    ];
+
+    let selection = Select::new()
+        .with_prompt("  What would you like to do?")
+        .items(&choices)
+        .default(0)
+        .interact()
+        .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+    match selection {
+        0 => Ok(existing),
+        1 => {
+            if !cli.json {
+                println!("  {} Starting fresh...", "→".bold());
+            }
+            Ok(Config::default())
+        }
+        _ => Err(ActionbookError::SetupError("Setup cancelled.".to_string())),
+    }
+}
+
+/// Print the welcome banner with Actionbook logo.
+fn print_welcome() {
+    println!();
+    println!(
+        "{}",
+        r#"
+     _        _   _             _                 _
+    / \   ___| |_(_) ___  _ __ | |__   ___   ___ | | __
+   / _ \ / __| __| |/ _ \| '_ \| '_ \ / _ \ / _ \| |/ /
+  / ___ \ (__| |_| | (_) | | | | |_) | (_) | (_) |   <
+ /_/   \_\___|\__|_|\___/|_| |_|_.__/ \___/ \___/|_|\_\
+"#
+        .cyan()
+    );
+    println!(
+        "  {}  {}\n",
+        format!("v{}", env!("CARGO_PKG_VERSION")).dimmed(),
+        "Setup Wizard".bold()
+    );
+}
+
+/// Run a health check by testing API connectivity.
+async fn run_health_check(cli: &Cli, config: &Config) {
+    if !cli.json {
+        println!("\n  {}\n", "Health Check".cyan().bold());
+    }
+
+    // API key + connectivity check
+    if config.api.api_key.is_none() {
+        // No API key configured — skip connectivity test
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "health_check",
+                    "api_key": "not_configured",
+                })
+            );
+        } else {
+            println!(
+                "  {} API key not configured — run {} to add it later",
+                "−".yellow(),
+                "actionbook config set api.api_key <your-key>".cyan()
+            );
+        }
+    } else {
+        // API key present — test connectivity
+        let client = match ApiClient::from_config(config) {
+            Ok(c) => Some(c),
+            Err(e) => {
+                let err_msg = e.to_string();
+                if cli.json {
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "step": "health_check",
+                            "api_key": "configured",
+                            "api_connection": "failed",
+                            "error": err_msg,
+                        })
+                    );
+                } else {
+                    println!(
+                        "  {} API client creation failed: {}",
+                        "✗".red(),
+                        err_msg.dimmed()
+                    );
+                }
+                None
+            }
+        };
+
+        if let Some(client) = client {
+            let start = Instant::now();
+            match client.list_sources(Some(1)).await {
+                Ok(_) => {
+                    let elapsed = start.elapsed().as_millis();
+                    if cli.json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "step": "health_check",
+                                "api_key": "configured",
+                                "api_connection": "ok",
+                                "latency_ms": elapsed,
+                            })
+                        );
+                    } else {
+                        println!("  {} API connection ({}ms)", "✓".green(), elapsed);
+                    }
+                }
+                Err(e) => {
+                    let err_msg = e.to_string();
+                    if cli.json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "step": "health_check",
+                                "api_key": "configured",
+                                "api_connection": "failed",
+                                "error": err_msg,
+                            })
+                        );
+                    } else {
+                        println!(
+                            "  {} API connection failed: {}",
+                            "✗".red(),
+                            err_msg.dimmed()
+                        );
+                        println!(
+                            "    {}",
+                            "Check your API key and network connection.".dimmed()
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Config file check
+    let config_path = Config::config_path();
+    if config_path.exists() {
+        if cli.json {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "health_check",
+                    "config_file": "ok",
+                    "path": config_path.display().to_string(),
+                })
+            );
+        } else {
+            println!("  {} Config saved", "✓".green());
+        }
+    }
+}
+
+/// Print the completion summary with next steps.
+fn print_completion(cli: &Cli, config: &Config, results: &[mode::TargetResult]) {
+    if cli.json {
+        let file_results: Vec<serde_json::Value> = results
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "target": mode::target_display_name(&r.target),
+                    "path": r.path.display().to_string(),
+                    "status": format!("{}", r.status),
+                })
+            })
+            .collect();
+
+        let mode_names: Vec<&str> = results
+            .iter()
+            .map(|r| mode::target_display_name(&r.target))
+            .collect();
+
+        println!(
+            "{}",
+            serde_json::json!({
+                "command": "setup",
+                "status": "complete",
+                "config_path": Config::config_path().display().to_string(),
+                "browser": config.browser.executable.as_deref().unwrap_or("built-in"),
+                "headless": config.browser.headless,
+                "modes": mode_names,
+                "files": file_results,
+            })
+        );
+        return;
+    }
+
+    let browser_display = config.browser.executable.as_deref().unwrap_or("built-in");
+
+    let mode_names: Vec<&str> = results
+        .iter()
+        .map(|r| mode::target_display_name(&r.target))
+        .collect();
+    let modes_str = if mode_names.is_empty() {
+        "Standalone".to_string()
+    } else {
+        mode_names.join(", ")
+    };
+
+    println!();
+    println!("  {} {}", "✓".green().bold(), "Actionbook is ready!".bold());
+    println!();
+    println!(
+        "  Config:  {}",
+        Config::config_path().display().to_string().dimmed()
+    );
+    println!("  Browser: {}", browser_display);
+    println!("  Modes:   {}", modes_str);
+    println!();
+    println!("  Quick start:");
+    println!("    $ {}", "actionbook search \"<goal>\" --json".cyan());
+    println!("    $ {}", "actionbook get \"<area_id>\" --json".cyan());
+    println!();
+}

--- a/packages/actionbook-rs/src/commands/setup/mode.rs
+++ b/packages/actionbook-rs/src/commands/setup/mode.rs
@@ -1,0 +1,518 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use colored::Colorize;
+use dialoguer::{MultiSelect, Select};
+
+use super::detect::EnvironmentInfo;
+use super::templates;
+use crate::cli::{Cli, SetupTarget};
+use crate::error::{ActionbookError, Result};
+
+/// Result of generating a single integration file
+#[derive(Debug)]
+pub struct TargetResult {
+    pub target: SetupTarget,
+    pub path: PathBuf,
+    pub status: FileStatus,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FileStatus {
+    Created,
+    Updated,
+    Skipped,
+    AlreadyUpToDate,
+}
+
+impl std::fmt::Display for FileStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileStatus::Created => write!(f, "created"),
+            FileStatus::Updated => write!(f, "updated (backup saved)"),
+            FileStatus::Skipped => write!(f, "skipped"),
+            FileStatus::AlreadyUpToDate => write!(f, "already up to date"),
+        }
+    }
+}
+
+/// Interactively select usage modes, with auto-detection pre-selecting items.
+pub fn select_modes(
+    cli: &Cli,
+    env: &EnvironmentInfo,
+    mode_flag: Option<&[SetupTarget]>,
+    non_interactive: bool,
+) -> Result<Vec<SetupTarget>> {
+    if !cli.json {
+        println!("\n  {}\n", "Integration".cyan().bold());
+    }
+
+    // If modes provided via flag, use them directly
+    if let Some(modes) = mode_flag {
+        let targets = expand_targets(modes);
+        if cli.json {
+            let names: Vec<&str> = targets.iter().map(target_name).collect();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "modes",
+                    "selected": names,
+                })
+            );
+        } else {
+            for t in &targets {
+                println!("  {} Mode: {}", "✓".green(), target_name(t));
+            }
+        }
+        return Ok(targets);
+    }
+
+    if non_interactive {
+        // Auto-select based on detected environment
+        let mut targets = Vec::new();
+        if env.claude_code {
+            targets.push(SetupTarget::Claude);
+        }
+        if env.cursor {
+            targets.push(SetupTarget::Cursor);
+        }
+        if env.codex {
+            targets.push(SetupTarget::Codex);
+        }
+        if targets.is_empty() {
+            // Default to standalone if nothing detected
+            targets.push(SetupTarget::Standalone);
+        }
+
+        if cli.json {
+            let names: Vec<&str> = targets.iter().map(target_name).collect();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "step": "modes",
+                    "selected": names,
+                    "auto_detected": true,
+                })
+            );
+        } else {
+            for t in &targets {
+                println!("  {} Mode: {} (auto-detected)", "✓".green(), target_name(t));
+            }
+        }
+        return Ok(targets);
+    }
+
+    // Interactive multi-select
+    let items = vec![
+        format!(
+            "Claude Code{}",
+            if env.claude_code {
+                "  (detected ✓)".to_string()
+            } else {
+                String::new()
+            }
+        ),
+        format!(
+            "Cursor{}",
+            if env.cursor {
+                "  (detected ✓)".to_string()
+            } else {
+                String::new()
+            }
+        ),
+        format!(
+            "Codex (OpenAI){}",
+            if env.codex {
+                "  (detected ✓)".to_string()
+            } else {
+                String::new()
+            }
+        ),
+        "Standalone CLI".to_string(),
+    ];
+
+    // Pre-select detected tools
+    let defaults: Vec<bool> = vec![env.claude_code, env.cursor, env.codex, false];
+
+    let selections = MultiSelect::new()
+        .with_prompt("  How will you use Actionbook? (Space to toggle, Enter to confirm)")
+        .items(&items)
+        .defaults(&defaults)
+        .interact()
+        .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+    let all_targets = [
+        SetupTarget::Claude,
+        SetupTarget::Cursor,
+        SetupTarget::Codex,
+        SetupTarget::Standalone,
+    ];
+
+    let targets: Vec<SetupTarget> = selections.iter().map(|&i| all_targets[i]).collect();
+
+    if targets.is_empty() {
+        if !cli.json {
+            println!(
+                "  {} No modes selected, skipping integration files.",
+                "!".yellow()
+            );
+        }
+    } else if cli.json {
+        let names: Vec<&str> = targets.iter().map(target_name).collect();
+        println!(
+            "{}",
+            serde_json::json!({
+                "step": "modes",
+                "selected": names,
+            })
+        );
+    } else {
+        for t in &targets {
+            println!("  {} Mode: {}", "✓".green(), target_name(t));
+        }
+    }
+
+    Ok(targets)
+}
+
+/// Generate integration files for the selected targets.
+///
+/// Idempotent behavior:
+/// - File doesn't exist → create (auto-create dirs)
+/// - File exists + same content → skip ("already up to date")
+/// - File exists + different + --force → backup + overwrite
+/// - File exists + different + interactive → prompt keep/overwrite
+/// - File exists + different + non-interactive → skip
+pub fn generate_integration_files(
+    cli: &Cli,
+    targets: &[SetupTarget],
+    force: bool,
+    non_interactive: bool,
+) -> Result<Vec<TargetResult>> {
+    let mut results = Vec::new();
+
+    for target in targets {
+        if let Some((path, content)) = target_file_info(target) {
+            let result =
+                write_file_idempotent(cli, *target, &path, content, force, non_interactive)?;
+            results.push(result);
+        }
+    }
+
+    Ok(results)
+}
+
+/// Map a target to its file path and template content.
+fn target_file_info(target: &SetupTarget) -> Option<(PathBuf, &'static str)> {
+    match target {
+        SetupTarget::Claude => Some((
+            PathBuf::from(".claude/skills/actionbook/SKILL.md"),
+            templates::CLAUDE_SKILL_TEMPLATE,
+        )),
+        SetupTarget::Codex => Some((
+            PathBuf::from(".agents/skills/actionbook/SKILL.md"),
+            templates::CODEX_SKILL_TEMPLATE,
+        )),
+        SetupTarget::Cursor => Some((
+            PathBuf::from(".cursor/rules/actionbook.md"),
+            templates::CURSOR_RULES_TEMPLATE,
+        )),
+        SetupTarget::Standalone => None, // No file to generate
+        SetupTarget::All => None,        // Expanded before reaching here
+    }
+}
+
+/// Write a file with idempotent semantics and optional backup.
+fn write_file_idempotent(
+    cli: &Cli,
+    target: SetupTarget,
+    rel_path: &Path,
+    content: &str,
+    force: bool,
+    non_interactive: bool,
+) -> Result<TargetResult> {
+    let path = rel_path.to_path_buf();
+
+    if path.exists() {
+        let existing = fs::read_to_string(&path)?;
+
+        if existing == content {
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "file": path.display().to_string(),
+                        "status": "already_up_to_date",
+                    })
+                );
+            } else {
+                println!("  {} {} (already up to date)", "✓".green(), path.display());
+            }
+            return Ok(TargetResult {
+                target,
+                path,
+                status: FileStatus::AlreadyUpToDate,
+            });
+        }
+
+        // Content differs
+        if force {
+            backup_file(&path)?;
+            write_with_dirs(&path, content)?;
+
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "file": path.display().to_string(),
+                        "status": "updated",
+                    })
+                );
+            } else {
+                println!(
+                    "  {} {} (updated, backup saved)",
+                    "✓".green(),
+                    path.display()
+                );
+            }
+            return Ok(TargetResult {
+                target,
+                path,
+                status: FileStatus::Updated,
+            });
+        }
+
+        if non_interactive {
+            if cli.json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "file": path.display().to_string(),
+                        "status": "skipped",
+                        "reason": "file_exists_different_content",
+                    })
+                );
+            } else {
+                println!(
+                    "  {} {} (skipped, file exists with different content)",
+                    "○".dimmed(),
+                    path.display()
+                );
+            }
+            return Ok(TargetResult {
+                target,
+                path,
+                status: FileStatus::Skipped,
+            });
+        }
+
+        // Interactive: ask the user
+        let choices = vec!["Keep existing file", "Overwrite (backup saved)"];
+        let selection = Select::new()
+            .with_prompt(format!("  {} already exists. What to do?", path.display()))
+            .items(&choices)
+            .default(0)
+            .interact()
+            .map_err(|e| ActionbookError::SetupError(format!("Prompt failed: {}", e)))?;
+
+        if selection == 0 {
+            if !cli.json {
+                println!("  {} {} (kept)", "✓".green(), path.display());
+            }
+            return Ok(TargetResult {
+                target,
+                path,
+                status: FileStatus::Skipped,
+            });
+        }
+
+        backup_file(&path)?;
+        write_with_dirs(&path, content)?;
+
+        if !cli.json {
+            println!(
+                "  {} {} (updated, backup saved)",
+                "✓".green(),
+                path.display()
+            );
+        }
+        return Ok(TargetResult {
+            target,
+            path,
+            status: FileStatus::Updated,
+        });
+    }
+
+    // File doesn't exist: create
+    write_with_dirs(&path, content)?;
+
+    if cli.json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "file": path.display().to_string(),
+                "status": "created",
+            })
+        );
+    } else {
+        println!("  {} {} (created)", "✓".green(), path.display());
+    }
+
+    Ok(TargetResult {
+        target,
+        path,
+        status: FileStatus::Created,
+    })
+}
+
+/// Create parent directories and write content to a file.
+fn write_with_dirs(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, content)?;
+    Ok(())
+}
+
+/// Create a backup of the file with a timestamp suffix.
+fn backup_file(path: &Path) -> Result<()> {
+    if !path.exists() {
+        return Ok(());
+    }
+    let timestamp = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let backup_name = format!("{}.bak.{}", path.display(), timestamp);
+    fs::copy(path, &backup_name)?;
+    Ok(())
+}
+
+/// Expand `All` target into individual targets (excluding Standalone),
+/// deduplicating while preserving order.
+fn expand_targets(targets: &[SetupTarget]) -> Vec<SetupTarget> {
+    let mut result = Vec::new();
+    for t in targets {
+        match t {
+            SetupTarget::All => {
+                for expanded in [SetupTarget::Claude, SetupTarget::Cursor, SetupTarget::Codex] {
+                    if !result.contains(&expanded) {
+                        result.push(expanded);
+                    }
+                }
+            }
+            other => {
+                if !result.contains(other) {
+                    result.push(*other);
+                }
+            }
+        }
+    }
+    result
+}
+
+fn target_name(t: &SetupTarget) -> &'static str {
+    match t {
+        SetupTarget::Claude => "Claude Code",
+        SetupTarget::Cursor => "Cursor",
+        SetupTarget::Codex => "Codex",
+        SetupTarget::Standalone => "Standalone CLI",
+        SetupTarget::All => "All",
+    }
+}
+
+/// Get a human-readable name for a target (public for mod.rs).
+pub fn target_display_name(t: &SetupTarget) -> &'static str {
+    target_name(t)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_expand_targets_all() {
+        let targets = expand_targets(&[SetupTarget::All]);
+        assert_eq!(targets.len(), 3);
+        assert!(targets.contains(&SetupTarget::Claude));
+        assert!(targets.contains(&SetupTarget::Cursor));
+        assert!(targets.contains(&SetupTarget::Codex));
+    }
+
+    #[test]
+    fn test_expand_targets_dedup() {
+        let targets = expand_targets(&[SetupTarget::All, SetupTarget::Codex]);
+        assert_eq!(targets.len(), 3);
+        assert_eq!(targets[0], SetupTarget::Claude);
+        assert_eq!(targets[1], SetupTarget::Cursor);
+        assert_eq!(targets[2], SetupTarget::Codex);
+    }
+
+    #[test]
+    fn test_expand_targets_individual() {
+        let targets = expand_targets(&[SetupTarget::Claude, SetupTarget::Standalone]);
+        assert_eq!(targets.len(), 2);
+        assert!(targets.contains(&SetupTarget::Claude));
+        assert!(targets.contains(&SetupTarget::Standalone));
+    }
+
+    #[test]
+    fn test_target_file_info_claude() {
+        let info = target_file_info(&SetupTarget::Claude);
+        assert!(info.is_some());
+        let (path, content) = info.unwrap();
+        assert!(path.ends_with("SKILL.md"));
+        assert!(!content.is_empty());
+    }
+
+    #[test]
+    fn test_target_file_info_standalone_none() {
+        assert!(target_file_info(&SetupTarget::Standalone).is_none());
+    }
+
+    #[test]
+    fn test_write_with_dirs_creates_parents() {
+        let tmp = TempDir::new().unwrap();
+        let file_path = tmp.path().join("a/b/c/test.md");
+        write_with_dirs(&file_path, "hello").unwrap();
+        assert_eq!(fs::read_to_string(&file_path).unwrap(), "hello");
+    }
+
+    #[test]
+    fn test_backup_file_creates_bak() {
+        let tmp = TempDir::new().unwrap();
+        let file_path = tmp.path().join("test.md");
+        fs::write(&file_path, "original").unwrap();
+        backup_file(&file_path).unwrap();
+
+        // Check that a .bak file exists
+        let entries: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert!(
+            entries.len() >= 2,
+            "Expected at least 2 files (original + backup)"
+        );
+        let has_backup = entries
+            .iter()
+            .any(|e| e.file_name().to_string_lossy().contains(".bak."));
+        assert!(has_backup, "Expected a .bak file");
+    }
+
+    #[test]
+    fn test_backup_nonexistent_file_noop() {
+        let result = backup_file(Path::new("/nonexistent/file.md"));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_target_name() {
+        assert_eq!(target_name(&SetupTarget::Claude), "Claude Code");
+        assert_eq!(target_name(&SetupTarget::Cursor), "Cursor");
+        assert_eq!(target_name(&SetupTarget::Codex), "Codex");
+        assert_eq!(target_name(&SetupTarget::Standalone), "Standalone CLI");
+    }
+}

--- a/packages/actionbook-rs/src/commands/setup/templates.rs
+++ b/packages/actionbook-rs/src/commands/setup/templates.rs
@@ -1,0 +1,157 @@
+/// SKILL.md template for Claude Code integration
+pub const CLAUDE_SKILL_TEMPLATE: &str = r#"---
+name: actionbook
+version: 1.0
+description: Query Actionbook for website action manuals (selectors, methods, flows)
+---
+
+# Actionbook Skill
+
+## When to Use
+
+- User asks to automate a website (e.g. "book an Airbnb", "search on Google")
+- You need reliable CSS/XPath selectors for a website
+- You need step-by-step operation flows for a web page
+- Before writing browser automation code (Playwright, Puppeteer, etc.)
+
+## How to Use
+
+### Search for actions
+```bash
+actionbook search "<goal>" --json
+```
+Example: `actionbook search "airbnb search listings" --json`
+
+### Get action details by area ID
+```bash
+actionbook get "<area_id>" --json
+```
+Example: `actionbook get "airbnb.com:/:default" --json`
+
+## Typical Workflow
+
+1. `actionbook search "<what the user wants to do>" --json` to find relevant actions
+2. Review returned area IDs and pick the best match
+3. `actionbook get "<area_id>" --json` to get full selectors and methods
+4. Use the returned selectors in your automation code
+
+## Response Format
+
+Always use `--json` flag for structured output that you can parse programmatically.
+
+## Safety
+
+- Actionbook is **read-only** - it returns selectors and instructions, never executes actions
+- All selectors are community-verified
+- Never hardcode selectors; always query Actionbook for up-to-date values
+"#;
+
+/// SKILL.md template for Codex (OpenAI) integration
+pub const CODEX_SKILL_TEMPLATE: &str = r#"---
+name: actionbook
+version: 1.0
+description: Query Actionbook for website action manuals
+---
+
+# Actionbook Skill
+
+## Purpose
+
+Provides accurate, real-time website operation information (element selectors, operation methods, page structure) for browser automation tasks.
+
+## Trigger Conditions
+
+- User requests website automation
+- You need CSS/XPath selectors for interactive elements
+- You need to understand a website's page structure before automating
+
+## Commands
+
+### Search for actions
+```bash
+actionbook search "<goal>" --json
+```
+
+### Get action details
+```bash
+actionbook get "<area_id>" --json
+```
+
+## Response Format
+
+Always pass `--json` for machine-readable output. Parse the JSON to extract:
+- `selectors`: CSS, XPath, aria-label, data-testid
+- `methods`: click, type, select, hover, etc.
+- `steps`: ordered operation sequence for scenarios
+
+## Constraints
+
+- Read-only: Actionbook provides information, never executes browser actions
+- Always use `--json` flag
+- Prefer `actionbook search` first, then `actionbook get` for details
+"#;
+
+/// Rules template for Cursor integration
+pub const CURSOR_RULES_TEMPLATE: &str = r#"# Actionbook Rules
+
+## When to Invoke
+
+- User asks to automate or interact with a website
+- You need element selectors (CSS, XPath, aria-label)
+- You need step-by-step browser operation flows
+- Before writing Playwright, Puppeteer, or Selenium code
+
+## How to Invoke
+
+Search for actions:
+```bash
+actionbook search "<goal>" --json
+```
+
+Get action details by area ID:
+```bash
+actionbook get "<area_id>" --json
+```
+
+## How to Present Results
+
+1. Show the user which actions were found
+2. Use returned selectors directly in automation code
+3. Follow the step ordering from scenario flows
+
+## Constraints
+
+- Always use `--json` flag for structured output
+- Actionbook is read-only - it provides selectors, never executes actions
+- Query Actionbook every time; do not cache or hardcode selectors
+- Search first (`actionbook search`), then get details (`actionbook get`)
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_claude_template_not_empty() {
+        assert!(!CLAUDE_SKILL_TEMPLATE.is_empty());
+        assert!(CLAUDE_SKILL_TEMPLATE.contains("actionbook search"));
+        assert!(CLAUDE_SKILL_TEMPLATE.contains("actionbook get"));
+        assert!(CLAUDE_SKILL_TEMPLATE.contains("--json"));
+    }
+
+    #[test]
+    fn test_codex_template_not_empty() {
+        assert!(!CODEX_SKILL_TEMPLATE.is_empty());
+        assert!(CODEX_SKILL_TEMPLATE.contains("actionbook search"));
+        assert!(CODEX_SKILL_TEMPLATE.contains("actionbook get"));
+        assert!(CODEX_SKILL_TEMPLATE.contains("--json"));
+    }
+
+    #[test]
+    fn test_cursor_template_not_empty() {
+        assert!(!CURSOR_RULES_TEMPLATE.is_empty());
+        assert!(CURSOR_RULES_TEMPLATE.contains("actionbook search"));
+        assert!(CURSOR_RULES_TEMPLATE.contains("actionbook get"));
+        assert!(CURSOR_RULES_TEMPLATE.contains("--json"));
+    }
+}

--- a/packages/actionbook-rs/src/config/profile.rs
+++ b/packages/actionbook-rs/src/config/profile.rs
@@ -52,6 +52,7 @@ impl ProfileConfig {
     }
 
     /// Create a profile for remote connection
+    #[allow(dead_code)]
     pub fn remote(cdp_url: String) -> Self {
         Self {
             cdp_url: Some(cdp_url),

--- a/packages/actionbook-rs/src/error.rs
+++ b/packages/actionbook-rs/src/error.rs
@@ -27,10 +27,14 @@ pub enum ActionbookError {
     ProfileNotFound(String),
 
     #[error("Profile already exists: {0}")]
+    #[allow(dead_code)]
     ProfileExists(String),
 
     #[error("API error: {0}")]
     ApiError(String),
+
+    #[error("Setup error: {0}")]
+    SetupError(String),
 
     #[error("Timeout: {0}")]
     Timeout(String),

--- a/packages/actionbook-rs/tests/cli_test.rs
+++ b/packages/actionbook-rs/tests/cli_test.rs
@@ -3,6 +3,8 @@
 //! These tests verify that CLI arguments are parsed correctly,
 //! matching the behavior of the original TypeScript CLI.
 
+#![allow(deprecated)]
+
 use assert_cmd::Command;
 use predicates::prelude::*;
 

--- a/packages/actionbook-rs/tests/integration_test.rs
+++ b/packages/actionbook-rs/tests/integration_test.rs
@@ -6,6 +6,8 @@
 //! Run with: cargo test --test integration_test
 //! Or with custom API URL: ACTIONBOOK_API_URL=http://localhost:3100 cargo test --test integration_test
 
+#![allow(deprecated)]
+
 use std::env;
 use std::time::Duration;
 
@@ -17,7 +19,12 @@ fn get_api_url() -> String {
 
 async fn is_api_available(client: &reqwest::Client, base_url: &str) -> bool {
     let url = format!("{}/health", base_url);
-    match client.get(&url).timeout(Duration::from_secs(3)).send().await {
+    match client
+        .get(&url)
+        .timeout(Duration::from_secs(3))
+        .send()
+        .await
+    {
         Ok(response) => response.status().is_success(),
         Err(_) => {
             // Try the search endpoint as health check alternative
@@ -141,7 +148,12 @@ mod real_api_integration {
 
         // Now get the action by ID
         let get_url = format!("{}/api/actions", api_url);
-        let get_response = match client.get(&get_url).query(&[("id", action_id)]).send().await {
+        let get_response = match client
+            .get(&get_url)
+            .query(&[("id", action_id)])
+            .send()
+            .await
+        {
             Ok(r) => r,
             Err(e) => {
                 eprintln!("Skipping test: Get request failed - {}", e);
@@ -155,7 +167,10 @@ mod real_api_integration {
             get_response.status()
         );
 
-        let body: Value = get_response.json().await.expect("Should parse JSON response");
+        let body: Value = get_response
+            .json()
+            .await
+            .expect("Should parse JSON response");
 
         assert_eq!(body["action_id"].as_str(), Some(action_id));
         assert!(body["content"].is_string());
@@ -344,7 +359,9 @@ mod cli_integration {
                     let stdout = String::from_utf8_lossy(&output.stdout);
                     // Verify it contains expected text
                     assert!(
-                        stdout.contains("Next step") || stdout.contains("area_id") || stdout.is_empty(),
+                        stdout.contains("Next step")
+                            || stdout.contains("area_id")
+                            || stdout.is_empty(),
                         "Output should contain guidance or be empty: {}",
                         stdout
                     );
@@ -369,10 +386,7 @@ mod cli_integration {
     #[test]
     fn cli_config_show_runs() {
         // Config show should always work (local operation)
-        actionbook()
-            .args(["config", "show"])
-            .assert()
-            .success();
+        actionbook().args(["config", "show"]).assert().success();
     }
 
     #[test]
@@ -388,10 +402,7 @@ mod cli_integration {
     #[test]
     fn cli_profile_list_runs() {
         // Profile list should always work (local operation)
-        actionbook()
-            .args(["profile", "list"])
-            .assert()
-            .success();
+        actionbook().args(["profile", "list"]).assert().success();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Remove rigid "Step N:" labels across all setup steps, use clean cyan section titles
- **API Key**: friendly description + dashboard link, support skip (leave blank), non-interactive graceful skip
- **Browser**: Select-based display mode (Headless/Visible) instead of Y/n, visual hierarchy between labels and options
- **Health Check**: show API key status (configured vs skipped) before connectivity test
- **config reset**: new subcommand to delete config file (with confirmation prompt)
- **browser status**: show active Configuration block (browser path + display mode)

### Review fixes included

- Fix `mask_key` panic on non-ASCII input (byte slicing → chars iteration)
- Fix `config reset` missing confirmation prompt (destructive operation)
- Fix non-interactive browser built-in branch not clearing stale `executable` path
- Fix `--mode all,codex` duplicate target processing (dedup after expansion)
- Fix API key config key name mismatch in skip prompt (`api_key` → `api.api_key`)
- Hide API key env values in CLI help output (`hide_env_values = true`)
- Run `cargo fmt` for consistent formatting

## Test plan

- [x] All 76 tests pass (27 unit + 37 CLI + 12 integration)
- [x] `cargo fmt --check` clean
- [x] `cargo check` zero warnings
- [ ] Manual: `actionbook config reset && actionbook setup` — full fresh setup flow
- [ ] Manual: `actionbook setup --non-interactive` — verify skip behavior without API key
- [ ] Manual: `actionbook browser status` — verify Configuration block shows correct browser + display mode
- [ ] Manual: `actionbook setup --mode all,codex` — verify Codex not processed twice