### PR TITLE
docs: add contextual menu options (CUE-419)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -73,6 +73,9 @@
       "href": "https://actionbook.dev/dashboard"
     }
   },
+  "contextual": {
+    "options": ["copy", "view", "chatgpt", "claude", "perplexity"]
+  },
   "footer": {
     "socials": {
       "github": "https://github.com/actionbook",


### PR DESCRIPTION
## Summary
- add Mintlify `contextual` config to docs site
- enable contextual menu options: `copy`, `view`, `chatgpt`, `claude`, `perplexity`

## Scope
- docs/docs.json only

Linear: CUE-419