### PR TITLE
chore: bump actionbook-cli to v0.5.7

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `packages/actionbook-rs/Cargo.toml` version from `0.5.6` → `0.5.7`
- Cargo.lock auto-updated

## Context
Preparing for `actionbook-cli-v0.5.7` release tag. The incorrect `v0.5.7` tag has been deleted.

After merge, the `actionbook-cli-v0.5.7` tag will be created on main to trigger the release CI workflow.