### PR TITLE
fix(cli): store config at ~/.actionbook/config.toml

### DIFF
--- a/packages/actionbook-rs/README.md
+++ b/packages/actionbook-rs/README.md
@@ -252,9 +252,9 @@ actionbook --profile work browser open "https://example.com"
 
 ### Config File Location
 
-- macOS: `~/.config/actionbook/config.toml`
-- Linux: `~/.config/actionbook/config.toml`
-- Windows: `%APPDATA%\actionbook\config.toml`
+- macOS: `~/.actionbook/config.toml`
+- Linux: `~/.actionbook/config.toml`
+- Windows: `%USERPROFILE%\.actionbook\config.toml`
 
 ### Example Config
 

--- a/packages/actionbook-rs/tests/integration_test.rs
+++ b/packages/actionbook-rs/tests/integration_test.rs
@@ -396,7 +396,7 @@ mod cli_integration {
             .args(["config", "path"])
             .assert()
             .success()
-            .stdout(predicate::str::contains("config"));
+            .stdout(predicate::str::contains(".actionbook"));
     }
 
     #[test]

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -146,7 +146,7 @@ actionbook profile delete work
 
 ## Configuration
 
-Config file location: `~/.config/actionbook/config.toml`
+Config file location: `~/.actionbook/config.toml`
 
 ```toml
 [api]


### PR DESCRIPTION
## Summary
- change Rust CLI config path to `~/.actionbook/config.toml`
- keep backward compatibility by loading legacy config from the platform config dir when the new file does not exist
- update CLI README paths and the `config path` integration assertion

## Testing
- `cargo test --manifest-path packages/actionbook-rs/Cargo.toml config_path`
- `cargo run --manifest-path packages/actionbook-rs/Cargo.toml -- config path`

## Risk
- existing users with legacy config keep working because config load falls back to the old path until a new file is written
