### PR TITLE
docs: fix Actionbook skills install guidance

### DIFF
--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -13,7 +13,7 @@ Use the Actionbook skills package:
 npx skills add actionbook/actionbook
 ```
 
-In the interactive flow, choose the skill you want to install (for example `actionbook` or `active-research`).
+In the interactive flow, choose the skill you want to install (for example `actionbook` or `active-research`). If you need both, run the same command again and select the other skill.
 
 ## What each skill does
 


### PR DESCRIPTION
## Summary
- fix Skills guide install command guidance
- keep single install command: `npx skills add actionbook/actionbook`
- clarify that specific skill selection happens in the interactive step (e.g. `actionbook`, `active-research`)

## Scope
- docs/guides/skills.mdx only

Follow-up for: CUE-418 / PR #145 review comment