### PR TITLE
Make docs CLI-first and reposition MCP/SDK as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,11 @@ npx skills add actionbook/actionbook
 
 ## Installation
 
-Actionbook provides three integration methods:
+```bash
+npm install -g @actionbookdev/cli
+```
 
-- **CLI (Recommended)**: Best for AI agents and general automation.
-- **MCP Server**: For AI IDEs like Cursor and Claude.
-- **JavaScript SDK**: For custom programmatic integration.
-
-For detailed installation instructions, please visit the [Installation Guide](https://actionbook.dev/docs/guides/installation).
+The CLI is all you need to get started. For advanced use cases, Actionbook also offers an [MCP Server](https://actionbook.dev/docs/guides/mcp-server) and [JavaScript SDK](https://actionbook.dev/docs/guides/sdk-integration).
 
 
 ## Examples
@@ -104,9 +102,7 @@ Explore real-world examples in the [Examples Documentation](https://actionbook.d
 
 ## Available Tools
 
-Actionbook provides tools for searching and retrieving action manuals.
-
-Check out the [CLI Reference](https://actionbook.dev/docs/api-reference/cli) and [MCP Tools Reference](https://actionbook.dev/docs/api-reference/mcp-tools).
+Actionbook provides tools for searching and retrieving action manuals. See the [CLI Reference](https://actionbook.dev/docs/api-reference/cli) for the full command list. If you're using the MCP integration, see the [MCP Tools Reference](https://actionbook.dev/docs/api-reference/mcp-tools).
 
 
 ## Documentation

--- a/docs/api-reference/mcp-tools.mdx
+++ b/docs/api-reference/mcp-tools.mdx
@@ -1,9 +1,15 @@
 ---
-title: "MCP Tools Reference"
-description: "Reference for Actionbook MCP Tools"
+title: 'MCP Tools Reference'
+description: 'Reference for Actionbook MCP Tools'
 ---
 
 # MCP Tools Reference
+
+<Note>
+  Most users should start with the [CLI](/guides/installation). This page covers
+  the MCP protocol internals — useful if you're building custom integrations or
+  debugging tool calls.
+</Note>
 
 ## MCP Tools
 
@@ -14,6 +20,7 @@ Actionbook exposes the following tools through the MCP protocol:
 Search for actions by keyword.
 
 **Parameters:**
+
 - `query` (string): Search keyword
 
 **Returns:** List of matching actions with metadata
@@ -23,6 +30,7 @@ Search for actions by keyword.
 Get action content by ActionId.
 
 **Parameters:**
+
 - `actionId` (string): The ActionId in format `site/{domain}/page/{pageType}/element/{semanticId}`
 
 **Returns:** Action content including selectors and methods

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,10 +15,7 @@
         "groups": [
           {
             "group": "Welcome",
-            "pages": [
-              "index",
-              "quickstart"
-            ]
+            "pages": ["index", "quickstart"]
           },
           {
             "group": "Guides",
@@ -32,15 +29,11 @@
           },
           {
             "group": "Examples",
-            "pages": [
-              "examples"
-            ]
+            "pages": ["examples"]
           },
           {
             "group": "Community",
-            "pages": [
-              "community/contributing"
-            ]
+            "pages": ["community/contributing"]
           }
         ]
       },
@@ -49,15 +42,7 @@
         "groups": [
           {
             "group": "CLI",
-            "pages": [
-              "api-reference/cli"
-            ]
-          },
-          {
-            "group": "MCP Tools",
-            "pages": [
-              "api-reference/mcp-tools"
-            ]
+            "pages": ["api-reference/cli"]
           }
         ]
       }

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -1,55 +1,38 @@
 ---
-title: "Installation"
-description: "How to install Actionbook"
+title: 'Installation'
+description: 'How to install Actionbook'
 ---
 
-Actionbook provides four integration methods, with the CLI being the primary and recommended way for most users.
-
-| Method | Best For | Installation Time |
-|--------|----------|-------------------|
-| **CLI (Recommended)** | AI agents, browser automation, command line | < 1 minute |
-| **Browser (Extension)** | Use your own Chrome with login sessions | < 2 minutes |
-| **MCP Server** | AI IDEs (Cursor, Claude Code, VS Code) | < 1 minute |
-| **JavaScript SDK** | Custom agents, programmatic integration | < 2 minutes |
+Install the Actionbook CLI to give any AI agent reliable browser automation. No API key is required for the CLI during open beta.
 
 ## Prerequisites
 
-Before installing, make sure you have:
-
 - <Icon icon="check" color="#22c55e" /> **Node.js** >= v18.0.0 ([Download](https://nodejs.org))
 
-<Tip>
-  Check your Node.js version with `node --version`
-</Tip>
+<Tip>Check your Node.js version with `node --version`</Tip>
 
-<Note>
-  Actionbook is currently in open beta. No API key required!
-</Note>
-
-## CLI Installation (Recommended)
-
-Install the CLI globally to use Actionbook anywhere:
+## Install the CLI
 
 ```bash
 npm install -g @actionbookdev/cli
 ```
 
-The Rust-based CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium), so no extra browser install step is required.
+The CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium) — no extra browser install needed.
 
-Once installed, you can use the `actionbook` command directly or let your AI agent use it.
+Once installed, use the `actionbook` command directly or let your AI agent call it.
 
-## Skill Installation
+## Add the Skill (Optional)
 
-To enhance your AI agent's capabilities with Actionbook, add the skill to your project:
+For tighter AI agent integration, add the Actionbook skill to your project:
 
 ```bash
 npx skills add actionbook/actionbook
 ```
 
-## Other Methods
+## Advanced Integrations (Optional)
 
-For specific IDE integrations or programmatic usage, see:
+If you need programmatic access or IDE-level integration:
 
+- [MCP Server Guide](/guides/mcp-server) — connect Actionbook to MCP-compatible IDEs
+- [SDK Integration Guide](/guides/sdk-integration) — use `@actionbookdev/sdk` in your own code
 - [Browser Automation Guide](/guides/browser)
-- [MCP Server Guide](/guides/mcp-server)
-- [SDK Integration Guide](/guides/sdk-integration)

--- a/docs/guides/mcp-server.mdx
+++ b/docs/guides/mcp-server.mdx
@@ -1,9 +1,20 @@
 ---
-title: "MCP Server"
-description: "Use Actionbook with AI IDEs"
+title: 'MCP Server'
+description: 'Use Actionbook with AI IDEs'
 ---
 
+<Note>
+  The recommended way to get started is the [CLI](/guides/installation). The MCP
+  server is an **optional, advanced** integration for AI IDEs that support the
+  MCP protocol.
+</Note>
+
 Use this option if you're working with an MCP-compatible AI IDE.
+
+<Note>
+  CLI usage does not require an API key in open beta. Some MCP client setups may
+  still ask for an explicit `--api-key` parameter depending on the host tool.
+</Note>
 
 <AccordionGroup>
   <Accordion title="Cursor">
@@ -21,6 +32,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Claude Code">
@@ -29,6 +41,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
     ```bash
     claude mcp add actionbook -- npx -y @actionbookdev/mcp@latest --api-key YOUR_API_KEY
     ```
+
   </Accordion>
 
   <Accordion title="VS Code">
@@ -46,6 +59,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Windsurf">
@@ -61,6 +75,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Claude Desktop">
@@ -76,6 +91,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Cline">
@@ -91,6 +107,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Zed">
@@ -108,6 +125,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="JetBrains IDEs">
@@ -123,6 +141,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Amazon Q Developer CLI">
@@ -138,6 +157,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Warp">
@@ -154,6 +174,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Roo Code">
@@ -169,6 +190,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Augment Code">
@@ -184,6 +206,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Trae">
@@ -199,6 +222,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 
   <Accordion title="Gemini CLI">
@@ -214,6 +238,7 @@ Use this option if you're working with an MCP-compatible AI IDE.
       }
     }
     ```
+
   </Accordion>
 </AccordionGroup>
 

--- a/docs/guides/sdk-integration.mdx
+++ b/docs/guides/sdk-integration.mdx
@@ -1,7 +1,13 @@
 ---
-title: "JavaScript SDK"
-description: "Integrate Actionbook into your custom AI agents"
+title: 'JavaScript SDK'
+description: 'Integrate Actionbook into your custom AI agents'
 ---
+
+<Note>
+  The recommended way to get started is the [CLI](/guides/installation). The
+  JavaScript SDK is an **optional, advanced** path for developers building
+  custom AI agents programmatically.
+</Note>
 
 Use this option to integrate Actionbook directly into your custom AI agents built with any LLM framework.
 
@@ -34,6 +40,7 @@ Use this option to integrate Actionbook directly into your custom AI agents buil
       prompt: 'Search for LinkedIn message actions and get the action manual',
     })
     ```
+
   </Accordion>
 
   <Accordion title="With OpenAI SDK">
@@ -69,6 +76,7 @@ Use this option to integrate Actionbook directly into your custom AI agents buil
       messages: [{ role: 'user', content: 'Search for Google login actions' }],
     })
     ```
+
   </Accordion>
 
   <Accordion title="With Anthropic Claude SDK">
@@ -99,6 +107,7 @@ Use this option to integrate Actionbook directly into your custom AI agents buil
       messages: [{ role: 'user', content: 'Search for Twitter post actions' }],
     })
     ```
