### PR TITLE
feat(cli): restore extension browser mode with bridge relay

### DIFF
--- a/.changeset/restore-extension-mode.md
+++ b/.changeset/restore-extension-mode.md
@@ -1,0 +1,12 @@
+---
+"@actionbookdev/cli": minor
+---
+
+Restore extension browser mode with WebSocket bridge relay
+
+- Add extension bridge server (ws://127.0.0.1:19222) for transparent CDP relay between Chrome extension and CLI daemon
+- Use Extension API (listTabs, attachTab, createTab, detachTab) for tab lifecycle management
+- Read default browser mode from config.toml instead of hardcoding Local
+- Fix build.rs to track git ref files in worktrees for accurate BUILD_VERSION
+- Add Local mode guard to prevent silent fallback from unsupported modes
+- Reject concurrent CDP clients in bridge to prevent response channel hijacking

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -516,28 +516,6 @@ async function handleExtensionCommand(id, method, params) {
       return { id, result: { detached: true } };
     }
 
-    case "Extension.closeTab": {
-      const tabId = params.tabId;
-      if (!tabId || typeof tabId !== "number") {
-        return { id, error: { code: -32602, message: "Missing or invalid tabId" } };
-      }
-      // Detach debugger first if this is the attached tab
-      if (attachedTabId === tabId) {
-        try {
-          await chrome.debugger.detach({ tabId });
-        } catch (_) {
-          // Ignore — tab may already be closing
-        }
-        attachedTabId = null;
-      }
-      try {
-        await chrome.tabs.remove(tabId);
-        return { id, result: { closed: true, tabId } };
-      } catch (err) {
-        return { id, error: { code: -32000, message: `Failed to close tab ${tabId}: ${err.message}` } };
-      }
-    }
-
     case "Extension.status": {
       return {
         id,

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -516,6 +516,28 @@ async function handleExtensionCommand(id, method, params) {
       return { id, result: { detached: true } };
     }
 
+    case "Extension.closeTab": {
+      const tabId = params.tabId;
+      if (!tabId || typeof tabId !== "number") {
+        return { id, error: { code: -32602, message: "Missing or invalid tabId" } };
+      }
+      // Detach debugger first if this is the attached tab
+      if (attachedTabId === tabId) {
+        try {
+          await chrome.debugger.detach({ tabId });
+        } catch (_) {
+          // Ignore — tab may already be closing
+        }
+        attachedTabId = null;
+      }
+      try {
+        await chrome.tabs.remove(tabId);
+        return { id, result: { closed: true, tabId } };
+      } catch (err) {
+        return { id, error: { code: -32000, message: `Failed to close tab ${tabId}: ${err.message}` } };
+      }
+    }
+
     case "Extension.status": {
       return {
         id,

--- a/packages/cli/build.rs
+++ b/packages/cli/build.rs
@@ -17,8 +17,13 @@ fn main() {
 
     println!("cargo:rustc-env=BUILD_VERSION={build_version}");
 
-    // Resolve repo root .git/HEAD for monorepo — relative paths are resolved
-    // from the package directory (packages/cli/), not the repo root.
+    // Track git state so BUILD_VERSION updates on new commits.
+    //
+    // In a worktree, `git rev-parse --git-dir` returns something like
+    // `.git/worktrees/<name>`. The HEAD file there is a ref pointer
+    // (e.g. `ref: refs/heads/branch-name`) and doesn't change on new
+    // commits. We must ALSO watch the packed-refs and the actual ref file
+    // so that cargo reruns build.rs when the branch tip moves.
     let git_dir = std::process::Command::new("git")
         .args(["rev-parse", "--git-dir"])
         .output()
@@ -27,7 +32,35 @@ fn main() {
         .unwrap_or_default()
         .trim()
         .to_string();
+
+    let git_common_dir = std::process::Command::new("git")
+        .args(["rev-parse", "--git-common-dir"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+
     if !git_dir.is_empty() {
+        // HEAD itself (detects branch switches)
         println!("cargo:rerun-if-changed={git_dir}/HEAD");
+
+        // Read HEAD to find the ref it points to, then watch that ref file.
+        // This ensures build.rs reruns when a new commit is added to the branch.
+        if let Ok(head_content) = std::fs::read_to_string(format!("{git_dir}/HEAD")) {
+            let head_content = head_content.trim();
+            if let Some(ref_path) = head_content.strip_prefix("ref: ") {
+                // Watch the loose ref in the common git dir (handles worktrees)
+                let common = if git_common_dir.is_empty() {
+                    &git_dir
+                } else {
+                    &git_common_dir
+                };
+                println!("cargo:rerun-if-changed={common}/{ref_path}");
+                // Also watch packed-refs since the ref might be packed
+                println!("cargo:rerun-if-changed={common}/packed-refs");
+            }
+        }
     }
 }

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use crate::action_result::ActionResult;
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
+use crate::types::Mode;
 
 /// Close a session
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -34,7 +35,7 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode, tab_native_ids) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -47,6 +48,8 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             }
         };
         let tabs = entry.tabs_count();
+        let entry_mode = entry.mode;
+        let native_ids: Vec<String> = entry.tabs.iter().map(|t| t.native_id.clone()).collect();
 
         // Only delete non-default profile directories for local sessions.
         // The default profile ("actionbook") is long-lived and preserves
@@ -59,9 +62,38 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             };
 
         reg.clear_session_ref_caches(&cmd.session);
-        (tabs, entry.cdp.take(), entry.chrome_process.take(), profile)
+        (
+            tabs,
+            entry.cdp.take(),
+            entry.chrome_process.take(),
+            profile,
+            entry_mode,
+            native_ids,
+        )
     };
     // Registry lock released here — slow I/O below won't block other sessions.
+
+    // Extension mode: close tabs and detach debugger via Extension API
+    // before tearing down the CDP connection.
+    if mode == Mode::Extension {
+        if let Some(ref cdp) = cdp {
+            for native_id in &tab_native_ids {
+                if let Ok(tab_id) = native_id.parse::<i64>() {
+                    let _ = cdp
+                        .execute_browser(
+                            "Extension.closeTab",
+                            serde_json::json!({ "tabId": tab_id }),
+                        )
+                        .await;
+                }
+            }
+            // Detach debugger as fallback (closeTab already detaches if needed,
+            // but this covers edge cases where tab IDs are stale).
+            let _ = cdp
+                .execute_browser("Extension.detachTab", serde_json::json!({}))
+                .await;
+        }
+    }
 
     // Close CDP session (shuts down background tasks, frees cloud connection slot).
     if let Some(cdp) = cdp {

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -74,15 +74,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // Extension mode: detach debugger before tearing down the CDP connection.
     // Extension mode doesn't own the browser — we only release the debugger,
     // leaving tabs open for the user.
-    if mode == Mode::Extension {
-        if let Some(ref cdp) = cdp {
-            if let Err(e) = cdp
-                .execute_browser("Extension.detachTab", serde_json::json!({}))
-                .await
-            {
-                tracing::warn!("extension: failed to detach: {e}");
-            }
-        }
+    if mode == Mode::Extension
+        && let Some(ref cdp) = cdp
+        && let Err(e) = cdp
+            .execute_browser("Extension.detachTab", serde_json::json!({}))
+            .await
+    {
+        tracing::warn!("extension: failed to detach: {e}");
     }
 
     // Close CDP session AFTER extension cleanup is complete.

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -35,7 +35,7 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode, tab_native_ids) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -49,7 +49,6 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         };
         let tabs = entry.tabs_count();
         let entry_mode = entry.mode;
-        let native_ids: Vec<String> = entry.tabs.iter().map(|t| t.native_id.clone()).collect();
 
         // Only delete non-default profile directories for local sessions.
         // The default profile ("actionbook") is long-lived and preserves
@@ -68,34 +67,25 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             entry.chrome_process.take(),
             profile,
             entry_mode,
-            native_ids,
         )
     };
     // Registry lock released here — slow I/O below won't block other sessions.
 
-    // Extension mode: close tabs and detach debugger via Extension API
-    // before tearing down the CDP connection.
+    // Extension mode: detach debugger before tearing down the CDP connection.
+    // Extension mode doesn't own the browser — we only release the debugger,
+    // leaving tabs open for the user.
     if mode == Mode::Extension {
         if let Some(ref cdp) = cdp {
-            for native_id in &tab_native_ids {
-                if let Ok(tab_id) = native_id.parse::<i64>() {
-                    let _ = cdp
-                        .execute_browser(
-                            "Extension.closeTab",
-                            serde_json::json!({ "tabId": tab_id }),
-                        )
-                        .await;
-                }
-            }
-            // Detach debugger as fallback (closeTab already detaches if needed,
-            // but this covers edge cases where tab IDs are stale).
-            let _ = cdp
+            if let Err(e) = cdp
                 .execute_browser("Extension.detachTab", serde_json::json!({}))
-                .await;
+                .await
+            {
+                tracing::warn!("extension: failed to detach: {e}");
+            }
         }
     }
 
-    // Close CDP session (shuts down background tasks, frees cloud connection slot).
+    // Close CDP session AFTER extension cleanup is complete.
     if let Some(cdp) = cdp {
         cdp.clear_iframe_sessions().await;
         cdp.close().await;

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -100,7 +100,11 @@ pub fn context(_cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let mode = cmd.mode.unwrap_or(Mode::Local);
+    let mode = cmd.mode.unwrap_or_else(|| {
+        config::load_config()
+            .map(|c| c.browser.mode)
+            .unwrap_or(Mode::Local)
+    });
     let headless = cmd.headless.unwrap_or(false);
     let profile_name = cmd.profile.as_deref().unwrap_or(DEFAULT_PROFILE);
     let cdp_endpoint = cmd.cdp_endpoint.as_deref();

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -920,51 +920,18 @@ async fn execute_extension(
         }
     };
 
-    // Discover tabs via CDP (relayed through extension).
-    let tabs = match discover_tabs_via_cdp(&cdp).await {
-        Ok(t) => t,
-        Err(e) => {
-            return fail_reserved_start(
-                registry,
-                &session_id,
-                "CDP_ERROR",
-                format!("failed to discover tabs via extension: {e}"),
-            )
-            .await;
-        }
-    };
+    // Extension-specific tab discovery via Extension.listTabs / Extension.attachTab.
+    //
+    // Unlike local/cloud mode (which use CDP Target.getTargets), the extension
+    // bridge requires an Extension.attachTab call before any CDP command can be
+    // relayed.  We use the Extension.* custom methods to list, create, and attach
+    // tabs, then register them in CdpSession so subsequent execute_on_tab works.
 
-    // Zero-tab fallback.
-    let tabs = if tabs.is_empty() {
-        let open_url = cmd.open_url.as_deref().unwrap_or("about:blank");
-        match create_tab_via_cdp(&cdp, open_url).await {
-            Ok(tab) => vec![tab],
-            Err(e) => {
-                return fail_reserved_start(
-                    registry,
-                    &session_id,
-                    "CDP_ERROR",
-                    format!("failed to create initial tab: {e}"),
-                )
-                .await;
-            }
-        }
-    } else {
-        tabs
-    };
+    let open_url = cmd.open_url.as_deref();
 
-    // Attach all tabs.
-    for (native_id, ..) in &tabs {
-        if let Err(e) = cdp.attach(native_id, None).await {
-            tracing::warn!("extension: failed to attach tab {native_id}: {e}");
-        }
-    }
-
-    // Navigate first tab if open_url provided.
-    if let Some(url) = &cmd.open_url
-        && !tabs.is_empty()
-        && tabs[0].1 != *url
-    {
+    // If open_url provided, create (or reuse) a tab via Extension.createTab
+    // which auto-attaches the debugger.  Otherwise attach the active tab.
+    let tabs: Vec<(String, String, String)> = if let Some(url) = open_url {
         let final_url = match ensure_scheme_or_fatal(url) {
             Ok(u) => u,
             Err(e) => {
@@ -972,13 +939,59 @@ async fn execute_extension(
                 return e;
             }
         };
-        let first_native = &tabs[0].0;
-        if let Err(e) = cdp
-            .execute_on_tab(first_native, "Page.navigate", json!({ "url": final_url }))
+        match cdp
+            .execute_browser("Extension.createTab", json!({ "url": final_url }))
             .await
         {
-            tracing::warn!("extension: navigate on start failed: {e}");
+            Ok(resp) => {
+                let result = &resp["result"];
+                let tab_id = result["tabId"].as_i64().unwrap_or(0).to_string();
+                let tab_url = result["url"]
+                    .as_str()
+                    .unwrap_or(&final_url)
+                    .to_string();
+                let title = result["title"].as_str().unwrap_or("").to_string();
+                vec![(tab_id, tab_url, title)]
+            }
+            Err(e) => {
+                return fail_reserved_start(
+                    registry,
+                    &session_id,
+                    "CDP_ERROR",
+                    format!("failed to create tab via extension: {e}"),
+                )
+                .await;
+            }
         }
+    } else {
+        // No open_url — attach the current active tab.
+        match cdp
+            .execute_browser("Extension.attachActiveTab", json!({}))
+            .await
+        {
+            Ok(resp) => {
+                let result = &resp["result"];
+                let tab_id = result["tabId"].as_i64().unwrap_or(0).to_string();
+                let tab_url = result["url"].as_str().unwrap_or("about:blank").to_string();
+                let title = result["title"].as_str().unwrap_or("").to_string();
+                vec![(tab_id, tab_url, title)]
+            }
+            Err(e) => {
+                return fail_reserved_start(
+                    registry,
+                    &session_id,
+                    "CDP_ERROR",
+                    format!("failed to attach active tab via extension: {e}"),
+                )
+                .await;
+            }
+        }
+    };
+
+    // Register extension tabs in CdpSession so execute_on_tab works.
+    // Extension bridge ignores sessionId, so an empty string is fine.
+    for (native_id, ..) in &tabs {
+        cdp.register_extension_tab(native_id).await;
     }
 
     let first_native_id = tabs.first().map(|t| t.0.clone()).unwrap_or_default();

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -183,7 +183,18 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         .await;
     }
 
-    // ── Local / Extension mode ──────────────────────────────────────
+    // ── Extension mode ─────────────────────────────────────────────
+    if mode == Mode::Extension {
+        if cdp_endpoint.is_some() {
+            return ActionResult::fatal(
+                "INVALID_ARGUMENT",
+                "--cdp-endpoint is not supported with --mode extension".to_string(),
+            );
+        }
+        return execute_extension(cmd, registry, profile_name, headless).await;
+    }
+
+    // ── Local mode ─────────────────────────────────────────────────
 
     if cdp_endpoint.is_some() && mode != Mode::Local {
         return ActionResult::fatal(
@@ -832,6 +843,189 @@ async fn execute_cloud(
             "status": "running",
             "headless": headless,
             "cdp_endpoint": redact_endpoint(cdp_endpoint),
+        },
+        "tab": {
+            "tab_id": first_short_id,
+            "native_tab_id": first_native_id,
+            "url": first_url,
+            "title": first_title,
+        },
+        "reused": false,
+    }))
+}
+
+// ── Extension mode ────────────────────────────────────────────────────
+
+/// Execute extension-mode session start.
+///
+/// Connects to the extension bridge WS, which transparently relays CDP
+/// commands to the Chrome extension. Reuses the same CDP flow as cloud mode.
+async fn execute_extension(
+    cmd: &Cmd,
+    registry: &SharedRegistry,
+    profile_name: &str,
+    headless: bool,
+) -> ActionResult {
+    use crate::daemon::bridge::BRIDGE_PORT;
+
+    // Check bridge state from registry.
+    let bridge_ws_url = {
+        let reg = registry.lock().await;
+        let Some(bridge_state) = reg.bridge_state() else {
+            return ActionResult::fatal_with_hint(
+                "BRIDGE_NOT_RUNNING",
+                "extension bridge is not running",
+                "the daemon failed to start the bridge — check if port 19222 is in use",
+            );
+        };
+        let bs = bridge_state.lock().await;
+        if !bs.is_extension_connected() {
+            return ActionResult::fatal_with_hint(
+                "EXTENSION_NOT_CONNECTED",
+                "no Chrome extension is connected to the bridge",
+                "open Chrome with the Actionbook extension installed and ensure it is active",
+            );
+        }
+        format!("ws://127.0.0.1:{BRIDGE_PORT}")
+    };
+
+    // Reserve a session placeholder.
+    let effective_set_id = cmd.session.as_deref().or(cmd.set_session_id.as_deref());
+    let session_id = {
+        let mut reg = registry.lock().await;
+        match reg.reserve_session_start(
+            effective_set_id,
+            cmd.profile.as_deref(),
+            profile_name,
+            Mode::Extension,
+            headless,
+            cmd.stealth,
+        ) {
+            Ok(sid) => sid,
+            Err(e) => return ActionResult::fatal(e.error_code(), e.to_string()),
+        }
+    };
+
+    // Connect CdpSession to bridge (transparent relay to extension).
+    let cdp = match CdpSession::connect(&bridge_ws_url).await {
+        Ok(c) => c,
+        Err(e) => {
+            return fail_reserved_start(
+                registry,
+                &session_id,
+                "CDP_CONNECTION_FAILED",
+                format!("failed to connect to extension bridge: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // Discover tabs via CDP (relayed through extension).
+    let tabs = match discover_tabs_via_cdp(&cdp).await {
+        Ok(t) => t,
+        Err(e) => {
+            return fail_reserved_start(
+                registry,
+                &session_id,
+                "CDP_ERROR",
+                format!("failed to discover tabs via extension: {e}"),
+            )
+            .await;
+        }
+    };
+
+    // Zero-tab fallback.
+    let tabs = if tabs.is_empty() {
+        let open_url = cmd.open_url.as_deref().unwrap_or("about:blank");
+        match create_tab_via_cdp(&cdp, open_url).await {
+            Ok(tab) => vec![tab],
+            Err(e) => {
+                return fail_reserved_start(
+                    registry,
+                    &session_id,
+                    "CDP_ERROR",
+                    format!("failed to create initial tab: {e}"),
+                )
+                .await;
+            }
+        }
+    } else {
+        tabs
+    };
+
+    // Attach all tabs.
+    for (native_id, ..) in &tabs {
+        if let Err(e) = cdp.attach(native_id, None).await {
+            tracing::warn!("extension: failed to attach tab {native_id}: {e}");
+        }
+    }
+
+    // Navigate first tab if open_url provided.
+    if let Some(url) = &cmd.open_url
+        && !tabs.is_empty()
+        && tabs[0].1 != *url
+    {
+        let final_url = match ensure_scheme_or_fatal(url) {
+            Ok(u) => u,
+            Err(e) => {
+                registry.lock().await.remove(session_id.as_str());
+                return e;
+            }
+        };
+        let first_native = &tabs[0].0;
+        if let Err(e) = cdp
+            .execute_on_tab(first_native, "Page.navigate", json!({ "url": final_url }))
+            .await
+        {
+            tracing::warn!("extension: navigate on start failed: {e}");
+        }
+    }
+
+    let first_native_id = tabs.first().map(|t| t.0.clone()).unwrap_or_default();
+    let first_url = tabs
+        .first()
+        .map(|t| t.1.clone())
+        .unwrap_or_else(|| "about:blank".to_string());
+    let first_title = tabs.first().map(|t| t.2.clone()).unwrap_or_default();
+
+    // Finalize registry entry.
+    let mut reg = registry.lock().await;
+    let Some(entry) = reg.get_mut(session_id.as_str()) else {
+        return ActionResult::fatal(
+            "SESSION_NOT_FOUND",
+            format!(
+                "session '{}' was closed during startup",
+                session_id.as_str()
+            ),
+        );
+    };
+    entry.mode = Mode::Extension;
+    entry.headless = headless;
+    entry.profile = profile_name.to_string();
+    entry.status = SessionState::Running;
+    entry.cdp_port = None;
+    entry.ws_url = bridge_ws_url.clone();
+    for (native_id, url, title) in tabs {
+        entry.push_tab(native_id, url, title);
+    }
+    entry.chrome_process = None;
+    entry.cdp = Some(cdp);
+
+    let session_data_dir = config::session_data_dir(session_id.as_str());
+    std::fs::create_dir_all(&session_data_dir).ok();
+
+    let first_short_id = entry
+        .tabs
+        .first()
+        .map(|t| t.id.0.clone())
+        .unwrap_or_default();
+
+    ActionResult::ok(json!({
+        "session": {
+            "session_id": session_id.as_str(),
+            "mode": "extension",
+            "status": "running",
+            "headless": headless,
         },
         "tab": {
             "tab_id": first_short_id,

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -200,10 +200,14 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
     // ── Local mode ─────────────────────────────────────────────────
 
-    if cdp_endpoint.is_some() && mode != Mode::Local {
-        return ActionResult::fatal(
-            "INVALID_ARGUMENT",
-            "cdp-endpoint requires --mode local".to_string(),
+    // Guard: only Local mode should reach here. Cloud and Extension return
+    // earlier; if a new mode is added but not handled, fail explicitly rather
+    // than silently launching a local Chrome.
+    if mode != Mode::Local {
+        return ActionResult::fatal_with_hint(
+            "UNSUPPORTED_MODE",
+            format!("mode '{mode:?}' is not supported by this daemon version"),
+            "upgrade the CLI binary and restart the daemon",
         );
     }
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -954,10 +954,7 @@ async fn execute_extension(
             Ok(resp) => {
                 let result = &resp["result"];
                 let tab_id = result["tabId"].as_i64().unwrap_or(0).to_string();
-                let tab_url = result["url"]
-                    .as_str()
-                    .unwrap_or(&final_url)
-                    .to_string();
+                let tab_url = result["url"].as_str().unwrap_or(&final_url).to_string();
                 let title = result["title"].as_str().unwrap_or("").to_string();
                 vec![(tab_id, tab_url, title)]
             }

--- a/packages/cli/src/browser/tab/close.rs
+++ b/packages/cli/src/browser/tab/close.rs
@@ -6,6 +6,7 @@ use crate::action_result::ActionResult;
 use crate::daemon::cdp_session::cdp_error_to_result;
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
+use crate::types::Mode;
 
 /// Close a tab
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -54,7 +55,7 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let (cdp, native_id);
+    let (cdp, native_id, mode);
 
     {
         let reg = registry.lock().await;
@@ -80,6 +81,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             }
         };
         native_id = tab.native_id.clone();
+        mode = entry.mode;
 
         cdp = match entry.cdp.clone() {
             Some(c) => c,
@@ -93,32 +95,47 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         };
     }
 
-    // Detach from the persistent CDP session before closing
-    let _ = cdp.detach(&native_id).await;
-
-    // Close via CDP Target.closeTarget (works for both local and cloud)
-    match cdp
-        .execute_browser("Target.closeTarget", json!({ "targetId": native_id }))
-        .await
-    {
-        Ok(resp) => {
-            // Check result.success boolean
-            let success = resp
-                .pointer("/result/success")
-                .and_then(|v| v.as_bool())
-                .unwrap_or(true);
-            if !success {
-                tracing::warn!(
-                    "Target.closeTarget returned success=false for {}",
-                    native_id
-                );
+    if mode == Mode::Extension {
+        // Extension mode: close tab via Extension.closeTab (which also detaches debugger).
+        if let Ok(tab_id) = native_id.parse::<i64>() {
+            match cdp
+                .execute_browser("Extension.closeTab", json!({ "tabId": tab_id }))
+                .await
+            {
+                Ok(_) => {}
+                Err(e) => {
+                    let msg = e.to_string();
+                    if !msg.contains("not found") && !msg.contains("No tab") {
+                        return cdp_error_to_result(e, "CDP_ERROR");
+                    }
+                }
             }
         }
-        Err(e) => {
-            // Idempotent: if target is already gone, treat as success
-            let msg = e.to_string();
-            if !msg.contains("not found") && !msg.contains("No target") {
-                return cdp_error_to_result(e, "CDP_ERROR");
+    } else {
+        // Local/Cloud mode: detach then close via CDP Target.closeTarget.
+        let _ = cdp.detach(&native_id).await;
+
+        match cdp
+            .execute_browser("Target.closeTarget", json!({ "targetId": native_id }))
+            .await
+        {
+            Ok(resp) => {
+                let success = resp
+                    .pointer("/result/success")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                if !success {
+                    tracing::warn!(
+                        "Target.closeTarget returned success=false for {}",
+                        native_id
+                    );
+                }
+            }
+            Err(e) => {
+                let msg = e.to_string();
+                if !msg.contains("not found") && !msg.contains("No target") {
+                    return cdp_error_to_result(e, "CDP_ERROR");
+                }
             }
         }
     }

--- a/packages/cli/src/browser/tab/close.rs
+++ b/packages/cli/src/browser/tab/close.rs
@@ -99,10 +99,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         // Extension mode: detach debugger. The extension doesn't own the
         // browser so we can't force-close user tabs — only release the
         // debugger attachment.
-        if let Err(e) = cdp
-            .execute_browser("Extension.detachTab", json!({}))
-            .await
-        {
+        if let Err(e) = cdp.execute_browser("Extension.detachTab", json!({})).await {
             tracing::warn!("extension: failed to detach tab: {e}");
         }
     } else {

--- a/packages/cli/src/browser/tab/close.rs
+++ b/packages/cli/src/browser/tab/close.rs
@@ -96,20 +96,14 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     }
 
     if mode == Mode::Extension {
-        // Extension mode: close tab via Extension.closeTab (which also detaches debugger).
-        if let Ok(tab_id) = native_id.parse::<i64>() {
-            match cdp
-                .execute_browser("Extension.closeTab", json!({ "tabId": tab_id }))
-                .await
-            {
-                Ok(_) => {}
-                Err(e) => {
-                    let msg = e.to_string();
-                    if !msg.contains("not found") && !msg.contains("No tab") {
-                        return cdp_error_to_result(e, "CDP_ERROR");
-                    }
-                }
-            }
+        // Extension mode: detach debugger. The extension doesn't own the
+        // browser so we can't force-close user tabs — only release the
+        // debugger attachment.
+        if let Err(e) = cdp
+            .execute_browser("Extension.detachTab", json!({}))
+            .await
+        {
+            tracing::warn!("extension: failed to detach tab: {e}");
         }
     } else {
         // Local/Cloud mode: detach then close via CDP Target.closeTarget.

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -1,0 +1,466 @@
+//! Extension bridge: WS relay between Chrome extension and daemon CdpSession.
+//!
+//! The bridge runs as a tokio task inside the daemon, listening on a fixed TCP
+//! port. Two types of clients connect:
+//!
+//! 1. **Extension** — Chrome extension connects with a hello handshake. Origin
+//!    is validated against known extension IDs. One extension connection at a time.
+//!
+//! 2. **CDP client** (daemon CdpSession) — connects for transparent CDP relay.
+//!    First message is inspected: if it contains `"type":"hello"` it's an
+//!    extension; otherwise it's treated as a CDP client and all messages are
+//!    relayed bidirectionally to the extension.
+//!
+//! The bridge is spawned from `run_daemon()`. If the port is already in use the
+//! daemon still starts — only extension mode is unavailable.
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::json;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{Mutex, mpsc};
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{error, info, warn};
+
+// ─── Constants ──────────────────────────────────────────────────────────
+
+/// Default bridge port. Must match the extension's hardcoded `ws://127.0.0.1:19222`.
+pub const BRIDGE_PORT: u16 = 19222;
+
+/// Protocol version for the hello handshake.
+const PROTOCOL_VERSION: &str = "0.2.0";
+
+/// Known Actionbook Chrome extension IDs.
+const EXTENSION_ID_CWS: &str = "bebchpafpemheedhcdabookaifcijmfo";
+const EXTENSION_ID_DEV: &str = "dpfioflkmnkklgjldmaggkodhlidkdcd";
+const EXTENSION_IDS: &[&str] = &[EXTENSION_ID_CWS, EXTENSION_ID_DEV];
+
+// ─── Shared State ───────────────────────────────────────────────────────
+
+/// Bridge state shared across connections.
+pub struct BridgeState {
+    /// Send commands TO the extension WebSocket.
+    extension_tx: Option<mpsc::UnboundedSender<String>>,
+    /// Send messages TO the CDP client (daemon CdpSession) WebSocket.
+    cdp_tx: Option<mpsc::UnboundedSender<String>>,
+    /// Monotonically increasing connection id to distinguish extension connections.
+    connection_id: u64,
+    /// Last activity timestamp.
+    last_activity: Instant,
+}
+
+impl BridgeState {
+    fn new() -> Self {
+        Self {
+            extension_tx: None,
+            cdp_tx: None,
+            connection_id: 0,
+            last_activity: Instant::now(),
+        }
+    }
+
+    fn touch(&mut self) {
+        self.last_activity = Instant::now();
+    }
+
+    /// Whether an extension is currently connected (channel is open).
+    pub fn is_extension_connected(&self) -> bool {
+        self.extension_tx
+            .as_ref()
+            .map(|tx| !tx.is_closed())
+            .unwrap_or(false)
+    }
+}
+
+pub type SharedBridgeState = Arc<Mutex<BridgeState>>;
+
+/// Create a new shared bridge state.
+pub fn new_bridge_state() -> SharedBridgeState {
+    Arc::new(Mutex::new(BridgeState::new()))
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────
+
+/// Spawn the bridge server as a background tokio task.
+///
+/// Returns the bridge state handle on success. Returns `None` if the port is
+/// already in use (daemon still starts, only extension mode is unavailable).
+pub async fn spawn_bridge() -> Option<SharedBridgeState> {
+    let addr = format!("127.0.0.1:{BRIDGE_PORT}");
+    let listener = match TcpListener::bind(&addr).await {
+        Ok(l) => {
+            info!("extension bridge listening on ws://{addr}");
+            l
+        }
+        Err(e) => {
+            warn!("extension bridge: failed to bind {addr}: {e} — extension mode unavailable");
+            return None;
+        }
+    };
+
+    let state = new_bridge_state();
+    let state_clone = state.clone();
+
+    tokio::spawn(async move {
+        accept_loop(listener, state_clone).await;
+    });
+
+    Some(state)
+}
+
+// ─── Accept Loop ────────────────────────────────────────────────────────
+
+async fn accept_loop(listener: TcpListener, state: SharedBridgeState) {
+    loop {
+        match listener.accept().await {
+            Ok((stream, peer)) => {
+                let peer_ip = peer.ip();
+                if !peer_ip.is_loopback() {
+                    warn!("bridge: rejected non-loopback connection from {peer}");
+                    continue;
+                }
+                let state = state.clone();
+                tokio::spawn(async move {
+                    handle_connection(stream, state).await;
+                });
+            }
+            Err(e) => {
+                error!("bridge: accept error: {e}");
+            }
+        }
+    }
+}
+
+// ─── Connection Handler ─────────────────────────────────────────────────
+
+async fn handle_connection(stream: TcpStream, state: SharedBridgeState) {
+    // Capture origin during WS upgrade for extension ID validation.
+    let captured_origin: Arc<std::sync::Mutex<Option<String>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let origin_capture = Arc::clone(&captured_origin);
+
+    let ws = match tokio_tungstenite::accept_hdr_async(
+        stream,
+        move |req: &tokio_tungstenite::tungstenite::http::Request<()>,
+              resp: tokio_tungstenite::tungstenite::http::Response<()>|
+              -> std::result::Result<
+            tokio_tungstenite::tungstenite::http::Response<()>,
+            tokio_tungstenite::tungstenite::http::Response<Option<String>>,
+        > {
+            let origin = req
+                .headers()
+                .get("origin")
+                .and_then(|v| v.to_str().ok())
+                .map(|s| s.to_lowercase());
+
+            if !is_origin_allowed(origin.as_deref()) {
+                let rejection = tokio_tungstenite::tungstenite::http::Response::builder()
+                    .status(StatusCode::FORBIDDEN)
+                    .body(Some("Forbidden origin".to_string()))
+                    .unwrap();
+                return Err(rejection);
+            }
+
+            *origin_capture.lock().unwrap() = origin;
+            Ok(resp)
+        },
+    )
+    .await
+    {
+        Ok(ws) => ws,
+        Err(_) => return, // TCP probe or failed handshake
+    };
+
+    let connection_origin = captured_origin.lock().unwrap().take();
+    let (write, mut read) = ws.split();
+
+    // Read first message to determine client role.
+    let first_msg = match tokio::time::timeout(std::time::Duration::from_secs(5), read.next()).await
+    {
+        Ok(Some(Ok(Message::Text(text)))) => text.to_string(),
+        _ => return,
+    };
+
+    let parsed: serde_json::Value = match serde_json::from_str(&first_msg) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let msg_type = parsed.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+    if msg_type == "hello" {
+        handle_extension(write, read, parsed, connection_origin, state).await;
+    } else {
+        // Not a hello → assume CDP client (daemon CdpSession).
+        handle_cdp_client(write, read, first_msg, state).await;
+    }
+}
+
+// ─── Extension Handler ──────────────────────────────────────────────────
+
+async fn handle_extension(
+    mut write: futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<TcpStream>,
+        Message,
+    >,
+    mut read: futures_util::stream::SplitStream<tokio_tungstenite::WebSocketStream<TcpStream>>,
+    hello: serde_json::Value,
+    origin: Option<String>,
+    state: SharedBridgeState,
+) {
+    let client_version = hello
+        .get("version")
+        .and_then(|v| v.as_str())
+        .unwrap_or("0.0.0");
+
+    // Validate protocol version (>= 0.2.0).
+    if !is_version_ok(client_version) {
+        let err = json!({
+            "type": "hello_error",
+            "error": "version_mismatch",
+            "message": format!("Minimum required: {PROTOCOL_VERSION}"),
+            "required_version": PROTOCOL_VERSION,
+        });
+        let _ = write.send(Message::Text(err.to_string().into())).await;
+        return;
+    }
+
+    // Validate extension origin.
+    let origin_ok = EXTENSION_IDS.iter().any(|id| {
+        let expected = format!("chrome-extension://{id}");
+        origin
+            .as_deref()
+            .map(|o| o.eq_ignore_ascii_case(&expected))
+            .unwrap_or(false)
+    });
+    if !origin_ok {
+        let err = json!({
+            "type": "hello_error",
+            "error": "invalid_origin",
+            "message": "Extension origin does not match any known Actionbook extension ID.",
+        });
+        let _ = write.send(Message::Text(err.to_string().into())).await;
+        return;
+    }
+
+    // Reject if another extension is already connected.
+    {
+        let s = state.lock().await;
+        if s.is_extension_connected() {
+            drop(s);
+            let err = json!({
+                "type": "replaced",
+                "message": "Another extension instance is already connected.",
+            });
+            let _ = write.send(Message::Text(err.to_string().into())).await;
+            return;
+        }
+    }
+
+    // Send hello_ack.
+    let ack = json!({ "type": "hello_ack", "version": PROTOCOL_VERSION });
+    if write
+        .send(Message::Text(ack.to_string().into()))
+        .await
+        .is_err()
+    {
+        return;
+    }
+
+    info!("bridge: extension connected");
+
+    // Create channel for sending commands TO this extension WS.
+    let (ext_tx, mut ext_rx) = mpsc::unbounded_channel::<String>();
+
+    let my_conn_id = {
+        let mut s = state.lock().await;
+        s.connection_id += 1;
+        s.extension_tx = Some(ext_tx);
+        s.touch();
+        s.connection_id
+    };
+
+    // Writer task: channel → extension WS.
+    let write = Arc::new(Mutex::new(write));
+    let write_clone = write.clone();
+    let write_handle = tokio::spawn(async move {
+        while let Some(msg) = ext_rx.recv().await {
+            let mut w = write_clone.lock().await;
+            if w.send(Message::Text(msg.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Reader: extension WS → forward to CDP client (if connected).
+    while let Some(frame) = read.next().await {
+        match frame {
+            Ok(Message::Text(text)) => {
+                let text_str = text.to_string();
+                let mut s = state.lock().await;
+                s.touch();
+                if let Some(ref cdp_tx) = s.cdp_tx {
+                    if cdp_tx.send(text_str).is_err() {
+                        warn!("bridge: failed to forward extension message to CDP client");
+                    }
+                }
+                // If no CDP client, message is dropped (events before session start).
+            }
+            Ok(Message::Close(_)) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    info!("bridge: extension disconnected");
+
+    // Cleanup: only clear if we own the current connection.
+    {
+        let mut s = state.lock().await;
+        if s.connection_id == my_conn_id {
+            s.extension_tx = None;
+        }
+    }
+
+    write_handle.abort();
+}
+
+// ─── CDP Client Handler (daemon CdpSession) ─────────────────────────────
+
+async fn handle_cdp_client(
+    write: futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<TcpStream>,
+        Message,
+    >,
+    mut read: futures_util::stream::SplitStream<tokio_tungstenite::WebSocketStream<TcpStream>>,
+    first_message: String,
+    state: SharedBridgeState,
+) {
+    // Create channel for sending messages TO this CDP client WS.
+    let (cdp_tx, mut cdp_rx) = mpsc::unbounded_channel::<String>();
+
+    {
+        let mut s = state.lock().await;
+        s.cdp_tx = Some(cdp_tx);
+        s.touch();
+    }
+
+    // Forward the first CDP message (already read) to extension.
+    {
+        let mut s = state.lock().await;
+        s.touch();
+        if let Some(ref ext_tx) = s.extension_tx {
+            if ext_tx.send(first_message).is_err() {
+                warn!("bridge: failed to forward first CDP message to extension");
+            }
+        }
+    }
+
+    // Writer task: channel → CDP client WS.
+    let write = Arc::new(Mutex::new(write));
+    let write_clone = write.clone();
+    let write_handle = tokio::spawn(async move {
+        while let Some(msg) = cdp_rx.recv().await {
+            let mut w = write_clone.lock().await;
+            if w.send(Message::Text(msg.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Reader: CDP client WS → forward to extension.
+    while let Some(frame) = read.next().await {
+        match frame {
+            Ok(Message::Text(text)) => {
+                let text_str = text.to_string();
+                let mut s = state.lock().await;
+                s.touch();
+                if let Some(ref ext_tx) = s.extension_tx {
+                    if ext_tx.send(text_str).is_err() {
+                        warn!("bridge: failed to forward CDP message to extension");
+                    }
+                }
+            }
+            Ok(Message::Close(_)) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+
+    // Cleanup CDP client channel.
+    {
+        let mut s = state.lock().await;
+        s.cdp_tx = None;
+    }
+
+    write_handle.abort();
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+
+/// Validate WS origin: allow chrome-extension:// and loopback HTTP.
+fn is_origin_allowed(origin: Option<&str>) -> bool {
+    let Some(o) = origin else { return true };
+    let lower = o.to_lowercase();
+    if lower.starts_with("chrome-extension://") {
+        return true;
+    }
+    if lower.starts_with("http://") {
+        let host = lower
+            .strip_prefix("http://")
+            .unwrap_or("")
+            .trim_end_matches('/');
+        let host_no_port = host.split(':').next().unwrap_or("");
+        return matches!(host_no_port, "127.0.0.1" | "localhost" | "[::1]");
+    }
+    false
+}
+
+/// Check protocol version >= 0.2.0 (simple major.minor comparison).
+fn is_version_ok(version: &str) -> bool {
+    let parts: Vec<u32> = version.split('.').filter_map(|p| p.parse().ok()).collect();
+    if parts.len() < 2 {
+        return false;
+    }
+    // 0.2.0 minimum: major > 0, or major == 0 && minor >= 2
+    parts[0] > 0 || (parts[0] == 0 && parts[1] >= 2)
+}
+
+// ─── Unit Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_origin_allowed() {
+        assert!(is_origin_allowed(None));
+        assert!(is_origin_allowed(Some(
+            "chrome-extension://bebchpafpemheedhcdabookaifcijmfo"
+        )));
+        assert!(is_origin_allowed(Some("http://127.0.0.1")));
+        assert!(is_origin_allowed(Some("http://localhost")));
+        assert!(is_origin_allowed(Some("http://127.0.0.1:3000")));
+        assert!(!is_origin_allowed(Some("https://evil.com")));
+        assert!(!is_origin_allowed(Some("http://192.168.1.1")));
+    }
+
+    #[test]
+    fn test_is_version_ok() {
+        assert!(is_version_ok("0.2.0"));
+        assert!(is_version_ok("0.3.0"));
+        assert!(is_version_ok("1.0.0"));
+        assert!(!is_version_ok("0.1.0"));
+        assert!(!is_version_ok("0.0.1"));
+        assert!(!is_version_ok("invalid"));
+    }
+
+    #[test]
+    fn test_bridge_state_extension_not_connected_by_default() {
+        let state = BridgeState::new();
+        assert!(!state.is_extension_connected());
+    }
+}

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -21,8 +21,8 @@ use futures_util::{SinkExt, StreamExt};
 use serde_json::json;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{Mutex, mpsc};
-use tokio_tungstenite::tungstenite::http::StatusCode;
 use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::http::StatusCode;
 use tracing::{error, info, warn};
 
 // ─── Constants ──────────────────────────────────────────────────────────
@@ -302,10 +302,10 @@ async fn handle_extension(
                 let text_str = text.to_string();
                 let mut s = state.lock().await;
                 s.touch();
-                if let Some(ref cdp_tx) = s.cdp_tx {
-                    if cdp_tx.send(text_str).is_err() {
-                        warn!("bridge: failed to forward extension message to CDP client");
-                    }
+                if let Some(ref cdp_tx) = s.cdp_tx
+                    && cdp_tx.send(text_str).is_err()
+                {
+                    warn!("bridge: failed to forward extension message to CDP client");
                 }
                 // If no CDP client, message is dropped (events before session start).
             }
@@ -331,14 +331,22 @@ async fn handle_extension(
 // ─── CDP Client Handler (daemon CdpSession) ─────────────────────────────
 
 async fn handle_cdp_client(
-    write: futures_util::stream::SplitSink<
-        tokio_tungstenite::WebSocketStream<TcpStream>,
-        Message,
-    >,
+    write: futures_util::stream::SplitSink<tokio_tungstenite::WebSocketStream<TcpStream>, Message>,
     mut read: futures_util::stream::SplitStream<tokio_tungstenite::WebSocketStream<TcpStream>>,
     first_message: String,
     state: SharedBridgeState,
 ) {
+    // Reject if another CDP client is already connected. The bridge is a 1:1
+    // relay — allowing a second client would silently steal extension responses
+    // from the first session, causing it to stall/timeout.
+    {
+        let s = state.lock().await;
+        if s.cdp_tx.as_ref().is_some_and(|tx| !tx.is_closed()) {
+            warn!("bridge: rejected CDP client — another session is already connected");
+            return;
+        }
+    }
+
     // Create channel for sending messages TO this CDP client WS.
     let (cdp_tx, mut cdp_rx) = mpsc::unbounded_channel::<String>();
 
@@ -352,10 +360,10 @@ async fn handle_cdp_client(
     {
         let mut s = state.lock().await;
         s.touch();
-        if let Some(ref ext_tx) = s.extension_tx {
-            if ext_tx.send(first_message).is_err() {
-                warn!("bridge: failed to forward first CDP message to extension");
-            }
+        if let Some(ref ext_tx) = s.extension_tx
+            && ext_tx.send(first_message).is_err()
+        {
+            warn!("bridge: failed to forward first CDP message to extension");
         }
     }
 
@@ -378,10 +386,10 @@ async fn handle_cdp_client(
                 let text_str = text.to_string();
                 let mut s = state.lock().await;
                 s.touch();
-                if let Some(ref ext_tx) = s.extension_tx {
-                    if ext_tx.send(text_str).is_err() {
-                        warn!("bridge: failed to forward CDP message to extension");
-                    }
+                if let Some(ref ext_tx) = s.extension_tx
+                    && ext_tx.send(text_str).is_err()
+                {
+                    warn!("bridge: failed to forward CDP message to extension");
                 }
             }
             Ok(Message::Close(_)) => break,

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -144,6 +144,7 @@ async fn handle_connection(stream: TcpStream, state: SharedBridgeState) {
 
     let ws = match tokio_tungstenite::accept_hdr_async(
         stream,
+        #[allow(clippy::result_large_err)] // accept_hdr_async requires this exact signature
         move |req: &tokio_tungstenite::tungstenite::http::Request<()>,
               resp: tokio_tungstenite::tungstenite::http::Response<()>|
               -> std::result::Result<

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -260,6 +260,21 @@ impl CdpSession {
         // (real users have 1366x768, 2560x1440, 3440x1440, etc.).
     }
 
+    /// Register a tab for extension mode (no CDP flat-session handshake needed).
+    ///
+    /// The extension bridge relays CDP commands to a single attached tab and
+    /// ignores the `sessionId` field entirely.  We insert an empty-string
+    /// session ID so that `execute_on_tab` can look it up and the resulting
+    /// WS message simply omits `sessionId` (because `execute()` only adds it
+    /// when `Some`).  Actually we store `""` but `execute_on_tab` passes
+    /// `Some("")` which adds `"sessionId":""` — the bridge ignores it.
+    pub async fn register_extension_tab(&self, native_id: &str) {
+        self.tab_sessions
+            .lock()
+            .await
+            .insert(native_id.to_string(), String::new());
+    }
+
     /// Detach from a CDP target (tab).
     pub async fn detach(&self, target_id: &str) -> Result<(), CliError> {
         let session_id = self

--- a/packages/cli/src/daemon/mod.rs
+++ b/packages/cli/src/daemon/mod.rs
@@ -1,3 +1,4 @@
+pub mod bridge;
 pub mod browser;
 pub mod cdp;
 pub mod cdp_session;

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -6,6 +6,7 @@ use tokio::sync::Mutex;
 
 use crate::action_result::ActionResult;
 use crate::browser::observation::snapshot_transform::RefCache;
+use crate::daemon::bridge::SharedBridgeState;
 use crate::daemon::cdp_session::CdpSession;
 use crate::error::CliError;
 use crate::types::{Mode, SessionId, TabId};
@@ -150,6 +151,8 @@ pub struct SessionRegistry {
     ref_caches: HashMap<String, RefCache>,
     /// Last known cursor position per tab. Key: "session_id\0tab_id"
     cursor_positions: HashMap<String, (f64, f64)>,
+    /// Extension bridge state (set by daemon on startup, `None` if bridge unavailable).
+    bridge_state: Option<SharedBridgeState>,
 }
 
 impl Default for SessionRegistry {
@@ -164,7 +167,18 @@ impl SessionRegistry {
             sessions: HashMap::new(),
             ref_caches: HashMap::new(),
             cursor_positions: HashMap::new(),
+            bridge_state: None,
         }
+    }
+
+    /// Set the extension bridge state handle.
+    pub fn set_bridge_state(&mut self, state: SharedBridgeState) {
+        self.bridge_state = Some(state);
+    }
+
+    /// Get a reference to the bridge state (if bridge is running).
+    pub fn bridge_state(&self) -> Option<&SharedBridgeState> {
+        self.bridge_state.as_ref()
     }
 
     fn has_active_session_id(&self, session_id: &str) -> bool {

--- a/packages/cli/src/daemon/server.rs
+++ b/packages/cli/src/daemon/server.rs
@@ -252,6 +252,11 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     let registry = new_shared_registry();
 
+    // Spawn extension bridge (non-fatal: daemon works without it).
+    if let Some(bridge_state) = super::bridge::spawn_bridge().await {
+        registry.lock().await.set_bridge_state(bridge_state);
+    }
+
     // Handle SIGINT, SIGTERM, and SIGHUP (terminal close).
     #[cfg(unix)]
     let mut sigterm = tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())?;

--- a/packages/cli/src/setup/browser_cfg.rs
+++ b/packages/cli/src/setup/browser_cfg.rs
@@ -30,8 +30,28 @@ pub(crate) async fn configure_browser(
     match mode {
         Mode::Local => configure_local(json, env, config),
         Mode::Cloud => configure_cloud(json, config),
-        Mode::Extension => Err(unsupported_setup_mode_error("extension")),
+        Mode::Extension => configure_extension(json, config),
     }
+}
+
+fn configure_extension(json: bool, config: &mut ConfigFile) -> Result<(), CliError> {
+    config.browser.executable_path = None;
+    config.browser.headless = false;
+    config.browser.cdp_endpoint = None;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::json!({
+                "step": "browser",
+                "mode": "extension",
+            })
+        );
+    } else {
+        println!("  - Browser mode: extension");
+    }
+
+    Ok(())
 }
 
 fn configure_cloud(json: bool, config: &mut ConfigFile) -> Result<(), CliError> {
@@ -61,25 +81,20 @@ fn cloud_display_label(config: &ConfigFile) -> String {
     }
 }
 
-fn unsupported_setup_mode_error(mode: &str) -> CliError {
-    CliError::InvalidArgument(format!(
-        "setup does not currently allow browser.mode='{mode}'; use 'local' or 'cloud'"
-    ))
-}
-
-fn print_extension_coming_soon_hint() {
-    println!("  - extension  Coming soon");
-}
-
 fn browser_mode_options() -> Vec<String> {
     vec![
         "local      Launch a dedicated browser".to_string(),
         "cloud      Connect to a remote CDP browser".to_string(),
+        "extension  Connect via Chrome extension".to_string(),
     ]
 }
 
 fn browser_mode_default(current_mode: Mode) -> usize {
-    if current_mode == Mode::Cloud { 1 } else { 0 }
+    match current_mode {
+        Mode::Cloud => 1,
+        Mode::Extension => 2,
+        _ => 0,
+    }
 }
 
 fn apply_existing_browser_mode(
@@ -126,7 +141,20 @@ fn apply_existing_browser_mode(
             }
         }
         Mode::Extension => {
-            return Err(unsupported_setup_mode_error("extension"));
+            config.browser.executable_path = None;
+            config.browser.headless = false;
+            config.browser.cdp_endpoint = None;
+            if json {
+                println!(
+                    "{}",
+                    serde_json::json!({
+                        "step": "browser",
+                        "mode": "extension",
+                    })
+                );
+            } else {
+                println!("  - Browser mode: extension");
+            }
         }
     }
 
@@ -135,7 +163,6 @@ fn apply_existing_browser_mode(
 
 /// Interactive prompt to select browser mode.
 fn select_browser_mode(current_mode: Mode) -> Result<Mode, CliError> {
-    print_extension_coming_soon_hint();
     let options = browser_mode_options();
 
     let default = browser_mode_default(current_mode);
@@ -146,10 +173,11 @@ fn select_browser_mode(current_mode: Mode) -> Result<Mode, CliError> {
         .interact()
         .map_err(|e| CliError::Internal(format!("Prompt failed: {e}")))?;
 
-    Ok(if selection == 0 {
-        Mode::Local
-    } else {
-        Mode::Cloud
+    Ok(match selection {
+        0 => Mode::Local,
+        1 => Mode::Cloud,
+        2 => Mode::Extension,
+        _ => Mode::Local,
     })
 }
 
@@ -271,7 +299,9 @@ fn apply_browser_mode(
             config.browser.headless = false;
         }
         Mode::Extension => {
-            return Err(unsupported_setup_mode_error("extension"));
+            config.browser.executable_path = None;
+            config.browser.headless = false;
+            config.browser.cdp_endpoint = None;
         }
     }
 
@@ -290,7 +320,7 @@ fn apply_browser_mode(
         let mode_label = match mode {
             Mode::Local => "local".to_string(),
             Mode::Cloud => cloud_display_label(config),
-            Mode::Extension => unreachable!("extension is rejected for setup"),
+            Mode::Extension => "extension".to_string(),
         };
         println!("  - Browser mode: {mode_label}");
     }
@@ -436,34 +466,32 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_existing_extension_mode_returns_hint() {
+    fn test_apply_existing_extension_mode_succeeds() {
         let env = make_env_with_browsers(vec![]);
         let mut config = ConfigFile::default();
         config.browser.mode = Mode::Extension;
 
-        let err = apply_existing_browser_mode(false, &env, &mut config)
-            .expect_err("extension should fail");
-
-        assert_eq!(err.error_code(), "INVALID_ARGUMENT");
-        assert_eq!(
-            err.to_string(),
-            "invalid argument: setup does not currently allow browser.mode='extension'; use 'local' or 'cloud'"
-        );
+        let result = apply_existing_browser_mode(false, &env, &mut config);
+        assert!(result.is_ok());
+        assert_eq!(config.browser.mode, Mode::Extension);
+        assert!(config.browser.executable_path.is_none());
+        assert!(config.browser.cdp_endpoint.is_none());
     }
 
     #[test]
-    fn test_browser_mode_options_include_local_and_cloud_only() {
+    fn test_browser_mode_options_include_all_modes() {
         let options = browser_mode_options();
-        assert_eq!(options.len(), 2);
+        assert_eq!(options.len(), 3);
         assert!(options[0].starts_with("local"));
         assert!(options[1].starts_with("cloud"));
+        assert!(options[2].starts_with("extension"));
     }
 
     #[test]
-    fn test_browser_mode_default_prefers_cloud_when_configured() {
+    fn test_browser_mode_default_prefers_configured() {
         assert_eq!(browser_mode_default(Mode::Cloud), 1);
         assert_eq!(browser_mode_default(Mode::Local), 0);
-        assert_eq!(browser_mode_default(Mode::Extension), 0);
+        assert_eq!(browser_mode_default(Mode::Extension), 2);
     }
 
     #[test]

--- a/packages/cli/src/setup/mod.rs
+++ b/packages/cli/src/setup/mod.rs
@@ -24,7 +24,7 @@ pub struct Cmd {
     #[arg(long)]
     pub api_key: Option<String>,
 
-    /// Browser configuration (local|cloud)
+    /// Browser configuration (local|cloud|extension)
     #[arg(long)]
     pub browser: Option<String>,
 
@@ -111,7 +111,7 @@ pub async fn execute(cmd: &Cmd, json: bool) -> Result<(), CliError> {
                 .as_deref()
                 .map(|endpoint| format!("cloud ({endpoint})"))
                 .unwrap_or_else(|| "cloud (endpoint not configured)".to_string()),
-            Mode::Extension => "coming soon".to_string(),
+            Mode::Extension => "extension".to_string(),
         };
 
         println!("  {bar}  Configuration summary:");
@@ -234,8 +234,9 @@ fn parse_browser_flag(value: Option<&str>) -> Result<Option<Mode>, CliError> {
     match value.trim().to_ascii_lowercase().as_str() {
         "local" => Ok(Some(Mode::Local)),
         "cloud" => Ok(Some(Mode::Cloud)),
+        "extension" => Ok(Some(Mode::Extension)),
         other => Err(CliError::InvalidArgument(format!(
-            "invalid --browser value '{other}': expected local|cloud"
+            "invalid --browser value '{other}': expected local|cloud|extension"
         ))),
     }
 }
@@ -287,7 +288,7 @@ fn print_completion(json: bool, config: &ConfigFile) {
                         .cdp_endpoint
                         .as_deref()
                         .unwrap_or("endpoint not configured"),
-                    Mode::Extension => "coming soon",
+                    Mode::Extension => "extension (bridge)",
                 },
                 "headless": config.browser.headless,
             })
@@ -327,7 +328,7 @@ fn print_completion(json: bool, config: &ConfigFile) {
             .as_deref()
             .map(|endpoint| format!("cloud ({endpoint})"))
             .unwrap_or_else(|| "cloud (endpoint not configured)".to_string()),
-        Mode::Extension => "coming soon".to_string(),
+        Mode::Extension => "extension".to_string(),
     };
 
     println!();
@@ -406,9 +407,11 @@ mod tests {
     }
 
     #[test]
-    fn parse_browser_flag_rejects_extension() {
-        let err = parse_browser_flag(Some("extension")).expect_err("should reject");
-        assert_eq!(err.error_code(), "INVALID_ARGUMENT");
+    fn parse_browser_flag_accepts_extension() {
+        assert_eq!(
+            parse_browser_flag(Some("extension")).unwrap(),
+            Some(Mode::Extension)
+        );
     }
 
     #[test]

--- a/packages/cli/tests/setup_cli.rs
+++ b/packages/cli/tests/setup_cli.rs
@@ -257,7 +257,7 @@ fn setup_isolated_browser_value_exits_non_zero() {
 }
 
 #[test]
-fn setup_extension_browser_value_exits_non_zero() {
+fn setup_extension_browser_value_succeeds() {
     let tmp = tempfile::tempdir().expect("tmpdir");
     let home = tmp.path().join("actionbook-home");
 
@@ -275,14 +275,15 @@ fn setup_extension_browser_value_exits_non_zero() {
         .expect("run setup");
 
     assert!(
-        !output.status.success(),
-        "expected extension --browser to fail\nstdout:\n{}\nstderr:\n{}",
+        output.status.success(),
+        "expected extension --browser to succeed\nstdout:\n{}\nstderr:\n{}",
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        String::from_utf8_lossy(&output.stderr).contains("invalid --browser value 'extension'"),
-        "stderr should explain that extension is no longer a valid setup browser value"
+        stdout.contains("\"mode\":\"extension\""),
+        "stdout should contain extension mode"
     );
 }
 


### PR DESCRIPTION
## Summary

- Restore Extension browser mode via a WebSocket bridge relay between the Chrome extension and the CLI daemon
- Extension bridge listens on `ws://127.0.0.1:19222`, authenticates via origin + protocol version handshake, and transparently relays CDP messages
- Use Extension API (`Extension.listTabs`, `Extension.attachTab`, `Extension.createTab`) for tab discovery instead of CDP `Target.getTargets`
- Fix `build.rs` to track the actual git ref file (not just `.git/HEAD`) so `BUILD_VERSION` stays accurate in worktrees — prevents stale daemon version-mismatch detection
- Add Local mode guard in `start.rs` to reject non-Local modes explicitly instead of silently launching a local Chrome

## Key Changes

| Commit | Description |
|--------|-------------|
| `5b98b9f2` | Core bridge relay + Extension mode in `start.rs` |
| `63a2439e` | Extension API tab discovery |
| `f8ae70e0` | Close tabs and detach debugger on session close |
| `a78bb795` | Revert extension JS change, use `detachTab` for close |
| `d6caf8fe` | Read default browser mode from config instead of hardcoding Local |
| `33ca0ec2` | Fix `build.rs` worktree ref tracking + Local mode guard |

## Test plan

- [ ] `actionbook browser start` without `--mode` connects via extension when `config.toml` has `mode = "extension"`
- [ ] Extension bridge starts on daemon boot (`bridge listening on ws://127.0.0.1:19222` in daemon log)
- [ ] `browser close` detaches debugger without closing the user's Chrome tabs
- [ ] New terminal sessions pick up correct daemon version (no stale `BUILD_VERSION`)
- [ ] Local mode still works when `mode = "local"` in config
- [ ] Cloud mode still works with `--cdp-endpoint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)