### PR TITLE
chore: bump CLI version to 0.5.4

### DIFF
--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.5.1"
+version = "0.5.4"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `actionbook` CLI version to 0.5.4 for release

Includes fix from PR #77: support @eN snapshot refs in click and other commands (CUE-314)