### PR TITLE
Fix CLI error messages showing platform binary name

### DIFF
--- a/packages/actionbook-rs/src/cli.rs
+++ b/packages/actionbook-rs/src/cli.rs
@@ -5,7 +5,7 @@ use crate::error::Result;
 
 /// Actionbook CLI - Browser automation with zero installation
 #[derive(Parser)]
-#[command(name = "actionbook")]
+#[command(name = "actionbook", bin_name = "actionbook")]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Browser executable path (overrides auto-discovery)


### PR DESCRIPTION
## Summary
- Add `bin_name = "actionbook"` to clap command config so CLI error/usage messages display `actionbook` instead of the platform-specific binary name (e.g., `actionbook-darwin-arm64`)

## Changes
- `packages/actionbook-rs/src/cli.rs`: Added `bin_name = "actionbook"` attribute to `Cli` struct

## Test plan
- [x] Verified `actionbook browser open google.com --headed` now shows `Usage: actionbook browser open` instead of `Usage: actionbook-darwin-arm64 browser open`
- [x] Build passes successfully

Fixes CUE-312

🤖 Generated with [Claude Code](https://claude.com/claude-code)