### PR TITLE
docs: add missing help for network, batch, and setup --target

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -310,7 +310,7 @@ Usage: actionbook <command> [options]
 
 Commands:
   browser    Control browser sessions, tabs, and page interactions
-  setup      Configure actionbook
+  setup      Configure actionbook (or --target <agent> for quick skills install)
   help       Show this help
   --version  Show version
 
@@ -385,6 +385,10 @@ Logs:
   logs console        --session --tab  Get console logs
   logs errors         --session --tab  Get error logs (exceptions + rejections)
 
+Network:
+  network requests    --session --tab  List tracked network requests
+  network request <id>  --session --tab  Get detail for a single request (incl. body)
+
 Wait:
   wait element <selector>  --session --tab  Wait for element to appear
   wait navigation          --session --tab  Wait for navigation to complete
@@ -419,6 +423,11 @@ Interaction:
   mouse-move <x,y>       --session --tab  Move mouse to coordinates
   cursor-position         --session --tab  Get current cursor position
   scroll <direction|edge|into-view>  --session --tab  Scroll page or container
+
+Batch:
+  batch-new-tab --urls <url...>  --session  Open multiple tabs (alias: batch-open)
+  batch-snapshot --tabs <tab...>  --session  Snapshot multiple tabs
+  batch-click <sel...>  --session --tab  Click multiple elements sequentially
 
 Global flags (apply to all subcommands):
   --json          Output as JSON envelope

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -72,7 +72,9 @@ All commands support `--help` for full usage and examples.
 | Cookies | `cookies list`, `cookies get`, `cookies set`, `cookies delete`, `cookies clear` | `actionbook browser cookies list --help` |
 | Storage | `local-storage list\|get\|set\|delete\|clear`, `session-storage ...` | `actionbook browser local-storage get --help` |
 | Logs | `logs console`, `logs errors` | `actionbook browser logs console --help` |
+| Network | `network requests`, `network request <id>` | `actionbook browser network requests --help` |
 | Query | `query one\|all\|nth\|count` | `actionbook browser query --help` |
+| Batch | `batch-new-tab`, `batch-snapshot`, `batch-click` | `actionbook browser batch-new-tab --help` |
 
 Full command reference: [command-reference.md](references/command-reference.md)
 

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -192,6 +192,21 @@ actionbook browser logs errors --since err-3 --session s1 --tab t1
 actionbook browser logs errors --clear --session s1 --tab t1
 ```
 
+## Network
+
+```bash
+actionbook browser network requests --session s1 --tab t1                          # List all tracked requests
+actionbook browser network requests --filter /api/ --session s1 --tab t1           # Filter by URL substring
+actionbook browser network requests --type xhr,fetch --session s1 --tab t1         # Filter by resource type
+actionbook browser network requests --method POST --session s1 --tab t1            # Filter by HTTP method
+actionbook browser network requests --status 2xx --session s1 --tab t1             # Filter by status (200, 2xx, 400-499)
+actionbook browser network requests --clear --session s1 --tab t1                  # Clear request buffer
+
+actionbook browser network request 1234.1 --session s1 --tab t1                   # Get full request detail + response body
+```
+
+Requests are captured automatically per tab (500 cap ring buffer). Use `network requests` to list IDs, then `network request <id>` for detail including response body.
+
 ## Wait
 
 ```bash
@@ -236,12 +251,33 @@ actionbook browser session-storage get user_id --session s1 --tab t1
 actionbook browser session-storage set lang en --session s1 --tab t1
 ```
 
+## Batch
+
+Batch commands operate on multiple targets in one call for higher throughput.
+
+```bash
+# Open multiple tabs
+actionbook browser batch-new-tab --urls https://a.com https://b.com --session s1
+actionbook browser batch-new-tab --urls https://a.com https://b.com --tabs inbox settings --session s1
+
+# Snapshot multiple tabs
+actionbook browser batch-snapshot --tabs t1 t2 t3 --session s1
+
+# Click multiple elements sequentially
+actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
+```
+
+`batch-new-tab` (alias `batch-open`) opens each URL as a new tab. If `--tabs` is provided, its length must match `--urls`. `batch-click` stops on first failure and reports progress. `batch-snapshot` returns per-tab results (ok or error).
+
 ## Setup
 
 ```bash
-actionbook setup                              # Interactive configuration wizard
+actionbook setup                                    # Interactive configuration wizard
 actionbook setup --non-interactive --api-key <KEY>  # Non-interactive setup
-actionbook setup --reset                      # Reset configuration
+actionbook setup --reset                            # Reset configuration
+actionbook setup --target claude                    # Quick mode: install skills for an agent
+actionbook setup -t codex                           # Short flag
+# Targets: claude, codex, cursor, windsurf, antigravity, opencode, standalone, all
 ```
 
 ## Practical Examples


### PR DESCRIPTION
## Summary
- Add **Network** section to `handle_browser_help()`, SKILL.md, and command-reference.md (`network requests`, `network request <id>`)
- Add **Batch** section to all three (`batch-new-tab`, `batch-snapshot`, `batch-click`)
- Add **setup --target** quick mode to `handle_help()` and command-reference.md Setup section
- All 5 new command `.rs` files already had `after_help` — no changes needed there

## Test plan
- [x] `cargo check` passes
- [ ] `actionbook --help` shows setup --target description
- [ ] `actionbook browser --help` shows Network and Batch sections
- [ ] SKILL.md command table includes Network and Batch rows
- [ ] command-reference.md has Network, Batch, and updated Setup sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)