### PR TITLE
chore: route Discord links through actionbook.dev/discord (CUE-412)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://actionbook.dev/docs
     about: Check our comprehensive documentation first
   - name: 💬 Discussions
-    url: https://discord.gg/7sKKp7XQ2d
+    url: https://actionbook.dev/discord
     about: Ask questions and discuss ideas with the community on Discord
   - name: 🔒 Security Vulnerability
     url: https://github.com/actionbook/actionbook/security/advisories/new

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -360,7 +360,7 @@ Please read and follow our [Code of Conduct](CODE_OF_CONDUCT.md). We are committ
 
 - **GitHub Issues** - Bug reports, feature requests, questions
 - **X (Twitter)** - Follow [@actionbookdev](https://x.com/actionbookdev) for updates
-- **Discord** - Join our community at [discord.gg/7sKKp7XQ2d](https://discord.gg/7sKKp7XQ2d)
+- **Discord** - Join our community at [actionbook.dev/discord](https://actionbook.dev/discord)
 
 ### Getting Help
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Actionbook provides up-to-date action manuals and DOM structure,
 <br />
 so your agent operates any website instantly without guessing.
 
-[Website](https://actionbook.dev) · [GitHub](https://github.com/actionbook/actionbook) · [X](https://x.com/ActionbookHQ) · [Discord](https://discord.gg/7sKKp7XQ2d)
+[Website](https://actionbook.dev) · [GitHub](https://github.com/actionbook/actionbook) · [X](https://x.com/ActionbookHQ) · [Discord](https://actionbook.dev/discord)
 
 </div>
 
@@ -123,7 +123,7 @@ We move fast. Star Actionbook on Github to support and get latest information.
 
 Join the community:
 
-- [Chat with us on Discord](https://discord.gg/7sKKp7XQ2d) - Get help, share your agents, and discuss ideas
+- [Chat with us on Discord](https://actionbook.dev/discord) - Get help, share your agents, and discuss ideas
 - [Follow @ActionbookHQ on X](https://x.com/ActionbookHQ) - Product updates and announcements
 
 ## Development

--- a/docs/community/contributing.mdx
+++ b/docs/community/contributing.mdx
@@ -42,5 +42,5 @@ pnpm dev
 ## Contributing
 
 - **[Request a Website](https://actionbook.dev/request-website)** - Suggest websites you want Actionbook to index.
-- **[Join the Community](https://discord.gg/7sKKp7XQ2d)** - Join our Discord to get help, share your agents, and discuss ideas.
+- **[Join the Community](https://actionbook.dev/discord)** - Join our Discord to get help, share your agents, and discuss ideas.
 - **[Join the Waitlist](https://actionbook.dev)** - We are currently in private beta. Join if you are interested in contributing or using Actionbook.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -56,7 +56,7 @@
         },
         {
           "anchor": "Discord",
-          "href": "https://discord.gg/7sKKp7XQ2d",
+          "href": "https://actionbook.dev/discord",
           "icon": "discord"
         }
       ]
@@ -76,7 +76,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/actionbook",
-      "discord": "https://discord.gg/7sKKp7XQ2d",
+      "discord": "https://actionbook.dev/discord",
       "x": "https://x.com/ActionbookHQ"
     }
   }

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -91,7 +91,7 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
     title="Discord"
     icon="discord"
     iconType="brands"
-    href="https://discord.gg/7sKKp7XQ2d"
+    href="https://actionbook.dev/discord"
   >
     Get help and share your agents
   </Card>


### PR DESCRIPTION
## Summary
- replace Actionbook Discord invite links with `https://actionbook.dev/discord`
- update docs and community entry points to use the routed URL
- keep third-party snapshot paths untouched

## Verification
- `rg "discord\.gg/7sKKp7XQ2d"` returns no repo occurrences for actionbook-owned files

Linear: CUE-412