### PR TITLE
[packages/actionbook-extension]fix: dynamic version from manifest

### DIFF
--- a/packages/actionbook-extension/popup.html
+++ b/packages/actionbook-extension/popup.html
@@ -171,7 +171,7 @@
 </head>
 <body>
   <div class="header">
-    <h1>Actionbook <span class="version">v0.2.0</span></h1>
+    <h1>Actionbook <span class="version" id="versionLabel"></span></h1>
   </div>
 
   <div class="status-row">

--- a/packages/actionbook-extension/popup.js
+++ b/packages/actionbook-extension/popup.js
@@ -138,6 +138,10 @@ chrome.storage.local.get("bridgeToken", (result) => {
   }
 });
 
+// Set version from manifest
+document.getElementById("versionLabel").textContent =
+  "v" + chrome.runtime.getManifest().version;
+
 // Get initial state
 chrome.runtime.sendMessage({ type: "getState" }, (response) => {
   if (response) updateUI(response);


### PR DESCRIPTION
## Summary
- popup.html had hardcoded `v0.2.0` while `manifest.json` was at `0.1.0`, causing version mismatch
- Replaced hardcoded version string with dynamic `chrome.runtime.getManifest().version` read in `popup.js`
- Now version only needs to be updated in `manifest.json` and `package.json`

## Test plan
- [ ] Load extension in Chrome, open popup, verify version matches `manifest.json`
- [ ] Bump version in `manifest.json`, reload extension, confirm popup reflects new version