+
   </Accordion>
 
   <Accordion title="With Google Gemini SDK">
@@ -132,6 +141,7 @@ Use this option to integrate Actionbook directly into your custom AI agents buil
       config: { tools },
     })
     ```
+
   </Accordion>
 
   <Accordion title="With Stagehand">
@@ -159,6 +169,7 @@ Use this option to integrate Actionbook directly into your custom AI agents buil
 
     await agent.execute('Search for Airbnb booking actions and get the action manual')
     ```
+
   </Accordion>
 </AccordionGroup>
 
@@ -195,9 +206,10 @@ const action = await actionbook.getActionById(results[0].id)
 console.log('Action details:', action)
 
 // Access the selectors
-const selector = action.selectors.css ||
-                 action.selectors.dataTestId ||
-                 action.selectors.ariaLabel
+const selector =
+  action.selectors.css ||
+  action.selectors.dataTestId ||
+  action.selectors.ariaLabel
 
 console.log('Use this selector:', selector)
 ```
@@ -212,11 +224,11 @@ import { Actionbook } from '@actionbookdev/sdk'
 const actionbook = new Actionbook()
 
 // Description
-actionbook.searchActions.description  // "Search for action manuals by keyword"
+actionbook.searchActions.description // "Search for action manuals by keyword"
 
 // Params - JSON Schema format
-actionbook.searchActions.params.json  // { type: "object", properties: { query: { type: "string" } }, required: ["query"] }
+actionbook.searchActions.params.json // { type: "object", properties: { query: { type: "string" } }, required: ["query"] }
 
 // Params - Zod format
-actionbook.searchActions.params.zod   // z.object({ query: z.string() })
+actionbook.searchActions.params.zod // z.object({ query: z.string() })
 ```

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Introduction"
-description: "Make your agents act 10x faster with 100x token savings."
+title: 'Introduction'
+description: 'Make your agents act 10x faster with 100x token savings.'
 ---
 
