### PR TITLE
Bump CLI version to 0.6.1

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump `actionbook-rs` version from 0.6.0 to 0.6.1 in `Cargo.toml`
- Update `Cargo.lock` accordingly

## Release plan
After merge, tag with `actionbook-cli-v0.6.1` to trigger the release CI workflow.