### PR TITLE
fix(browser): address Codex review findings for network requests (ACT-882)

### DIFF
--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -112,6 +112,22 @@ fn record_request_will_be_sent(requests: &mut VecDeque<TrackedRequest>, params: 
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    // For redirect chains, CDP reuses the same requestId. Update in-place
+    // so the list shows the final URL and users can always inspect by ID.
+    if let Some(existing) = requests.iter_mut().find(|r| r.request_id == request_id) {
+        existing.url = url;
+        existing.method = method;
+        existing.resource_type = resource_type;
+        existing.timestamp_ms = timestamp_ms;
+        existing.request_headers = request_headers;
+        existing.post_data = post_data;
+        existing.status = None;
+        existing.mime_type = None;
+        existing.response_headers = HashMap::new();
+        existing.response_body = None;
+        return;
+    }
+
     if requests.len() >= MAX_TRACKED_REQUESTS {
         requests.pop_front();
     }

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -717,6 +717,10 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                 }
                 if let Some(requests) = requests {
                     for req in requests {
+                        let id = req
+                            .get("request_id")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("-");
                         let method = req.get("method").and_then(|v| v.as_str()).unwrap_or("-");
                         let status = req
                             .get("status")
@@ -733,7 +737,7 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                             .get("resource_type")
                             .and_then(|v| v.as_str())
                             .unwrap_or("");
-                        lines.push(format!("  {method} {status} {url} [{rtype}]"));
+                        lines.push(format!("  {id} {method} {status} {url} [{rtype}]"));
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Include `request_id` in text-mode `browser network requests` output so users can drill into `browser network request <id>` without switching to `--json` (P1)
- Deduplicate entries for redirect chains: `record_request_will_be_sent` now updates in-place when the same `requestId` appears again, preventing duplicate rows and ensuring detail lookup returns the correct final hop (P2)

Follow-up to PR #492 addressing Codex review comments.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [ ] CI lint + unit tests