### PR TITLE
fix: run cross build from repo root to fix aarch64-linux CI

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -53,7 +53,8 @@ jobs:
 
       - name: Build (cross)
         if: matrix.use-cross
-        run: cross build --release --target ${{ matrix.target }}
+        working-directory: .
+        run: cross build --release --target ${{ matrix.target }} --manifest-path packages/actionbook-rs/Cargo.toml
 
       - name: Build (native)
         if: ${{ !matrix.use-cross }}
@@ -72,7 +73,23 @@ jobs:
       - name: Rename binary for platform
         shell: bash
         run: |
-          SRC="target/${{ matrix.target }}/release/${{ steps.binary.outputs.name }}"
+          CANDIDATES=(
+            "target/${{ matrix.target }}/release/${{ steps.binary.outputs.name }}"
+            "../target/${{ matrix.target }}/release/${{ steps.binary.outputs.name }}"
+          )
+          SRC=""
+          for candidate in "${CANDIDATES[@]}"; do
+            if [[ -f "$candidate" ]]; then
+              SRC="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$SRC" ]]; then
+            echo "ERROR: Built binary not found in expected target directories."
+            printf 'Checked:\n  - %s\n' "${CANDIDATES[@]}"
+            exit 1
+          fi
+
           ARTIFACT_DIR="${RUNNER_TEMP}/actionbook-binaries"
           mkdir -p "$ARTIFACT_DIR"
 

--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.5.8"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "assert_cmd",


### PR DESCRIPTION
## Summary

- Run `cross build` from the repo root with `--manifest-path` so Docker mounts the entire repo, making `packages/actionbook-extension/` accessible for `include_str!()` at compile time
- Add candidate-based binary path search in the rename step to handle both `target/` and `../target/` locations
- Sync `Cargo.lock` version with `Cargo.toml` (0.5.8 → 0.5.11)

## Context

PR #89 introduced `embedded_extension.rs` which uses `include_str!("../../../actionbook-extension/...")`. The `cross` tool (used only for `aarch64-unknown-linux-gnu`) runs inside Docker and only mounts the crate directory, so the extension files were inaccessible — causing 9 compile-time errors.

## Test plan

- [ ] Merge this PR
- [ ] Re-tag `actionbook-cli-v0.5.11` on the merged commit
- [ ] Verify the aarch64-unknown-linux-gnu build passes in CI