### PR TITLE
[root]fix: simplify Discord release install section

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -56,17 +56,14 @@ jobs:
 
           ## Install Now
 
-          **macOS / Linux**
-          ```
-          curl -fsSL https://actionbook.dev/install.sh | bash
-          ```
-          **Windows**
-          ```
-          irm https://actionbook.dev/install.ps1 | iex
-          ```
           **npm**
           ```
           npm install -g @actionbookdev/cli
+          ```
+
+          **Or ask your AI agent**
+          ```
+          Search GitHub for actionbook and install the Actionbook CLI for me
           ```
           INSTALL_EOF
           )


### PR DESCRIPTION
## Summary

- Drop the macOS/Linux `curl | bash` and Windows `irm | iex` one-liners from the CLI release Discord notification — those install scripts on `actionbook.dev` are not currently aligned with the release asset naming, so they've been unreliable for users.
- Keep `npm install -g @actionbookdev/cli` as the canonical install path.
- Add an AI-agent-friendly prompt (`Search GitHub for actionbook and install the Actionbook CLI for me`) as an alternative install path, matching Actionbook's "designed for LLM consumers" positioning.

Only `.github/workflows/discord-release-notify.yml` is touched; nothing about the release pipeline, cleaning of PR attribution links, embed color scheme, or truncation logic changes.

## Test plan

- [x] Simulated the updated `run:` block locally via YAML → bash (heredoc indentation stripping verified, resulting `$CLEANED` variable inspected; renders as `## Install Now` + npm block + agent-prompt block, no dangling curl/irm lines).
- [ ] On the next CLI release (post-merge), confirm the Discord embed shows exactly the two blocks (`npm` and `Or ask your AI agent`) with no extra empty sections.
- [ ] Verify Extension and Dify Plugin release notifications are unaffected (they have `install=false`, so the `APPEND_INSTALL` branch is not taken).