### PR TITLE
docs: flatten docs navigation and split CLI skills (CUE-418)

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -14,35 +14,26 @@
         "tab": "Documentation",
         "groups": [
           {
-            "group": "Welcome",
+            "group": "Getting Started",
             "pages": ["index", "quickstart", "openclaw"]
           },
           {
-            "group": "Guides",
+            "group": "CLI",
             "pages": [
               "guides/installation",
-              "guides/cli-and-skills",
-              "guides/browser",
-              "guides/mcp-server",
-              "guides/sdk-integration"
+              "guides/skills",
+              "api-reference/cli",
+              "guides/browser"
             ]
           },
           {
-            "group": "Examples",
-            "pages": ["examples"]
-          },
-          {
-            "group": "Community",
-            "pages": ["community/contributing"]
-          }
-        ]
-      },
-      {
-        "tab": "API Reference",
-        "groups": [
-          {
-            "group": "CLI",
-            "pages": ["api-reference/cli"]
+            "group": "Advanced",
+            "pages": [
+              "examples",
+              "guides/mcp-server",
+              "guides/sdk-integration",
+              "community/contributing"
+            ]
           }
         ]
       }

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Browser Automation"
+title: "Browser Modes"
 description: "Control browsers with Actionbook CLI — isolated or via your own Chrome"
 ---
 

--- a/docs/guides/installation.mdx
+++ b/docs/guides/installation.mdx
@@ -1,9 +1,9 @@
 ---
 title: 'Installation'
-description: 'How to install Actionbook'
+description: 'Install Actionbook CLI and run setup'
 ---
 
-Install the Actionbook CLI to give any AI agent reliable browser automation. No API key is required for the CLI during open beta.
+Install Actionbook CLI to use Actionbook from terminal and AI agents.
 
 ## Prerequisites
 
@@ -11,28 +11,25 @@ Install the Actionbook CLI to give any AI agent reliable browser automation. No 
 
 <Tip>Check your Node.js version with `node --version`</Tip>
 
-## Install the CLI
+## Step 1: Install the CLI
 
 ```bash
 npm install -g @actionbookdev/cli
+actionbook --version
 ```
 
-The CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium) — no extra browser install needed.
+The CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium).
 
-Once installed, use the `actionbook` command directly or let your AI agent call it.
-
-## Add the Skill (Optional)
-
-For tighter AI agent integration, add the Actionbook skill to your project:
+## Step 2: Run setup
 
 ```bash
-npx skills add actionbook/actionbook
+actionbook setup
 ```
 
-## Advanced Integrations (Optional)
+Setup helps install/configure skills for your agent environment.
 
-If you need programmatic access or IDE-level integration:
+## Next
 
-- [MCP Server Guide](/guides/mcp-server) — connect Actionbook to MCP-compatible IDEs
-- [SDK Integration Guide](/guides/sdk-integration) — use `@actionbookdev/sdk` in your own code
-- [Browser Automation Guide](/guides/browser)
+- [Skills](/guides/skills)
+- [CLI Commands](/api-reference/cli)
+- [Browser Modes](/guides/browser)

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -1,0 +1,44 @@
+---
+title: 'Skills'
+description: 'Install and use core Actionbook skills'
+---
+
+Skills give your AI agent reusable instructions for how to use Actionbook correctly.
+
+## Install core skills
+
+Install the Actionbook core skill:
+
+```bash
+npx skills add actionbook/actionbook
+```
+
+Install the Active Research skill:
+
+```bash
+npx skills add actionbook/active-research
+```
+
+## What each skill does
+
+### `actionbook/actionbook`
+
+Core browser-operation workflow for agents:
+
+- `actionbook search` to find relevant manuals
+- `actionbook get` to fetch verified selectors
+- execute browser actions with less selector guesswork
+
+### `actionbook/active-research`
+
+Research workflow for deep analysis and report generation:
+
+- structured multi-source collection
+- selector-aware browsing with Actionbook
+- output-ready report workflow for long-form research
+
+## Example prompt
+
+```text
+Use Actionbook skill workflow: search first, then get the best manual, then execute browser actions.
+```


### PR DESCRIPTION
## Summary
- flatten docs IA into a single `Documentation` tab
- restructure groups to `Getting Started` / `CLI` / `Advanced`
- add standalone `Skills` page under CLI
- update Installation page to explicitly include `actionbook setup`
- rename browser guide title to `Browser Modes`

## Navigation mapping
- Getting Started: index, quickstart, openclaw
- CLI: installation, skills, commands (CLI reference), browser modes
- Advanced: examples, mcp server, javascript sdk, contributing

## Scope
- docs/docs.json
- docs/guides/installation.mdx
- docs/guides/skills.mdx (new)
- docs/guides/browser.mdx

Linear: CUE-418