### PR TITLE
feat: add driver.dev remote browsers

### DIFF
--- a/packages/cli/docs/api-reference.md
+++ b/packages/cli/docs/api-reference.md
@@ -459,9 +459,18 @@ Create or attach to a session. The session_id can be specified via `--set-sessio
 | `--headless` | bool | No | Whether to use headless mode |
 | `--profile` | string | No | Profile to use for the session |
 | `--open-url` | string | No | Navigate to this URL when opening the browser |
-| `--cdp-endpoint` | string | No | Connect to an existing CDP endpoint (does not launch a new browser) |
+| `--cdp-endpoint` | string | No | Connect to an existing CDP endpoint (does not launch a new browser). In cloud mode, omitting this provisions a browser automatically via Driver.dev |
 | `--header <KEY:VALUE>` | string | No | Only effective with `--cdp-endpoint`, passes headers when connecting |
 | `--set-session-id` | string | No | Specify a semantic session ID |
+
+**Cloud mode:**
+
+When `--mode cloud` is used without `--cdp-endpoint`, a browser is provisioned automatically via [Driver.dev](https://driver.dev). This requires an API key configured via:
+
+- Environment variable: `ACTIONBOOK_DRIVER_API_KEY`
+- Config file (`~/.actionbook/config.toml`): `driver_api_key` under `[browser]`
+
+The remote browser is automatically stopped when the session is closed or restarted. When `--cdp-endpoint` is provided, Driver.dev is bypassed and the endpoint is used directly.
 
 **JSON `data`:**
 

--- a/packages/cli/src/browser/mod.rs
+++ b/packages/cli/src/browser/mod.rs
@@ -3,6 +3,7 @@ pub mod element;
 pub mod interaction;
 pub mod navigation;
 pub mod observation;
+pub mod provider;
 pub mod session;
 pub mod stealth;
 pub mod storage;

--- a/packages/cli/src/browser/provider/driver.rs
+++ b/packages/cli/src/browser/provider/driver.rs
@@ -1,0 +1,91 @@
+use serde::Deserialize;
+
+use crate::error::CliError;
+
+const API_BASE: &str = "https://api.driver.dev";
+
+pub struct DriverSession {
+    pub session_id: String,
+    pub cdp_url: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreateResponse {
+    session_id: String,
+    cdp_url: Option<String>,
+    status: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    served_by: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+pub async fn create_session(api_key: &str) -> Result<DriverSession, CliError> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{API_BASE}/v1/browser/session"))
+        .bearer_auth(api_key)
+        .json(&serde_json::json!({"type": "hosted"}))
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        return Err(CliError::DriverApiError(
+            "invalid or missing Driver.dev API key (401)".to_string(),
+        ));
+    }
+    if !status.is_success() {
+        let body: ErrorResponse = resp.json().await.unwrap_or(ErrorResponse {
+            error: format!("HTTP {status}"),
+        });
+        return Err(CliError::DriverApiError(body.error));
+    }
+
+    let body: CreateResponse = resp.json().await?;
+
+    if body.status == "error" {
+        return Err(CliError::DriverApiError(
+            "Driver.dev session creation returned error status".to_string(),
+        ));
+    }
+
+    let cdp_url = body.cdp_url.ok_or_else(|| {
+        CliError::DriverApiError("Driver.dev session has no cdpUrl — browser may not be ready".to_string())
+    })?;
+
+    Ok(DriverSession {
+        session_id: body.session_id,
+        cdp_url,
+    })
+}
+
+pub async fn stop_session(api_key: &str, session_id: &str) {
+    let client = reqwest::Client::new();
+    let result = client
+        .delete(format!("{API_BASE}/v1/browser/session"))
+        .bearer_auth(api_key)
+        .query(&[("sessionId", session_id)])
+        .send()
+        .await;
+
+    match result {
+        Ok(resp) if resp.status().is_success() => {
+            tracing::info!("driver.dev: stopped remote session {session_id}");
+        }
+        Ok(resp) => {
+            tracing::warn!(
+                "driver.dev: failed to stop session {session_id}: HTTP {}",
+                resp.status()
+            );
+        }
+        Err(e) => {
+            tracing::warn!("driver.dev: failed to stop session {session_id}: {e}");
+        }
+    }
+}

--- a/packages/cli/src/browser/provider/mod.rs
+++ b/packages/cli/src/browser/provider/mod.rs
@@ -1,0 +1,1 @@
+pub mod driver;

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -34,7 +34,7 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, driver_session_id) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -58,8 +58,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 None
             };
 
+        let driver_sid = entry.driver_session_id.take();
         reg.clear_session_ref_caches(&cmd.session);
-        (tabs, entry.cdp.take(), entry.chrome_process.take(), profile)
+        (tabs, entry.cdp.take(), entry.chrome_process.take(), profile, driver_sid)
     };
     // Registry lock released here — slow I/O below won't block other sessions.
 
@@ -67,6 +68,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(cdp) = cdp {
         cdp.clear_iframe_sessions().await;
         cdp.close().await;
+    }
+
+    // Stop Driver.dev remote session (best-effort).
+    if let Some(ref driver_sid) = driver_session_id {
+        if let Ok(api_key) = crate::config::resolve_driver_api_key() {
+            crate::browser::provider::driver::stop_session(&api_key, driver_sid).await;
+        }
     }
 
     if let Some(child) = chrome_process {

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -46,7 +46,7 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let (mode, headless, stealth, profile, open_url, cdp_endpoint, headers, cdp, chrome_process);
+    let (mode, headless, stealth, profile, open_url, cdp_endpoint, headers, cdp, chrome_process, driver_session_id);
     {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
@@ -72,6 +72,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             .collect::<Vec<_>>();
         cdp = entry.cdp.take();
         chrome_process = entry.chrome_process.take();
+        driver_session_id = entry.driver_session_id.take();
 
         reg.clear_session_ref_caches(&cmd.session);
     }
@@ -80,6 +81,12 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(cdp) = cdp {
         cdp.clear_iframe_sessions().await;
         cdp.close().await;
+    }
+    // Stop old Driver.dev session — a fresh one will be provisioned by start.
+    if let Some(ref driver_sid) = driver_session_id {
+        if let Ok(api_key) = crate::config::resolve_driver_api_key() {
+            crate::browser::provider::driver::stop_session(&api_key, driver_sid).await;
+        }
     }
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
@@ -93,7 +100,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         profile: Some(profile),
         executable_path: None,
         open_url,
-        cdp_endpoint,
+        // If the old session was provisioned by Driver.dev, clear the endpoint
+        // so execute() provisions a fresh one rather than reconnecting to a stopped URL.
+        cdp_endpoint: if driver_session_id.is_some() { None } else { cdp_endpoint },
         header: headers,
         session: None,
         set_session_id: Some(cmd.session.clone()),

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -22,7 +22,12 @@ Examples:
   actionbook browser start --session research
   actionbook browser start --session research --open-url https://google.com
   actionbook browser start --headless --profile scraper
+  actionbook browser start --mode cloud
   actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
+
+Cloud mode: when --cdp-endpoint is omitted, a browser is provisioned automatically via Driver.dev.
+Requires ACTIONBOOK_DRIVER_API_KEY env var or driver_api_key in ~/.actionbook/config.toml.
+When --cdp-endpoint is provided, connects directly to that endpoint (no Driver.dev account needed).
 
 --session: get-or-create — reuses an existing session with the given ID, or creates one if not found.
 --set-session-id: always creates — fails if the ID is already in use.
@@ -112,14 +117,32 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         );
     }
 
-    // Cloud mode requires --cdp-endpoint
-    if mode == Mode::Cloud && cdp_endpoint.is_none() {
-        return ActionResult::fatal_with_hint(
-            "MISSING_CDP_ENDPOINT",
-            "--mode cloud requires --cdp-endpoint",
-            "provide a cloud browser endpoint, e.g. --cdp-endpoint wss://...",
-        );
-    }
+    // Cloud mode without --cdp-endpoint: provision via Driver.dev
+    let driver_session: Option<crate::browser::provider::driver::DriverSession> =
+        if mode == Mode::Cloud && cdp_endpoint.is_none() {
+            let api_key = match config::resolve_driver_api_key() {
+                Ok(k) => k,
+                Err(e) => {
+                    return ActionResult::fatal_with_hint(
+                        e.error_code(),
+                        e.to_string(),
+                        "set ACTIONBOOK_DRIVER_API_KEY or provide --cdp-endpoint",
+                    );
+                }
+            };
+            match crate::browser::provider::driver::create_session(&api_key).await {
+                Ok(ds) => Some(ds),
+                Err(e) => {
+                    return ActionResult::fatal_with_hint(
+                        e.error_code(),
+                        e.to_string(),
+                        "check your Driver.dev API key and account balance at https://app.driver.dev",
+                    );
+                }
+            }
+        } else {
+            None
+        };
 
     // Parse headers from "KEY:VALUE" strings
     let headers = match parse_headers(&cmd.header) {
@@ -172,13 +195,19 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
     // ── Cloud mode ──────────────────────────────────────────────────
     if mode == Mode::Cloud {
+        let (effective_endpoint, driver_sid) = if let Some(ref ds) = driver_session {
+            (ds.cdp_url.as_str(), Some(ds.session_id.as_str()))
+        } else {
+            (cdp_endpoint.unwrap(), None)
+        };
         return execute_cloud(
             cmd,
             registry,
-            cdp_endpoint.unwrap(),
+            effective_endpoint,
             &headers,
             profile_name,
             headless,
+            driver_sid,
         )
         .await;
     }
@@ -655,6 +684,7 @@ async fn execute_cloud(
     headers: &[(String, String)],
     profile_name: &str,
     headless: bool,
+    driver_session_id: Option<&str>,
 ) -> ActionResult {
     let ws_url = match ensure_scheme_or_fatal(cdp_endpoint) {
         Ok(u) => u,
@@ -814,6 +844,7 @@ async fn execute_cloud(
     entry.cdp = Some(cdp);
     entry.cdp_endpoint = Some(cdp_endpoint.to_string());
     entry.headers = headers.to_vec();
+    entry.driver_session_id = driver_session_id.map(|s| s.to_string());
 
     // Create per-session data directory for artifacts (snapshots, etc.)
     let session_data_dir = config::session_data_dir(session_id.as_str());

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -47,6 +47,8 @@ pub(crate) struct BrowserConfig {
     pub(crate) executable_path: Option<String>,
     #[serde(alias = "cdp-endpoint", alias = "cdp_endpoint")]
     pub(crate) cdp_endpoint: Option<String>,
+    /// Driver.dev API key for cloud browser provisioning.
+    pub(crate) driver_api_key: Option<String>,
 }
 
 impl Default for BrowserConfig {
@@ -57,6 +59,7 @@ impl Default for BrowserConfig {
             profile_name: default_profile_name(),
             executable_path: None,
             cdp_endpoint: None,
+            driver_api_key: None,
         }
     }
 }
@@ -246,6 +249,21 @@ fn parse_env_mode(name: &str) -> Result<Option<Mode>, CliError> {
     Mode::from_str(&value)
         .map(Some)
         .map_err(|e| CliError::InvalidArgument(format!("{name}: {e}")))
+}
+
+/// Resolve Driver.dev API key from env var or config file.
+pub fn resolve_driver_api_key() -> Result<String, CliError> {
+    if let Some(key) = read_trimmed_env("ACTIONBOOK_DRIVER_API_KEY") {
+        return Ok(key);
+    }
+    let config = load_config()?;
+    config.browser.driver_api_key.ok_or_else(|| {
+        CliError::InvalidArgument(
+            "Driver.dev API key required for cloud mode without --cdp-endpoint. \
+             Set ACTIONBOOK_DRIVER_API_KEY or add driver_api_key under [browser] in ~/.actionbook/config.toml"
+                .to_string(),
+        )
+    })
 }
 
 fn normalize_optional(value: Option<String>) -> Option<String> {

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -62,6 +62,8 @@ pub struct SessionEntry {
     pub cdp_endpoint: Option<String>,
     /// Custom headers for cloud CDP connections (e.g. auth tokens).
     pub headers: Vec<(String, String)>,
+    /// Driver.dev remote session ID — used to stop the remote browser on close.
+    pub driver_session_id: Option<String>,
     /// Counter for assigning short tab IDs (t1, t2, ...).
     pub next_tab_id: u32,
 }
@@ -97,6 +99,7 @@ impl SessionEntry {
             cdp: None,
             cdp_endpoint: None,
             headers: Vec::new(),
+            driver_session_id: None,
             next_tab_id: 1,
         }
     }

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -53,6 +53,8 @@ pub enum CliError {
     VersionMismatch { cli: String, daemon: String },
     #[error("api error: {0}")]
     ApiError(String),
+    #[error("driver.dev error: {0}")]
+    DriverApiError(String),
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -85,6 +87,7 @@ impl CliError {
             CliError::CloudConnectionLost(_) => "CLOUD_CONNECTION_LOST",
             CliError::VersionMismatch { .. } => "VERSION_MISMATCH",
             CliError::ApiError(_) => "API_ERROR",
+            CliError::DriverApiError(_) => "DRIVER_API_ERROR",
             CliError::Internal(_) => "INTERNAL_ERROR",
         }
     }


### PR DESCRIPTION
## Description

Hello! I'm an engineer at driver.dev. This PR adds support for driver.dev's cloud browsers when using `--mode cloud`, feel free to alter how I did it or just use this as a template for your own integration.

## Changes Made

- Added support for driver.dev cloud browsers
- Documented support for driver.dev cloud browsers

## Validation

- Set your driver.dev API key as an env var `ACTIONBOOK_DRIVER_API_KEY` or in your Actionbook config.toml
- Run `actionbook browser start --mode cloud`, Actionbook will default to starting a session on driver.dev if no `--cdp-endpoint` is provided.