### PR TITLE
Fix tab opening to reuse initial empty tab

### DIFF
--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -374,12 +374,7 @@ async function createOrReuseTab(targetUrl) {
     isReusableInitialEmptyTab(tabsInCurrentWindow[0])
   ) {
     const reusableTab = tabsInCurrentWindow[0];
-    const shouldNavigate = targetUrl && targetUrl !== "about:blank";
-    const updateProps = shouldNavigate
-      ? { url: targetUrl, active: true }
-      : { active: true };
-
-    const tab = await chrome.tabs.update(reusableTab.id, updateProps);
+    const tab = await chrome.tabs.update(reusableTab.id, { url: targetUrl, active: true });
     return { tab, reused: true };
   }
 


### PR DESCRIPTION
## Summary
- extension mode: add reusable-empty-tab detection in `Extension.createTab` so initial blank tab can be reused instead of always creating a new one
- CLI non-extension mode: update `browser open` in Rust to reuse the single initial blank page (`about:blank` / new-tab URLs) before falling back to creating a new tab
- add unit tests for reusable initial blank URL detection in the Rust CLI command path

## Validation
- `node --check packages/actionbook-extension/background.js`
- `cargo test reusable_initial_blank_page_urls -- --nocapture`
- `cargo test non_reusable_page_urls -- --nocapture`
- `cargo test --test extension_bridge_test create_tab_then_cdp_succeeds -- --nocapture`
- `cargo test --test extension_bridge_test switch_tab_changes_cdp_target -- --nocapture`

## Risk
- tab-opening behavior changes only for initial-empty-tab scenarios; non-empty/multi-tab windows keep existing behavior.
