### PR TITLE
chore: bump actionbook-rs version to 0.5.8

### DIFF
--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.5.7"
+version = "0.5.8"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary

- Bump `actionbook-rs` version from 0.5.7 to 0.5.8 for release

## Changes in 0.5.8

- fix: support `[ref=eN]` selector format from snapshot output
- fix: add `mouseMoved` before click to fix CDP hit-test targeting