### PR TITLE
docs: remove redundant browser install step for Rust CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,9 @@ Get started with Actionbook in under 2 minutes:
 
 ```bash
 npm install -g @actionbookdev/cli
-
-# Install browser (Chromium) for automation
-actionbook browser install
 ```
+
+The Rust-based CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium), so no extra browser install step is required.
 
 **Step 2: Use with any AI Agent**
 

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -31,10 +31,9 @@ Install the CLI globally to use Actionbook anywhere:
 
 ```bash
 npm install -g @actionbookdev/cli
-
-# Install browser (Chromium) for automation
-actionbook browser install
 ```
+
+The Rust-based CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium), so no extra browser install step is required.
 
 Once installed, you can use the `actionbook` command directly or let your AI agent use it.
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -11,10 +11,9 @@ Install the CLI globally to use Actionbook from the command line or with any AI 
 
 ```bash
 npm install -g @actionbookdev/cli
-
-# Install browser (Chromium) for automation
-actionbook browser install
 ```
+
+The Rust-based CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium), so no extra browser install step is required.
 
 ## Step 2: Use with Any AI Agent
 


### PR DESCRIPTION
## Summary
- remove the obsolete `actionbook browser install` command from setup snippets
- update root README quick start to reflect Rust CLI behavior
- update docs quickstart and installation guides with the same no-extra-install note

## Validation
- `rg -n "actionbook browser install|Install browser \(Chromium\)" README.md docs -S` (no matches)
- `git diff -- README.md docs/quickstart.mdx docs/guides/installation.mdx`

## Risk
- low, documentation-only change
