### PR TITLE
fix(browser): await Promise in eval command

### DIFF
--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -81,7 +81,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         .execute_on_tab(
             &target_id,
             "Runtime.evaluate",
-            json!({ "expression": cmd.expression, "returnByValue": true }),
+            json!({ "expression": cmd.expression, "returnByValue": true, "awaitPromise": true }),
         )
         .await
     {

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -4994,6 +4994,55 @@ fn eval_json_number() {
 }
 
 #[test]
+fn eval_json_promise() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    // Synchronous-resolve Promise
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "Promise.resolve(42)",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "eval json promise resolve");
+    let v = parse_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["value"], serde_json::json!(42));
+    assert_eq!(v["data"]["type"], "number");
+
+    // Async Promise with delay
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "new Promise(r => setTimeout(() => r('done'), 50))",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "eval json promise delayed");
+    let v = parse_json(&out);
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["value"], serde_json::json!("done"));
+    assert_eq!(v["data"]["type"], "string");
+
+    close_session(&sid);
+}
+
+#[test]
 fn eval_text() {
     if skip() {
         return;


### PR DESCRIPTION
## Summary
- Add `awaitPromise: true` to the `Runtime.evaluate` CDP call in the `eval` command
- Without this flag, evaluating a Promise expression returns the Promise object itself, which serializes to `{}` (no enumerable properties)
- With `awaitPromise: true`, CDP waits for the Promise to resolve and returns the actual value — matching Playwright's behavior

Cherry-picked from #490 (which has merge conflicts due to stale click.rs/output.rs changes already in main via #475).

## Test plan
- [ ] `actionbook browser eval "Promise.resolve(42)" --session s1 --tab t1` → returns `42` instead of `{}`
- [ ] `actionbook browser eval "document.title" --session s1 --tab t1` → synchronous expressions still work
- [ ] `actionbook browser eval "new Promise(r => setTimeout(() => r('done'), 100))" --session s1 --tab t1` → async resolution works