### PR TITLE
chore: bump actionbook-cli version to 0.5.11

### DIFF
--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.5.8"
+version = "0.5.11"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `packages/actionbook-rs/Cargo.toml` version from `0.5.8` to `0.5.11` to sync with release tag

## Release
After merge, tag `actionbook-cli-v0.5.11` will be created on the merge commit to trigger CI release pipeline.