### PR TITLE
[packages/actionbook-rs]chore: bump version to 0.6.0

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.5.11"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.5.11"
+version = "0.6.0"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump actionbook-rs version from 0.5.11 to 0.6.0
- This release includes the extension decoupling from CLI binary (#93) and documentation updates (#95)

## Changes
- `Cargo.toml`: version 0.5.11 → 0.6.0
- `Cargo.lock`: auto-updated by cargo check