-Actionbook gives LLMs up-to-date DOM structure and action guides. Works with any AI agents.
+Actionbook gives LLMs up-to-date DOM structure and action guides. Install the CLI and start automating in minutes.
 
 <video
   controls
@@ -11,7 +11,7 @@ Actionbook gives LLMs up-to-date DOM structure and action guides. Works with any
   src="/actionbook-demo.mp4"
 />
 
-*See how Actionbook enables an agent to complete an Airbnb search task 10x faster.*
+_See how Actionbook enables an agent to complete an Airbnb search task 10x faster._
 
 ## Why Actionbook?
 
@@ -36,14 +36,18 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
 ## How It Works
 
 <Steps>
-  <Step title="Agent Requests Action" icon="robot">
-    Your AI agent calls Actionbook MCP tools like `search_actions` or `get_action_by_id` to find the action it needs.
+  <Step title="Search for Actions" icon="magnifying-glass">
+    Find available actions for any website using the CLI (`actionbook search
+    "airbnb login"`).
   </Step>
-  <Step title="Actionbook Retrieves Manual" icon="book">
-    Actionbook looks up the pre-verified action manual from its database, containing precise selectors and operation methods.
+  <Step title="Get Action Details" icon="book">
+    Retrieve the full action manual with precise selectors and step-by-step
+    instructions (`actionbook get "google.com:/:default"`).
   </Step>
