### PR TITLE
feat(browser): add network requests commands (ACT-882)

### DIFF
--- a/packages/cli/src/action.rs
+++ b/packages/cli/src/action.rs
@@ -46,6 +46,8 @@ pub enum Action {
     Pdf(observation::pdf::Cmd),
     LogsConsole(observation::logs_console::Cmd),
     LogsErrors(observation::logs_errors::Cmd),
+    NetworkRequests(observation::network_requests::Cmd),
+    NetworkRequestDetail(observation::network_request_detail::Cmd),
 
     // ── Cookies ────────────────────────────────────────────────
     CookiesList(cookies::list::Cmd),
@@ -141,6 +143,8 @@ impl Action {
             Action::Pdf(c) => st!(c),
             Action::LogsConsole(c) => st!(c),
             Action::LogsErrors(c) => st!(c),
+            Action::NetworkRequests(c) => st!(c),
+            Action::NetworkRequestDetail(c) => st!(c),
 
             // Cookies (session-level, no tab)
             Action::CookiesList(c) => s_only!(c),
@@ -216,6 +220,8 @@ impl Action {
             Action::Pdf(_) => observation::pdf::COMMAND_NAME,
             Action::LogsConsole(_) => observation::logs_console::COMMAND_NAME,
             Action::LogsErrors(_) => observation::logs_errors::COMMAND_NAME,
+            Action::NetworkRequests(_) => observation::network_requests::COMMAND_NAME,
+            Action::NetworkRequestDetail(_) => observation::network_request_detail::COMMAND_NAME,
             Action::CookiesList(_) => cookies::list::COMMAND_NAME,
             Action::CookiesGet(_) => cookies::get::COMMAND_NAME,
             Action::CookiesSet(_) => cookies::set::COMMAND_NAME,

--- a/packages/cli/src/browser/observation/mod.rs
+++ b/packages/cli/src/browser/observation/mod.rs
@@ -7,6 +7,8 @@ pub mod html;
 pub mod inspect_point;
 pub mod logs_console;
 pub mod logs_errors;
+pub mod network_request_detail;
+pub mod network_requests;
 pub mod pdf;
 pub mod query;
 pub mod screenshot;

--- a/packages/cli/src/browser/observation/network_request_detail.rs
+++ b/packages/cli/src/browser/observation/network_request_detail.rs
@@ -1,0 +1,152 @@
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::action_result::ActionResult;
+use crate::browser::navigation;
+use crate::daemon::cdp_session::get_cdp_and_target;
+use crate::daemon::registry::SharedRegistry;
+use crate::output::ResponseContext;
+
+/// Get detail for a single network request, including response body.
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[command(after_help = "\
+Examples:
+  actionbook browser network request 1234.1 --session s1 --tab t1
+
+Returns full request detail including response body fetched via Network.getResponseBody.
+Use `browser network requests` to list request IDs first.")]
+pub struct Cmd {
+    /// Request ID (from `browser network requests`)
+    pub request_id: String,
+    /// Session ID
+    #[arg(long)]
+    #[serde(rename = "session_id")]
+    pub session: String,
+    /// Tab ID
+    #[arg(long)]
+    #[serde(rename = "tab_id")]
+    pub tab: String,
+}
+
+pub const COMMAND_NAME: &str = "browser network request";
+
+pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
+    if let ActionResult::Fatal { code, .. } = result
+        && code == "SESSION_NOT_FOUND"
+    {
+        return None;
+    }
+    let tab_id = if let ActionResult::Fatal { code, .. } = result
+        && code == "TAB_NOT_FOUND"
+    {
+        None
+    } else {
+        Some(cmd.tab.clone())
+    };
+    let (url, title) = match result {
+        ActionResult::Ok { data } => (
+            data.get("__ctx_url")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            data.get("__ctx_title")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        ),
+        _ => (None, None),
+    };
+    Some(ResponseContext {
+        session_id: cmd.session.clone(),
+        tab_id,
+        window_id: None,
+        url,
+        title,
+    })
+}
+
+pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    let (cdp, target_id) = match get_cdp_and_target(registry, &cmd.session, &cmd.tab).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let cdp_session_id = match cdp.get_cdp_session_id(&target_id).await {
+        Some(sid) => sid,
+        None => {
+            return ActionResult::fatal(
+                "INTERNAL_ERROR",
+                format!("no CDP session for target '{target_id}'"),
+            );
+        }
+    };
+
+    let req = match cdp
+        .network_request_detail(&cdp_session_id, &cmd.request_id)
+        .await
+    {
+        Some(r) => r,
+        None => {
+            return ActionResult::fatal(
+                "REQUEST_NOT_FOUND",
+                format!("no tracked request with ID '{}'", cmd.request_id),
+            );
+        }
+    };
+
+    // Fetch response body on demand via Network.getResponseBody.
+    let (response_body, response_body_base64, body_error): (Option<String>, bool, Option<String>) =
+        match cdp
+            .execute_on_tab(
+                &target_id,
+                "Network.getResponseBody",
+                json!({ "requestId": cmd.request_id }),
+            )
+            .await
+        {
+            Ok(resp) => {
+                let body = resp
+                    .pointer("/result/body")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let base64 = resp
+                    .pointer("/result/base64Encoded")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                (body, base64, None)
+            }
+            Err(e) => (None, false, Some(e.to_string())),
+        };
+
+    let url = navigation::get_tab_url(&cdp, &target_id).await;
+    let title = navigation::get_tab_title(&cdp, &target_id).await;
+
+    let mut request_json = json!({
+        "request_id": req.request_id,
+        "url": req.url,
+        "method": req.method,
+        "resource_type": req.resource_type,
+        "timestamp": req.timestamp_ms,
+        "status": req.status,
+        "mime_type": req.mime_type,
+        "request_headers": req.request_headers,
+        "response_headers": req.response_headers,
+        "response_body": Value::Null,
+        "response_body_base64": response_body_base64,
+    });
+
+    if let Some(body) = response_body {
+        request_json["response_body"] = Value::String(body);
+    }
+    if let Some(err) = body_error {
+        request_json["body_error"] = Value::String(err);
+    }
+    if let Some(post_data) = req.post_data {
+        request_json["post_data"] = Value::String(post_data);
+    }
+
+    ActionResult::ok(json!({
+        "request": request_json,
+        "__ctx_url": url,
+        "__ctx_title": title,
+    }))
+}

--- a/packages/cli/src/browser/observation/network_requests.rs
+++ b/packages/cli/src/browser/observation/network_requests.rs
@@ -1,0 +1,155 @@
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::action_result::ActionResult;
+use crate::browser::navigation;
+use crate::daemon::cdp_session::{NetworkRequestsFilter, get_cdp_and_target};
+use crate::daemon::registry::SharedRegistry;
+use crate::output::ResponseContext;
+
+/// List tracked network requests for a tab.
+#[derive(Args, Debug, Clone, Serialize, Deserialize)]
+#[command(after_help = "\
+Examples:
+  actionbook browser network requests --session s1 --tab t1
+  actionbook browser network requests --filter /api/ --session s1 --tab t1
+  actionbook browser network requests --type xhr,fetch --session s1 --tab t1
+  actionbook browser network requests --method POST --session s1 --tab t1
+  actionbook browser network requests --status 2xx --session s1 --tab t1
+  actionbook browser network requests --clear --session s1 --tab t1
+
+Lists all network requests captured since the tab was attached (or since last --clear).
+Requests are captured automatically — no setup required.
+Use --filter for URL substring, --type for resource type (comma-separated),
+--method for HTTP method, --status for status code (200, 2xx, 400-499).
+Use --clear to reset the request buffer and return {cleared: true}.")]
+pub struct Cmd {
+    /// Session ID
+    #[arg(long)]
+    #[serde(rename = "session_id")]
+    pub session: String,
+    /// Tab ID
+    #[arg(long)]
+    #[serde(rename = "tab_id")]
+    pub tab: String,
+    /// Filter by URL substring
+    #[arg(long)]
+    pub filter: Option<String>,
+    /// Filter by resource type (comma-separated, e.g. xhr,fetch)
+    #[arg(long = "type")]
+    #[serde(rename = "resource_type")]
+    pub resource_type: Option<String>,
+    /// Filter by HTTP method (case-insensitive, e.g. POST)
+    #[arg(long)]
+    pub method: Option<String>,
+    /// Filter by status code: exact (200), class (2xx), or range (400-499)
+    #[arg(long)]
+    pub status: Option<String>,
+    /// Clear request buffer after retrieval (returns {cleared: true, count: N})
+    #[arg(long)]
+    pub clear: bool,
+}
+
+pub const COMMAND_NAME: &str = "browser network requests";
+
+pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
+    if let ActionResult::Fatal { code, .. } = result
+        && code == "SESSION_NOT_FOUND"
+    {
+        return None;
+    }
+    let tab_id = if let ActionResult::Fatal { code, .. } = result
+        && code == "TAB_NOT_FOUND"
+    {
+        None
+    } else {
+        Some(cmd.tab.clone())
+    };
+    let (url, title) = match result {
+        ActionResult::Ok { data } => (
+            data.get("__ctx_url")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            data.get("__ctx_title")
+                .and_then(|v| v.as_str())
+                .map(String::from),
+        ),
+        _ => (None, None),
+    };
+    Some(ResponseContext {
+        session_id: cmd.session.clone(),
+        tab_id,
+        window_id: None,
+        url,
+        title,
+    })
+}
+
+pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    let (cdp, target_id) = match get_cdp_and_target(registry, &cmd.session, &cmd.tab).await {
+        Ok(v) => v,
+        Err(e) => return e,
+    };
+
+    let cdp_session_id = match cdp.get_cdp_session_id(&target_id).await {
+        Some(sid) => sid,
+        None => {
+            return ActionResult::fatal(
+                "INTERNAL_ERROR",
+                format!("no CDP session for target '{target_id}'"),
+            );
+        }
+    };
+
+    if cmd.clear {
+        let count = cdp.clear_network_requests(&cdp_session_id).await;
+        let url = navigation::get_tab_url(&cdp, &target_id).await;
+        let title = navigation::get_tab_title(&cdp, &target_id).await;
+        return ActionResult::ok(json!({
+            "cleared": true,
+            "count": count,
+            "__ctx_url": url,
+            "__ctx_title": title,
+        }));
+    }
+
+    let filter = NetworkRequestsFilter {
+        url_substring: cmd.filter.clone(),
+        resource_types: cmd.resource_type.clone(),
+        method: cmd.method.clone(),
+        status: cmd.status.clone(),
+    };
+
+    let total = cdp.network_requests_total(&cdp_session_id).await;
+    let matched = cdp.network_requests(&cdp_session_id, &filter).await;
+    let filtered = matched.len();
+
+    let requests: Vec<Value> = matched
+        .into_iter()
+        .map(|req| {
+            json!({
+                "request_id": req.request_id,
+                "url": req.url,
+                "method": req.method,
+                "resource_type": req.resource_type,
+                "timestamp": req.timestamp_ms,
+                "status": req.status,
+                "mime_type": req.mime_type,
+                "request_headers": req.request_headers,
+                "response_headers": req.response_headers,
+            })
+        })
+        .collect();
+
+    let url = navigation::get_tab_url(&cdp, &target_id).await;
+    let title = navigation::get_tab_title(&cdp, &target_id).await;
+
+    ActionResult::ok(json!({
+        "requests": requests,
+        "total": total,
+        "filtered": filtered,
+        "__ctx_url": url,
+        "__ctx_title": title,
+    }))
+}

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -186,6 +186,11 @@ Examples:
         #[command(subcommand)]
         command: LogsCommands,
     },
