### PR TITLE
Add inline comments for install/setup commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ npx skills add actionbook/actionbook
 ## Installation
 
 ```bash
-npm install -g @actionbookdev/cli   # Install the Actionbook CLI globally
-actionbook setup                    # Initialize local configuration
+# Install the Actionbook CLI globally
+npm install -g @actionbookdev/cli
+
+# Initialize local configuration
+actionbook setup
 ```
 
 The CLI is all you need to get started. For advanced use cases, Actionbook also offers an [MCP Server](https://actionbook.dev/docs/guides/mcp-server) and [JavaScript SDK](https://actionbook.dev/docs/guides/sdk-integration).


### PR DESCRIPTION
## Summary
- Add concise inline comments in README Installation command block
- Clarify purpose of each command:
  - install CLI globally
  - run setup to initialize local configuration

## Validation
- Checking formatting...
All matched files use Prettier code style!
- Codex review: PASS

## Scope
- README.md only