-  <Step title="Agent Executes Precisely" icon="bullseye">
-    Your agent receives clean, structured action data and executes the operation with confidence - no guessing, no hallucinations.
+  <Step title="Launch & Execute" icon="bullseye">
+    Open a browser session and let your agent execute actions with confidence —
+    no guessing, no hallucinations (`actionbook browser open
+    "https://www.google.com"`).
   </Step>
 </Steps>
 
@@ -57,7 +61,7 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
     Isolated or extension — two modes for AI agents
   </Card>
   <Card title="MCP Server" icon="server" href="/guides/mcp-server">
-    IDE integrations for Cursor, Claude Code, VS Code, etc.
+    Integrate with Cursor, Claude Code, VS Code, etc.
   </Card>
 </Columns>
 
@@ -67,21 +71,36 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
   <Card title="Quickstart Guide" icon="rocket" href="/quickstart">
     Get started in under 2 minutes
   </Card>
-  <Card title="API Reference" icon="code" href="/api-reference/introduction">
-    MCP tools and API documentation
+  <Card title="API Reference" icon="code" href="/api-reference/cli">
+    CLI commands and API documentation
   </Card>
 </Columns>
 
 ## Community
 
 <Columns cols={3}>
-  <Card title="GitHub" icon="github" iconType="brands" href="https://github.com/actionbook/actionbook">
+  <Card
+    title="GitHub"
+    icon="github"
+    iconType="brands"
+    href="https://github.com/actionbook/actionbook"
+  >
     Star us and contribute
   </Card>
-  <Card title="Discord" icon="discord" iconType="brands" href="https://discord.gg/7sKKp7XQ2d">
+  <Card
+    title="Discord"
+    icon="discord"
+    iconType="brands"
+    href="https://discord.gg/7sKKp7XQ2d"
+  >
     Get help and share your agents
   </Card>
-  <Card title="X / Twitter" icon="x-twitter" iconType="brands" href="https://x.com/ActionbookHQ">
+  <Card
+    title="X / Twitter"
+    icon="x-twitter"
+    iconType="brands"
+    href="https://x.com/ActionbookHQ"
+  >
     Product updates and announcements
   </Card>
 </Columns>

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
-title: "Quickstart"
-description: "Get started with Actionbook in minutes"
+title: 'Quickstart'
+description: 'Get started with Actionbook in minutes'
 ---
 
 Get started with Actionbook in under 2 minutes using the CLI.
@@ -38,10 +38,14 @@ This installs the skill configuration directly into your project's `.skills` or 
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="CLI & Skills Guide" icon="terminal" href="/guides/cli-and-skills">
+  <Card
+    title="CLI & Skills Guide"
+    icon="terminal"
+    href="/guides/cli-and-skills"
+  >
     Learn more about CLI commands and Skills
   </Card>
-  <Card title="MCP Server" icon="server" href="/guides/mcp-server">
-    IDE Integration details
+  <Card title="MCP Server (Optional)" icon="server" href="/guides/mcp-server">
+    Advanced IDE integration via MCP
   </Card>
 </CardGroup>


### PR DESCRIPTION
## Summary
- Make installation and quickstart explicitly CLI-first
- Remove MCP Tools from primary API Reference navigation
- Reframe introduction flow around CLI workflow (`actionbook search` → `actionbook get` → `actionbook browser open`)
- Mark MCP Server, SDK, and MCP Tools docs as optional/advanced paths

## Validation
- `python3 -m json.tool docs/docs.json`
- `npx prettier --check docs/index.mdx docs/docs.json docs/quickstart.mdx docs/guides/installation.mdx docs/guides/mcp-server.mdx docs/guides/sdk-integration.mdx docs/api-reference/mcp-tools.mdx`

## Notes
- MCP/SDK pages are kept for advanced use, but no longer positioned as default onboarding.
- Clarified that CLI in open beta does not require API key; some MCP host clients may still request explicit `--api-key` configuration.
