### PR TITLE
[packages/actionbook-extension]feat: add CWS variant zip for Chrome Web Store

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -33,25 +33,16 @@ jobs:
           echo "Version verified: $TAG_VERSION"
 
       - name: Package extension
-        run: |
-          ZIP_NAME="actionbook-extension-v${{ steps.version.outputs.version }}.zip"
-          mkdir -p dist
-
-          zip -r9 "dist/${ZIP_NAME}" \
-            manifest.json \
-            background.js \
-            popup.html \
-            popup.js \
-            offscreen.html \
-            offscreen.js \
-            icons/
+        run: node scripts/package.js
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: Actionbook Extension v${{ steps.version.outputs.version }}
-          files: packages/actionbook-extension/dist/actionbook-extension-v${{ steps.version.outputs.version }}.zip
+          files: |
+            packages/actionbook-extension/dist/actionbook-extension-v${{ steps.version.outputs.version }}.zip
+            packages/actionbook-extension/dist/actionbook-extension-v${{ steps.version.outputs.version }}-cws.zip
           body: |
             ## Actionbook Chrome Extension v${{ steps.version.outputs.version }}
 
@@ -68,6 +59,9 @@ jobs:
             3. Open `chrome://extensions` in Chrome
             4. Enable **Developer mode**
             5. Click **Load unpacked** and select the unzipped folder
+
+            **Option 3: Chrome Web Store**
+            Download `actionbook-extension-v${{ steps.version.outputs.version }}-cws.zip` for Chrome Web Store submission (manifest without `key` field).
 
             ### After installing
             ```bash

--- a/packages/actionbook-extension/manifest.json
+++ b/packages/actionbook-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Actionbook",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Bridge between Actionbook CLI and your browser for AI-powered automation",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5xhsOXoi029BKiQTCV7UTZd/f/nzgW6JerV8XfbJLOEr+gHAVNU6J+2Yq3DvTE7+Tnx9EW9jQNGtE4ZXXaGpkvpkcP2ch3ggQQFpjOvHdlVGljepRB2gJivGWR5ooQ1QPWAyxwDLeA09/w2oZ54W9RMXeuzfjv1KRceq9FHlmkIIGaaqYfLzrQbbE7GSV1DSeRG1kG0f7Km2wUsuNDCINI6XyBbhM+662Clurs1GdP7S+Gw/+N/97YEY8Ir2smotGTknHmHuUl5N2XXJjhxfaCT85DkaMV0Kn9D9pVczK4xgqGypplCna5I61YjNDMrymA25qLNKQv2nf/mv7Y7l9wIDAQAB",
   "permissions": [


### PR DESCRIPTION
## Summary

- Add CWS (Chrome Web Store) build variant that produces a zip without the `key` field in manifest.json
- Update `release-extension.yml` workflow to build and attach both sideloading and CWS variant zips
- Bump extension version to 0.1.2

## After Merge

1. Tag the merge commit: `git tag actionbook-extension-v0.1.2 <merge-commit-sha>`
2. Push tag: `git push origin actionbook-extension-v0.1.2`
3. This triggers `release-extension.yml` which produces two artifacts:
   - `actionbook-extension-v0.1.2.zip` (sideloading, with `key`)
   - `actionbook-extension-v0.1.2-cws.zip` (CWS submission, without `key`)

## Test Plan

- [ ] Verify workflow produces both zip variants on tag push
- [ ] Confirm CWS zip does not contain `key` field in manifest.json
- [ ] Confirm sideloading zip retains `key` field in manifest.json