### PR TITLE
fix: auto-create parent dirs for screenshot/pdf output

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.1.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/actionbook-rs/src/commands/browser.rs
+++ b/packages/actionbook-rs/src/commands/browser.rs
@@ -1,4 +1,5 @@
 use std::fs;
+use std::path::Path;
 use std::time::Duration;
 
 use colored::Colorize;
@@ -578,6 +579,11 @@ async fn screenshot(cli: &Cli, config: &Config, path: &str, full_page: bool) -> 
             .await?
     };
 
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
     fs::write(path, screenshot_data)?;
 
     if cli.json {
@@ -603,6 +609,11 @@ async fn pdf(cli: &Cli, config: &Config, path: &str) -> Result<()> {
         .pdf_page(cli.profile.as_deref())
         .await?;
 
+    if let Some(parent) = Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
     fs::write(path, pdf_data)?;
 
     if cli.json {


### PR DESCRIPTION
## Summary
- When `actionbook browser screenshot <path>` or `actionbook browser pdf <path>` is called with a path whose parent directory doesn't exist, the command now auto-creates it via `fs::create_dir_all`
- Previously this would fail with a "No such file or directory" error

## Changes
- `packages/actionbook-rs/src/commands/browser.rs`: Added `std::path::Path` import and parent directory creation before `fs::write` in both `screenshot()` and `pdf()` functions

## Test plan
- [x] `cargo build` compiles successfully
- [x] Run `actionbook browser screenshot nested/dir/shot.png` — should create `nested/dir/` and save the screenshot
- [x] Run `actionbook browser pdf nested/dir/page.pdf` — should create `nested/dir/` and save the PDF
- [x] Run `actionbook browser screenshot shot.png` — still works as before (no parent dir needed)

Fixes: CUE-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)