+    /// Observe network requests
+    Network {
+        #[command(subcommand)]
+        command: NetworkCommands,
+    },
     /// Take screenshot
     #[command(after_help = "\
 Examples:
@@ -272,6 +277,15 @@ pub enum LogsCommands {
     Console(observation::logs_console::Cmd),
     /// Get error logs (window error events + unhandled rejections)
     Errors(observation::logs_errors::Cmd),
+}
+
+#[derive(Subcommand, Debug)]
+#[command(disable_help_subcommand = true)]
+pub enum NetworkCommands {
+    /// List tracked network requests for a tab
+    Requests(observation::network_requests::Cmd),
+    /// Get detail for a single network request (including response body)
+    Request(observation::network_request_detail::Cmd),
 }
 
 #[derive(Subcommand, Debug)]
@@ -422,6 +436,10 @@ impl BrowserCommands {
                 LogsCommands::Console(cmd) => Action::LogsConsole(cmd.clone()),
                 LogsCommands::Errors(cmd) => Action::LogsErrors(cmd.clone()),
             },
+            Self::Network { command } => match command {
+                NetworkCommands::Requests(cmd) => Action::NetworkRequests(cmd.clone()),
+                NetworkCommands::Request(cmd) => Action::NetworkRequestDetail(cmd.clone()),
+            },
             Self::Wait { command } => match command {
                 WaitCommands::Element(cmd) => Action::WaitElement(cmd.clone()),
                 WaitCommands::Navigation(cmd) => Action::WaitNavigation(cmd.clone()),
@@ -497,6 +515,10 @@ impl BrowserCommands {
                 LogsCommands::Console(_) => observation::logs_console::COMMAND_NAME,
                 LogsCommands::Errors(_) => observation::logs_errors::COMMAND_NAME,
             },
+            Self::Network { command } => match command {
+                NetworkCommands::Requests(_) => observation::network_requests::COMMAND_NAME,
+                NetworkCommands::Request(_) => observation::network_request_detail::COMMAND_NAME,
+            },
             Self::Wait { command } => match command {
                 WaitCommands::Element(_) => wait::element::COMMAND_NAME,
                 WaitCommands::Navigation(_) => wait::navigation::COMMAND_NAME,
@@ -568,6 +590,14 @@ impl BrowserCommands {
             Self::Logs { command } => match command {
                 LogsCommands::Console(cmd) => observation::logs_console::context(cmd, result),
                 LogsCommands::Errors(cmd) => observation::logs_errors::context(cmd, result),
+            },
+            Self::Network { command } => match command {
+                NetworkCommands::Requests(cmd) => {
+                    observation::network_requests::context(cmd, result)
+                }
+                NetworkCommands::Request(cmd) => {
+                    observation::network_request_detail::context(cmd, result)
+                }
             },
             Self::Wait { command } => match command {
                 WaitCommands::Element(cmd) => wait::element::context(cmd, result),

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -84,6 +84,12 @@ fn record_request_will_be_sent(requests: &mut VecDeque<TrackedRequest>, params: 
         .and_then(|v| v.as_str())
         .unwrap_or("")
         .to_string();
+    if url.starts_with("chrome://")
+        || url.starts_with("chrome-untrusted://")
+        || url.starts_with("chrome-extension://")
+    {
+        return;
+    }
     let method = req
         .and_then(|r| r.get("method"))
         .and_then(|v| v.as_str())
@@ -158,14 +164,17 @@ fn matches_status_filter(status: Option<u16>, filter: &str) -> bool {
     let Some(s) = status else { return false };
     // Range: "400-499"
     if let Some((lo, hi)) = filter.split_once('-')
-        && let (Ok(lo), Ok(hi)) = (lo.parse::<u16>(), hi.parse::<u16>()) {
-            return s >= lo && s <= hi;
-        }
+        && let (Ok(lo), Ok(hi)) = (lo.parse::<u16>(), hi.parse::<u16>())
+    {
+        return s >= lo && s <= hi;
+    }
     // Class: "2xx", "4xx", etc.
-    if filter.len() == 3 && filter.ends_with("xx")
-        && let Some(prefix) = filter.chars().next().and_then(|c| c.to_digit(10)) {
-            return (s / 100) as u32 == prefix;
-        }
+    if filter.len() == 3
+        && filter.ends_with("xx")
+        && let Some(prefix) = filter.chars().next().and_then(|c| c.to_digit(10))
+    {
+        return (s / 100) as u32 == prefix;
+    }
     // Exact: "200"
     if let Ok(code) = filter.parse::<u16>() {
         return s == code;
@@ -181,9 +190,10 @@ fn filter_tracked_requests(
         .iter()
         .filter(|req| {
             if let Some(ref sub) = filter.url_substring
-                && !req.url.contains(sub.as_str()) {
-                    return false;
-                }
+                && !req.url.contains(sub.as_str())
+            {
+                return false;
+            }
             if let Some(ref types) = filter.resource_types {
                 let types_lower: Vec<String> =
                     types.split(',').map(|t| t.trim().to_lowercase()).collect();
@@ -192,13 +202,15 @@ fn filter_tracked_requests(
                 }
             }
             if let Some(ref method) = filter.method
-                && req.method.to_lowercase() != method.to_lowercase() {
-                    return false;
-                }
+                && req.method.to_lowercase() != method.to_lowercase()
+            {
+                return false;
+            }
             if let Some(ref status) = filter.status
-                && !matches_status_filter(req.status, status) {
-                    return false;
-                }
+                && !matches_status_filter(req.status, status)
+            {
+                return false;
+            }
             true
         })
         .cloned()
@@ -1981,6 +1993,7 @@ mod tests {
             status,
             mime_type: Some("application/json".to_string()),
             request_headers,
+            post_data: None,
             response_headers,
             response_body: Some(r#"{"ok":true}"#.to_string()),
         }

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -4,7 +4,7 @@
 //! tabs via CDP flat sessions (Target.attachToTarget + sessionId). Concurrent
 //! requests are multiplexed using incrementing message IDs.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -32,6 +32,195 @@ type IframeSessions = Arc<Mutex<HashMap<String, String>>>;
 /// Iframe session IDs that need DOM.enable + Accessibility.enable before use.
 /// Populated by reader_loop; drained by callers (e.g. snapshot handler).
 type PendingIframeEnables = Arc<Mutex<Vec<String>>>;
+
+pub const MAX_TRACKED_REQUESTS: usize = 500;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TrackedRequest {
+    pub request_id: String,
+    pub url: String,
+    pub method: String,
+    pub resource_type: String,
+    pub timestamp_ms: u64,
+    pub status: Option<u16>,
+    pub mime_type: Option<String>,
+    pub request_headers: HashMap<String, String>,
+    pub post_data: Option<String>,
+    pub response_headers: HashMap<String, String>,
+    /// Only populated by `network_request_detail` — not stored in the ring buffer.
+    pub response_body: Option<String>,
+}
+
+type TabNetRequests = Arc<Mutex<HashMap<String, VecDeque<TrackedRequest>>>>;
+
+#[derive(Debug, Clone, Default)]
+pub struct NetworkRequestsFilter {
+    pub url_substring: Option<String>,
+    pub resource_types: Option<String>,
+    pub method: Option<String>,
+    pub status: Option<String>,
+}
+
+fn normalize_headers(headers: Option<&Value>) -> HashMap<String, String> {
+    let Some(obj) = headers.and_then(|v| v.as_object()) else {
+        return HashMap::new();
+    };
+    obj.iter()
+        .filter_map(|(k, v)| v.as_str().map(|s| (k.to_lowercase(), s.to_string())))
+        .collect()
+}
+
+fn record_request_will_be_sent(requests: &mut VecDeque<TrackedRequest>, params: &Value) {
+    let request_id = params
+        .get("requestId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if request_id.is_empty() {
+        return;
+    }
+    let req = params.get("request");
+    let url = req
+        .and_then(|r| r.get("url"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let method = req
+        .and_then(|r| r.get("method"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("GET")
+        .to_string();
+    let resource_type = params
+        .get("type")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Other")
+        .to_string();
+    // CDP timestamp is seconds since epoch (float); convert to ms.
+    let timestamp_ms = params
+        .get("timestamp")
+        .and_then(|v| v.as_f64())
+        .map(|t| (t * 1000.0) as u64)
+        .unwrap_or(0);
+    let request_headers = normalize_headers(req.and_then(|r| r.get("headers")));
+    let post_data = req
+        .and_then(|r| r.get("postData"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    if requests.len() >= MAX_TRACKED_REQUESTS {
+        requests.pop_front();
+    }
+    requests.push_back(TrackedRequest {
+        request_id: request_id.to_string(),
+        url,
+        method,
+        resource_type,
+        timestamp_ms,
+        status: None,
+        mime_type: None,
+        request_headers,
+        post_data,
+        response_headers: HashMap::new(),
+        response_body: None,
+    });
+}
+
+fn record_response_received(requests: &mut VecDeque<TrackedRequest>, params: &Value) {
+    let request_id = params
+        .get("requestId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if request_id.is_empty() {
+        return;
+    }
+    let response = params.get("response");
+    let status = response
+        .and_then(|r| r.get("status"))
+        .and_then(|v| v.as_u64())
+        .map(|s| s as u16);
+    let mime_type = response
+        .and_then(|r| r.get("mimeType"))
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+    let response_headers = normalize_headers(response.and_then(|r| r.get("headers")));
+
+    if let Some(req) = requests
+        .iter_mut()
+        .rev()
+        .find(|r| r.request_id == request_id)
+    {
+        req.status = status;
+        req.mime_type = mime_type;
+        req.response_headers = response_headers;
+    }
+}
+
+fn matches_status_filter(status: Option<u16>, filter: &str) -> bool {
+    let Some(s) = status else { return false };
+    // Range: "400-499"
+    if let Some((lo, hi)) = filter.split_once('-')
+        && let (Ok(lo), Ok(hi)) = (lo.parse::<u16>(), hi.parse::<u16>()) {
+            return s >= lo && s <= hi;
+        }
+    // Class: "2xx", "4xx", etc.
+    if filter.len() == 3 && filter.ends_with("xx")
+        && let Some(prefix) = filter.chars().next().and_then(|c| c.to_digit(10)) {
+            return (s / 100) as u32 == prefix;
+        }
+    // Exact: "200"
+    if let Ok(code) = filter.parse::<u16>() {
+        return s == code;
+    }
+    false
+}
+
+fn filter_tracked_requests(
+    requests: &VecDeque<TrackedRequest>,
+    filter: &NetworkRequestsFilter,
+) -> Vec<TrackedRequest> {
+    requests
+        .iter()
+        .filter(|req| {
+            if let Some(ref sub) = filter.url_substring
+                && !req.url.contains(sub.as_str()) {
+                    return false;
+                }
+            if let Some(ref types) = filter.resource_types {
+                let types_lower: Vec<String> =
+                    types.split(',').map(|t| t.trim().to_lowercase()).collect();
+                if !types_lower.contains(&req.resource_type.to_lowercase()) {
+                    return false;
+                }
+            }
+            if let Some(ref method) = filter.method
+                && req.method.to_lowercase() != method.to_lowercase() {
+                    return false;
+                }
+            if let Some(ref status) = filter.status
+                && !matches_status_filter(req.status, status) {
+                    return false;
+                }
+            true
+        })
+        .cloned()
+        .collect()
+}
+
+fn clear_tracked_requests(requests: &mut VecDeque<TrackedRequest>) -> usize {
+    let count = requests.len();
+    requests.clear();
+    count
+}
+
+fn tracked_request_detail(
+    requests: &VecDeque<TrackedRequest>,
+    request_id: &str,
+) -> Option<TrackedRequest> {
+    requests
+        .iter()
+        .rev()
+        .find(|r| r.request_id == request_id)
+        .cloned()
+}
 
 /// Persistent CDP connection for a single browser session.
 ///
@@ -62,6 +251,9 @@ pub struct CdpSession {
     /// Iframe session IDs queued for domain enabling (DOM + Accessibility).
     /// reader_loop pushes here; callers drain before querying iframe AX trees.
     pending_iframe_enables: PendingIframeEnables,
+    /// Per-tab ring buffer of tracked network requests, keyed by CDP session ID.
+    /// Populated by reader_loop from Network events; capacity capped at MAX_TRACKED_REQUESTS.
+    tab_net_requests: TabNetRequests,
 }
 
 impl CdpSession {
@@ -103,6 +295,7 @@ impl CdpSession {
         let pending_iframe_enables: PendingIframeEnables = Arc::new(Mutex::new(Vec::new()));
         let tab_sessions: Arc<Mutex<HashMap<String, String>>> =
             Arc::new(Mutex::new(HashMap::new()));
+        let tab_net_requests: TabNetRequests = Arc::new(Mutex::new(HashMap::new()));
 
         tokio::spawn(Self::writer_loop(ws_writer, writer_rx));
         tokio::spawn(Self::reader_loop(
@@ -113,6 +306,7 @@ impl CdpSession {
             iframe_sessions.clone(),
             pending_iframe_enables.clone(),
             tab_sessions.clone(),
+            tab_net_requests.clone(),
         ));
 
         Ok(CdpSession {
@@ -124,6 +318,7 @@ impl CdpSession {
             tab_net_pending,
             iframe_sessions,
             pending_iframe_enables,
+            tab_net_requests,
         })
     }
 
@@ -294,6 +489,9 @@ impl CdpSession {
         // Clean up the pending counter for this session.
         self.tab_net_pending.lock().await.remove(&session_id);
 
+        // Clean up tracked network requests for this session.
+        self.tab_net_requests.lock().await.remove(&session_id);
+
         // Clean up all event subscriptions for this session.
         self.unsubscribe_all(&session_id).await;
 
@@ -360,6 +558,51 @@ impl CdpSession {
         } else {
             0
         }
+    }
+
+    /// Return all tracked network requests for a tab's CDP session, applying optional filters.
+    pub async fn network_requests(
+        &self,
+        cdp_session_id: &str,
+        filter: &NetworkRequestsFilter,
+    ) -> Vec<TrackedRequest> {
+        let tnr = self.tab_net_requests.lock().await;
+        if let Some(requests) = tnr.get(cdp_session_id) {
+            filter_tracked_requests(requests, filter)
+        } else {
+            Vec::new()
+        }
+    }
+
+    /// Return total count of tracked requests for a session (unfiltered).
+    pub async fn network_requests_total(&self, cdp_session_id: &str) -> usize {
+        self.tab_net_requests
+            .lock()
+            .await
+            .get(cdp_session_id)
+            .map(|q| q.len())
+            .unwrap_or(0)
+    }
+
+    /// Clear all tracked network requests for a tab's CDP session. Returns cleared count.
+    pub async fn clear_network_requests(&self, cdp_session_id: &str) -> usize {
+        let mut tnr = self.tab_net_requests.lock().await;
+        if let Some(requests) = tnr.get_mut(cdp_session_id) {
+            clear_tracked_requests(requests)
+        } else {
+            0
+        }
+    }
+
+    /// Return the detail entry for a single network request by request_id.
+    pub async fn network_request_detail(
+        &self,
+        cdp_session_id: &str,
+        request_id: &str,
+    ) -> Option<TrackedRequest> {
+        let tnr = self.tab_net_requests.lock().await;
+        tnr.get(cdp_session_id)
+            .and_then(|requests| tracked_request_detail(requests, request_id))
     }
 
     /// Subscribe to a CDP event for a specific flat-session.
@@ -493,6 +736,7 @@ impl CdpSession {
         iframe_sessions: IframeSessions,
         pending_iframe_enables: PendingIframeEnables,
         _tab_sessions: Arc<Mutex<HashMap<String, String>>>,
+        tab_net_requests: TabNetRequests,
     ) where
         S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
     {
@@ -590,6 +834,20 @@ impl CdpSession {
                                 tp.entry(session_id.to_string())
                                     .or_default()
                                     .insert(req_id.to_string(), std::time::Instant::now());
+                            }
+                            // Track request in ring buffer (all types, including skipped ones).
+                            if let Some(params) = params {
+                                let mut tnr = tab_net_requests.lock().await;
+                                let requests = tnr.entry(session_id.to_string()).or_default();
+                                record_request_will_be_sent(requests, params);
+                            }
+                        }
+                        "Network.responseReceived" => {
+                            if let Some(params) = resp.get("params") {
+                                let mut tnr = tab_net_requests.lock().await;
+                                if let Some(requests) = tnr.get_mut(session_id) {
+                                    record_response_received(requests, params);
+                                }
                             }
                         }
                         "Network.loadingFinished" | "Network.loadingFailed" => {
@@ -1698,5 +1956,365 @@ mod tests {
         .await;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         assert_eq!(cdp.network_pending("S_CACHE").await, 0);
+    }
+
+    fn sample_request(
+        request_id: &str,
+        url: &str,
+        method: &str,
+        resource_type: &str,
+        status: Option<u16>,
+    ) -> TrackedRequest {
+        let mut request_headers = HashMap::new();
+        request_headers.insert("accept".to_string(), "application/json".to_string());
+
+        let mut response_headers = HashMap::new();
+        response_headers.insert("content-type".to_string(), "application/json".to_string());
+        response_headers.insert("x-ab-fixture".to_string(), "api-data".to_string());
+
+        TrackedRequest {
+            request_id: request_id.to_string(),
+            url: url.to_string(),
+            method: method.to_string(),
+            resource_type: resource_type.to_string(),
+            timestamp_ms: 1_712_793_600_000,
+            status,
+            mime_type: Some("application/json".to_string()),
+            request_headers,
+            response_headers,
+            response_body: Some(r#"{"ok":true}"#.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_tracked_request_storage_updates_status_headers_and_mime() {
+        let mut requests = VecDeque::new();
+
+        record_request_will_be_sent(
+            &mut requests,
+            &json!({
+                "requestId": "req-1",
+                "type": "Fetch",
+                "timestamp": 1712793600.0,
+                "request": {
+                    "url": "http://127.0.0.1/api/data?source=fetch",
+                    "method": "GET",
+                    "headers": { "accept": "application/json" }
+                }
+            }),
+        );
+        record_response_received(
+            &mut requests,
+            &json!({
+                "requestId": "req-1",
+                "type": "Fetch",
+                "response": {
+                    "url": "http://127.0.0.1/api/data?source=fetch",
+                    "status": 200,
+                    "mimeType": "application/json",
+                    "headers": {
+                        "content-type": "application/json",
+                        "x-ab-fixture": "api-data"
+                    }
+                }
+            }),
+        );
+
+        let req = tracked_request_detail(&requests, "req-1").expect("request stored");
+        assert_eq!(req.url, "http://127.0.0.1/api/data?source=fetch");
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.resource_type, "Fetch");
+        assert_eq!(req.status, Some(200));
+        assert_eq!(req.mime_type.as_deref(), Some("application/json"));
+        assert_eq!(
+            req.response_headers.get("x-ab-fixture").map(String::as_str),
+            Some("api-data")
+        );
+    }
+
+    #[test]
+    fn test_tracked_request_fifo_eviction_drops_oldest_after_500() {
+        let mut requests = VecDeque::new();
+
+        for idx in 0..(MAX_TRACKED_REQUESTS + 1) {
+            record_request_will_be_sent(
+                &mut requests,
+                &json!({
+                    "requestId": format!("req-{idx}"),
+                    "type": "XHR",
+                    "timestamp": 1712793600.0 + idx as f64,
+                    "request": {
+                        "url": format!("http://127.0.0.1/api/data?i={idx}"),
+                        "method": "GET",
+                        "headers": {}
+                    }
+                }),
+            );
+        }
+
+        assert_eq!(requests.len(), MAX_TRACKED_REQUESTS);
+        assert!(tracked_request_detail(&requests, "req-0").is_none());
+        assert!(tracked_request_detail(&requests, "req-500").is_some());
+    }
+
+    #[test]
+    fn test_filter_tracked_requests_by_url_substring() {
+        let requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/page-a",
+                "GET",
+                "Document",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=fetch",
+                "GET",
+                "Fetch",
+                Some(200),
+            ),
+        ]);
+
+        let filtered = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                url_substring: Some("/api/data".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].request_id, "req-2");
+    }
+
+    #[test]
+    fn test_filter_tracked_requests_by_resource_type_case_insensitive_csv() {
+        let requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/page-a",
+                "GET",
+                "Document",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=fetch",
+                "GET",
+                "Fetch",
+                Some(200),
+            ),
+            sample_request(
+                "req-3",
+                "http://127.0.0.1/api/data?source=xhr",
+                "POST",
+                "XHR",
+                Some(201),
+            ),
+        ]);
+
+        let filtered = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                resource_types: Some("xhr,fetch".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+
+        assert_eq!(filtered.len(), 2);
+        assert!(
+            filtered
+                .iter()
+                .all(|req| { req.resource_type == "Fetch" || req.resource_type == "XHR" })
+        );
+    }
+
+    #[test]
+    fn test_filter_tracked_requests_by_method_case_insensitive() {
+        let requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/page-a",
+                "GET",
+                "Document",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=xhr",
+                "POST",
+                "XHR",
+                Some(201),
+            ),
+        ]);
+
+        let filtered = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                method: Some("post".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].request_id, "req-2");
+    }
+
+    #[test]
+    fn test_filter_tracked_requests_by_status_exact_class_and_range() {
+        let requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/page-a",
+                "GET",
+                "Document",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=create",
+                "POST",
+                "XHR",
+                Some(201),
+            ),
+            sample_request(
+                "req-3",
+                "http://127.0.0.1/api/data?source=error",
+                "GET",
+                "Fetch",
+                Some(404),
+            ),
+        ]);
+
+        let exact = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                status: Some("200".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+        let class = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                status: Some("2xx".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+        let range = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                status: Some("400-499".to_string()),
+                ..NetworkRequestsFilter::default()
+            },
+        );
+
+        assert_eq!(
+            exact
+                .iter()
+                .map(|r| r.request_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["req-1"]
+        );
+        assert_eq!(
+            class
+                .iter()
+                .map(|r| r.request_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["req-1", "req-2"]
+        );
+        assert_eq!(
+            range
+                .iter()
+                .map(|r| r.request_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["req-3"]
+        );
+    }
+
+    #[test]
+    fn test_filter_tracked_requests_with_combined_filters() {
+        let requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/api/data?source=fetch",
+                "GET",
+                "Fetch",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=xhr",
+                "POST",
+                "XHR",
+                Some(201),
+            ),
+            sample_request(
+                "req-3",
+                "http://127.0.0.1/asset.js",
+                "GET",
+                "Script",
+                Some(200),
+            ),
+        ]);
+
+        let filtered = filter_tracked_requests(
+            &requests,
+            &NetworkRequestsFilter {
+                url_substring: Some("/api/data".to_string()),
+                resource_types: Some("xhr".to_string()),
+                method: Some("POST".to_string()),
+                status: Some("2xx".to_string()),
+            },
+        );
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].request_id, "req-2");
+    }
+
+    #[test]
+    fn test_clear_tracked_requests_resets_list() {
+        let mut requests = VecDeque::from([
+            sample_request(
+                "req-1",
+                "http://127.0.0.1/page-a",
+                "GET",
+                "Document",
+                Some(200),
+            ),
+            sample_request(
+                "req-2",
+                "http://127.0.0.1/api/data?source=fetch",
+                "GET",
+                "Fetch",
+                Some(200),
+            ),
+        ]);
+
+        let cleared = clear_tracked_requests(&mut requests);
+        assert_eq!(cleared, 2);
+        assert!(requests.is_empty());
+    }
+
+    #[test]
+    fn test_tracked_request_detail_returns_headers_and_response_body() {
+        let requests = VecDeque::from([sample_request(
+            "req-9",
+            "http://127.0.0.1/api/data?source=fetch",
+            "GET",
+            "Fetch",
+            Some(200),
+        )]);
+
+        let req = tracked_request_detail(&requests, "req-9").expect("detail entry");
+        assert_eq!(
+            req.request_headers.get("accept").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(
+            req.response_headers.get("content-type").map(String::as_str),
+            Some("application/json")
+        );
+        assert_eq!(req.response_body.as_deref(), Some(r#"{"ok":true}"#));
     }
 }

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -740,6 +740,7 @@ impl CdpSession {
     }
 
     /// Background task: read WS messages and route responses/events to callers.
+    #[allow(clippy::too_many_arguments)]
     async fn reader_loop<S>(
         mut reader: S,
         pending: PendingRequests,

--- a/packages/cli/src/daemon/router.rs
+++ b/packages/cli/src/daemon/router.rs
@@ -46,6 +46,12 @@ pub async fn route(action: &Action, registry: &SharedRegistry) -> ActionResult {
             browser::observation::logs_console::execute(cmd, registry).await
         }
         Action::LogsErrors(cmd) => browser::observation::logs_errors::execute(cmd, registry).await,
+        Action::NetworkRequests(cmd) => {
+            browser::observation::network_requests::execute(cmd, registry).await
+        }
+        Action::NetworkRequestDetail(cmd) => {
+            browser::observation::network_request_detail::execute(cmd, registry).await
+        }
         Action::CookiesList(cmd) => browser::cookies::list::execute(cmd, registry).await,
         Action::CookiesGet(cmd) => browser::cookies::get::execute(cmd, registry).await,
         Action::CookiesSet(cmd) => browser::cookies::set::execute(cmd, registry).await,

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -227,6 +227,8 @@ pub fn format_text(
                     | "browser session-storage set"
                     | "browser session-storage delete"
                     | "browser session-storage clear"
+                    | "browser network requests"
+                    | "browser network request"
             );
 
             if is_action {

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -695,6 +695,76 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                 lines.push(format!("path: {path}"));
             }
         }
+        "browser network requests" => {
+            if data
+                .get("cleared")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false)
+            {
+                let count = data.get("count").and_then(|v| v.as_u64()).unwrap_or(0);
+                lines.push(format!("cleared: {count} requests"));
+            } else {
+                let requests = data.get("requests").and_then(|v| v.as_array());
+                let filtered = requests.map(|r| r.len()).unwrap_or(0);
+                let total = data.get("total").and_then(|v| v.as_u64()).unwrap_or(0);
+                if filtered == total as usize {
+                    let label = if filtered == 1 { "request" } else { "requests" };
+                    lines.push(format!("{filtered} {label}"));
+                } else {
+                    lines.push(format!("{filtered} requests (of {total} total)"));
+                }
+                if let Some(requests) = requests {
+                    for req in requests {
+                        let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("-");
+                        let status = req
+                            .get("status")
+                            .map(|v| {
+                                if v.is_null() {
+                                    "pending".to_string()
+                                } else {
+                                    v.to_string()
+                                }
+                            })
+                            .unwrap_or_else(|| "pending".to_string());
+                        let url = req.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                        let rtype = req
+                            .get("resource_type")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("");
+                        lines.push(format!("  {method} {status} {url} [{rtype}]"));
+                    }
+                }
+            }
+        }
+        "browser network request" => {
+            if let Some(req) = data.get("request") {
+                let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("-");
+                let status = req
+                    .get("status")
+                    .map(|v| {
+                        if v.is_null() {
+                            "pending".to_string()
+                        } else {
+                            v.to_string()
+                        }
+                    })
+                    .unwrap_or_else(|| "pending".to_string());
+                let url = req.get("url").and_then(|v| v.as_str()).unwrap_or("");
+                let rtype = req
+                    .get("resource_type")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                lines.push(format!("{method} {status} {url} [{rtype}]"));
+                if let Some(body) = req.get("response_body").and_then(|v| v.as_str()) {
+                    let preview = if body.len() > 200 {
+                        format!("{}...", &body[..200])
+                    } else {
+                        body.to_string()
+                    };
+                    lines.push(format!("body: {preview}"));
+                }
+            }
+        }
         "browser logs console" | "browser logs errors" => {
             // §10.12-§10.13: N log(s) then level timestamp source text per item
             if let Some(items) = data.get("items").and_then(|v| v.as_array()) {

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -234,6 +234,101 @@ setTimeout(() => {{
         return;
     }
 
+    if path.starts_with("/api/data") {
+        let source = path
+            .split("source=")
+            .nth(1)
+            .and_then(|value| value.split('&').next())
+            .unwrap_or("default");
+        let body = format!(r#"{{"ok":true,"source":"{source}"}}"#);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Ab-Fixture: api-data\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-fixture.css" {
+        let body = "body { background: rgb(245, 248, 255); }";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/css\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-fixture.js" {
+        let body = "window.__ab_network_script_loaded = true;";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/javascript\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-load" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Load Fixture</title>
+<link rel="stylesheet" href="http://127.0.0.1:{port}/network-fixture.css">
+<script src="http://127.0.0.1:{port}/network-fixture.js" defer></script>
+</head>
+<body>
+<h1>Network Load Fixture</h1>
+<p id="network-load-status">ready</p>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-xhr" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network XHR Fixture</title></head>
+<body>
+<h1>Network XHR Fixture</h1>
+<script>
+window.__ab_requests_done = false;
+window.__ab_requests_error = null;
+Promise.all([
+  fetch("http://127.0.0.1:{port}/api/data?source=fetch").then(r => r.json()),
+  new Promise((resolve, reject) => {{
+    const xhr = new XMLHttpRequest();
+    xhr.open("GET", "http://127.0.0.1:{port}/api/data?source=xhr");
+    xhr.onload = () => resolve(xhr.responseText);
+    xhr.onerror = () => reject(new Error("xhr failed"));
+    xhr.send();
+  }})
+]).then(() => {{
+  window.__ab_requests_done = true;
+}}).catch(err => {{
+  window.__ab_requests_error = String(err);
+  window.__ab_requests_done = true;
+}});
+</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // Cross-origin iframe parent: embeds child from a different port
     if path.starts_with("/iframe-xo-parent") {
         let xo_port = path
@@ -366,6 +461,16 @@ pub fn url_iframe_parent() -> String {
 /// URL for cursor-interactive fixture (cursor:pointer, onclick, tabindex elements).
 pub fn url_cursor_fixture() -> String {
     format!("http://127.0.0.1:{}/cursor-fixture", local_server().port)
+}
+
+/// URL for a page that loads a document, stylesheet, and script.
+pub fn url_network_load() -> String {
+    format!("http://127.0.0.1:{}/network-load", local_server().port)
+}
+
+/// URL for a page that performs fetch + XHR requests and marks completion.
+pub fn url_network_xhr() -> String {
+    format!("http://127.0.0.1:{}/network-xhr", local_server().port)
 }
 
 // ── Cross-origin server (second port for OOPIF tests) ─────────────

--- a/packages/cli/tests/e2e/main.rs
+++ b/packages/cli/tests/e2e/main.rs
@@ -22,6 +22,7 @@ mod inspect_point;
 mod interaction;
 mod logs;
 mod navigation;
+mod network;
 mod page_info;
 mod pdf;
 mod query;

--- a/packages/cli/tests/e2e/network.rs
+++ b/packages/cli/tests/e2e/network.rs
@@ -27,7 +27,7 @@ fn wait_requests_done(session_id: &str, tab_id: &str) {
     assert_success(&out, "wait requests done");
 }
 
-fn request_items<'a>(value: &'a serde_json::Value) -> &'a [serde_json::Value] {
+fn request_items(value: &serde_json::Value) -> &[serde_json::Value] {
     value["data"]["requests"]
         .as_array()
         .map(Vec::as_slice)

--- a/packages/cli/tests/e2e/network.rs
+++ b/packages/cli/tests/e2e/network.rs
@@ -1,0 +1,285 @@
+//! Browser network observation E2E tests.
+//!
+//! Covers the planned `browser network requests` and
+//! `browser network request <id>` commands for ACT-882.
+
+use crate::harness::{
+    SessionGuard, assert_meta, assert_success, headless_json, parse_json, skip, start_session,
+    url_network_load, url_network_xhr,
+};
+
+fn wait_requests_done(session_id: &str, tab_id: &str) {
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "condition",
+            "window.__ab_requests_done === true",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+            "--timeout",
+            "5000",
+        ],
+        10,
+    );
+    assert_success(&out, "wait requests done");
+}
+
+fn request_items<'a>(value: &'a serde_json::Value) -> &'a [serde_json::Value] {
+    value["data"]["requests"]
+        .as_array()
+        .map(Vec::as_slice)
+        .unwrap_or(&[])
+}
+
+#[test]
+fn network_requests_lists_page_load_requests() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_load());
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        15,
+    );
+    assert_success(&out, "network requests page load");
+    let v = parse_json(&out);
+    let requests = request_items(&v);
+
+    assert_eq!(v["command"], "browser network requests");
+    assert_eq!(v["ok"], true);
+    assert!(v["error"].is_null());
+    assert_eq!(v["context"]["session_id"], sid);
+    assert_eq!(v["context"]["tab_id"], tid);
+    assert!(requests.len() >= 3, "expected document + css + js requests");
+    assert!(
+        requests
+            .iter()
+            .any(|req| req["resource_type"] == "Document"),
+        "document request should be present"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|req| req["resource_type"] == "Stylesheet"),
+        "stylesheet request should be present"
+    );
+    assert!(
+        requests.iter().any(|req| req["resource_type"] == "Script"),
+        "script request should be present"
+    );
+    assert_eq!(
+        v["data"]["total"].as_u64().unwrap_or(0),
+        requests.len() as u64
+    );
+    assert_meta(&v);
+}
+
+#[test]
+fn network_requests_filter_by_type() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--type",
+            "xhr,fetch",
+        ],
+        15,
+    );
+    assert_success(&out, "network requests filter type");
+    let v = parse_json(&out);
+    let requests = request_items(&v);
+
+    assert_eq!(v["command"], "browser network requests");
+    assert!(!requests.is_empty(), "xhr/fetch requests should be present");
+    assert!(
+        requests
+            .iter()
+            .all(|req| { matches!(req["resource_type"].as_str(), Some("XHR") | Some("Fetch")) })
+    );
+    assert_eq!(
+        v["data"]["filtered"].as_u64().unwrap_or(0),
+        requests.len() as u64
+    );
+    assert_meta(&v);
+}
+
+#[test]
+fn network_requests_clear() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+
+    let clear_out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--clear",
+        ],
+        15,
+    );
+    assert_success(&clear_out, "network requests clear");
+    let clear_v = parse_json(&clear_out);
+    assert_eq!(clear_v["command"], "browser network requests");
+    assert_eq!(clear_v["data"]["cleared"], true);
+
+    let list_out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        15,
+    );
+    assert_success(&list_out, "network requests list after clear");
+    let list_v = parse_json(&list_out);
+    let requests = request_items(&list_v);
+
+    assert_eq!(requests.len(), 0);
+    assert_eq!(list_v["data"]["total"], 0);
+    assert_eq!(list_v["data"]["filtered"], 0);
+}
+
+#[test]
+fn network_request_detail() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+
+    let list_out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--filter",
+            "source=fetch",
+        ],
+        15,
+    );
+    assert_success(&list_out, "network requests list for detail");
+    let list_v = parse_json(&list_out);
+    let request_id = list_v["data"]["requests"][0]["request_id"]
+        .as_str()
+        .expect("request id")
+        .to_string();
+
+    let detail_out = headless_json(
+        &[
+            "browser",
+            "network",
+            "request",
+            &request_id,
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        15,
+    );
+    assert_success(&detail_out, "network request detail");
+    let v = parse_json(&detail_out);
+
+    assert_eq!(v["command"], "browser network request");
+    assert_eq!(v["ok"], true);
+    assert!(v["error"].is_null());
+    assert_eq!(v["context"]["session_id"], sid);
+    assert_eq!(v["context"]["tab_id"], tid);
+    assert_eq!(v["data"]["request"]["request_id"], request_id);
+    assert!(
+        v["data"]["request"]["url"]
+            .as_str()
+            .is_some_and(|url| url.contains("/api/data?source=fetch"))
+    );
+    assert_eq!(v["data"]["request"]["status"], 200);
+    assert_eq!(
+        v["data"]["request"]["response_headers"]["x-ab-fixture"],
+        "api-data"
+    );
+    assert!(
+        v["data"]["request"]["response_body"]
+            .as_str()
+            .is_some_and(|body| body.contains("\"source\":\"fetch\""))
+    );
+    assert_meta(&v);
+}
+
+#[test]
+fn network_requests_empty_on_fresh_tab() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        15,
+    );
+    assert_success(&out, "network requests fresh tab");
+    let v = parse_json(&out);
+    let requests = request_items(&v);
+
+    assert_eq!(v["command"], "browser network requests");
+    assert!(
+        requests.len() <= 1,
+        "fresh about:blank tab should be empty or minimal"
+    );
+    assert!(v["data"]["total"].as_u64().unwrap_or(0) <= 1);
+    assert_meta(&v);
+}


