### PR TITLE
test: changeset release workflow with CLI patch

### DIFF
--- a/.changeset/sunny-flowers-bake.md
+++ b/.changeset/sunny-flowers-bake.md
@@ -1,0 +1,5 @@
+---
+'@actionbookdev/cli': patch
+---
+
+Use changesets to manage packages


### PR DESCRIPTION
## Summary

- Test the unified changeset release workflow by adding a CLI patch changeset
- After merging, CI should create a "chore: version packages" PR that bumps `@actionbookdev/cli` to 0.3.2 with synced platform package versions

## Test plan

- [ ] Merge this PR → CI creates Version PR with CLI 0.3.1 → 0.3.2
- [ ] Version PR includes synced platform package versions + optionalDependencies
- [ ] Merge Version PR → `build-cli` + `publish-cli` jobs trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)