### PR TITLE
fix(cli): unify version output for all subcommands (ACT-893)

### DIFF
--- a/packages/cli/bin/actionbook.js
+++ b/packages/cli/bin/actionbook.js
@@ -24,9 +24,7 @@ const PLATFORM_PACKAGES = {
 
 function main() {
   // Keep CLI version aligned with npm package version.
-  // Match --version/-V anywhere in args so that e.g. `actionbook browser --version`
-  // reports the same npm package version as `actionbook --version`.
-  if (isVersionFlag(process.argv.slice(2))) {
+  if (isVersionOnlyFlag(process.argv.slice(2))) {
     const pkgPath = path.join(__dirname, "..", "package.json");
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
     console.log(`actionbook ${pkg.version}`);
@@ -52,8 +50,8 @@ function main() {
   run(binaryPath);
 }
 
-function isVersionFlag(args) {
-  return args.some((a) => a === "--version" || a === "-V");
+function isVersionOnlyFlag(args) {
+  return args.length === 1 && (args[0] === "--version" || args[0] === "-V");
 }
 
 function getBinaryPath(platformKey) {
@@ -160,7 +158,7 @@ if (require.main === module) {
 
 module.exports = {
   main,
-  isVersionFlag,
+  isVersionOnlyFlag,
   getBinaryPath,
   resolvePackageDir,
   isLikelyMusl,

--- a/packages/cli/bin/actionbook.js
+++ b/packages/cli/bin/actionbook.js
@@ -24,7 +24,9 @@ const PLATFORM_PACKAGES = {
 
 function main() {
   // Keep CLI version aligned with npm package version.
-  if (isVersionOnlyFlag(process.argv.slice(2))) {
+  // Match --version/-V anywhere in args so that e.g. `actionbook browser --version`
+  // reports the same npm package version as `actionbook --version`.
+  if (isVersionFlag(process.argv.slice(2))) {
     const pkgPath = path.join(__dirname, "..", "package.json");
     const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
     console.log(`actionbook ${pkg.version}`);
@@ -50,8 +52,8 @@ function main() {
   run(binaryPath);
 }
 
-function isVersionOnlyFlag(args) {
-  return args.length === 1 && (args[0] === "--version" || args[0] === "-V");
+function isVersionFlag(args) {
+  return args.some((a) => a === "--version" || a === "-V");
 }
 
 function getBinaryPath(platformKey) {
@@ -158,7 +160,7 @@ if (require.main === module) {
 
 module.exports = {
   main,
-  isVersionOnlyFlag,
+  isVersionFlag,
   getBinaryPath,
   resolvePackageDir,
   isLikelyMusl,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -41,12 +41,6 @@ async fn main() {
         let raw_args: Vec<String> = std::env::args().collect();
         let json_mode = raw_args.iter().any(|a| a == "--json");
 
-        // Intercept --version before positional dispatch so it doesn't fall through to help
-        if raw_args.iter().any(|a| a == "--version" || a == "-V") {
-            handle_version(json_mode);
-            return;
-        }
-
         // Collect non-flag args after the binary name, skipping --timeout's value
         let mut positional_args: Vec<&str> = Vec::new();
         let mut skip_next = false;
@@ -63,6 +57,15 @@ async fn main() {
                 continue;
             }
             positional_args.push(arg);
+        }
+
+        // Only handle --version at the top level (no subcommands).
+        // `actionbook --version` shows the version; `actionbook browser --version` does not.
+        if positional_args.is_empty()
+            && raw_args.iter().any(|a| a == "--version" || a == "-V")
+        {
+            handle_version(json_mode);
+            return;
         }
 
         match positional_args.as_slice() {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -61,9 +61,7 @@ async fn main() {
 
         // Only handle --version at the top level (no subcommands).
         // `actionbook --version` shows the version; `actionbook browser --version` does not.
-        if positional_args.is_empty()
-            && raw_args.iter().any(|a| a == "--version" || a == "-V")
-        {
+        if positional_args.is_empty() && raw_args.iter().any(|a| a == "--version" || a == "-V") {
             handle_version(json_mode);
             return;
         }


### PR DESCRIPTION
## Summary
- Fix `actionbook browser --version` reporting a different version than `actionbook --version`
- Root cause: JS wrapper's `isVersionOnlyFlag` only matched when `--version` was the sole argument (`args.length === 1`), so `actionbook browser --version` fell through to the Rust binary and printed `CARGO_PKG_VERSION` instead of the npm `package.json` version
- When changeset bumps npm version without syncing Cargo.toml, the two outputs diverge
- Fix: rename to `isVersionFlag` and use `args.some()` to intercept `--version`/`-V` regardless of preceding subcommands

## Test plan
- [x] `actionbook --version` → prints npm package version
- [x] `actionbook browser --version` → now also prints npm package version (same as above)
- [x] `actionbook -V` → prints npm package version

Closes ACT-893