### PR TITLE
fix: support [ref=eN] selector format from snapshot output

### DIFF
--- a/packages/actionbook-rs/src/browser/session.rs
+++ b/packages/actionbook-rs/src/browser/session.rs
@@ -694,7 +694,20 @@ impl SessionManager {
             .and_then(|v| v.as_f64())
             .ok_or_else(|| ActionbookError::Other("Invalid coordinates".to_string()))?;
 
-        // Send mouse click events
+        // Move mouse to target first so the browser updates its hit-test target,
+        // then press and release. Without mouseMoved, CDP may not dispatch the
+        // click to the correct DOM element.
+        self.send_cdp_command(
+            profile_name,
+            "Input.dispatchMouseEvent",
+            serde_json::json!({
+                "type": "mouseMoved",
+                "x": x,
+                "y": y
+            }),
+        )
+        .await?;
+
         self.send_cdp_command(
             profile_name,
             "Input.dispatchMouseEvent",


### PR DESCRIPTION
## Summary

- Fix `ElementNotFound` error when using `[ref=eN]` selectors from `actionbook browser snapshot` output
- Fix CDP click not actually triggering DOM events (links not navigating despite click reporting success)

## Changes

### 1. Normalize `[ref=eN]` selector format
The `snapshot` command outputs refs as `[ref=e15]`, but `__findElement()` only recognized the `@e15` format. When AI agents copied the ref directly from snapshot output, all selector-based commands (`click`, `type`, `fill`, etc.) failed with `ElementNotFound`. Now normalizes `[ref=eN]` → `@eN` before pattern matching.

### 2. Add `mouseMoved` before click for CDP hit-test
CDP `Input.dispatchMouseEvent` requires a `mouseMoved` event before `mousePressed` to update the browser's hit-test target. Without it, click events were not dispatched to the correct DOM element, causing links to silently fail to navigate. This matches the behavior of Puppeteer and Playwright.

## Reproduction (from CUE-332)

```
$ actionbook browser snapshot | head -10
- navigation "Toolbar" [ref=e1]:
  ...

# Before fix: ElementNotFound
$ actionbook browser click "[ref=e15]"
Error: ElementNotFound("[ref=e15]")

# After fix 1: click succeeds but page doesn't navigate
$ actionbook browser click "[ref=e15]"
✓ Clicked: [ref=e15]
# URL unchanged - click didn't trigger navigation

# After fix 2: click succeeds AND page navigates
$ actionbook browser click "[ref=e15]"
✓ Clicked: [ref=e15]
# URL changed to article page ✓
```

## Test plan

- [x] All 115 existing tests pass (unit + integration + CLI)
- [x] E2E: `blog.arxiv.org` → snapshot → `click "[ref=e15]"` → page navigates to article
- [x] E2E: `@eN` format still works
- [x] E2E: CSS selector format still works (`example.com` → `click "[ref=e2]"`)

Fixes CUE-332