### PR TITLE
[packages/actionbook-rs]chore: bump version to 0.6.2

### DIFF
--- a/packages/actionbook-rs/Cargo.lock
+++ b/packages/actionbook-rs/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump Rust CLI crate version from 0.6.1 to 0.6.2
- prepare tag-based CLI release for merged config path change

## Validation
- cargo run --manifest-path packages/actionbook-rs/Cargo.toml -- --version (prints actionbook 0.6.2)