### PR DESCRIPTION
## Summary
- Add `browser network requests` command to list tracked HTTP requests per tab with filters (URL, resource type, method, status code) and `--clear` support
- Add `browser network request <id>` command to fetch detailed request info including response body (on-demand via `Network.getResponseBody` CDP call)
- Store per-tab requests in a FIFO ring buffer (500 cap) with `TrackedRequest` struct tracking URL, method, resource type, status, headers (normalized HashMap), post data, and timestamps
- Filter Chrome internal URLs (`chrome://`, `chrome-untrusted://`, `chrome-extension://`) from tracking

## Implementation
- **Data layer** (`cdp_session.rs`): `TrackedRequest` struct, `TabNetRequests` type, CDP event handlers for `Network.requestWillBeSent` / `Network.responseReceived`, pure filter functions (`matches_status_filter`, `filter_tracked_requests`), public API methods
- **Command layer**: `network_requests.rs` (list with filters) + `network_request_detail.rs` (detail with body fetch)
- **Routing**: `cli.rs` `NetworkCommands` enum, `action.rs`, `router.rs`
- **Output**: text-mode formatting for both commands in `output.rs`

## Test plan
- [x] Unit tests: TrackedRequest storage, FIFO eviction, URL/type/method/status filters, combined filters, clear, request detail
- [x] E2e: `network_requests_lists_page_load_requests` — verify Document + Stylesheet + Script after page load
- [x] E2e: `network_requests_filter_by_type` — filter `--type xhr,fetch` on page with XHR/fetch calls
- [x] E2e: `network_requests_clear` — clear then verify empty
- [x] E2e: `network_request_detail` — get single request by ID, verify headers + response body
- [x] E2e: `network_requests_empty_on_fresh_tab` — about:blank tab returns empty/minimal

Closes ACT-882