### PR TITLE
[packages/actionbook-rs]chore: bump version to 0.7.1

### DIFF
--- a/packages/actionbook-rs/Cargo.toml
+++ b/packages/actionbook-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 description = "Actionbook CLI - Browser automation with zero installation"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump packages/actionbook-rs crate version from 0.7.0 to 0.7.1

## Notes
- follows the same release bump pattern used for actionbook-cli-v0.7.0
- tag should be created after this PR is merged into main: actionbook-cli-v0.7.1