### PR TITLE
Add setup command to README installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ npx skills add actionbook/actionbook
 
 ```bash
 npm install -g @actionbookdev/cli
+actionbook setup
 ```
 
 The CLI is all you need to get started. For advanced use cases, Actionbook also offers an [MCP Server](https://actionbook.dev/docs/guides/mcp-server) and [JavaScript SDK](https://actionbook.dev/docs/guides/sdk-integration).


### PR DESCRIPTION
## Summary
- Add 
  ◇  Existing configuration found immediately after CLI install command in README Installation section
- Keep scope minimal to a single README update

## Validation
- Checking formatting...
All matched files use Prettier code style!
- Codex review: PASS