### PR TITLE
docs: point Get Started button to dashboard (CUE-416)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -70,7 +70,7 @@
     "primary": {
       "type": "button",
       "label": "Get Started",
-      "href": "/dashboard"
+      "href": "https://actionbook.dev/dashboard"
     }
   },
   "footer": {


### PR DESCRIPTION
## Summary
- update docs site navbar primary button (`Get Started`) target
- change href from `/quickstart` to `https://actionbook.dev/dashboard`

## Scope
- docs/docs.json only

Linear: CUE-416