### PR TITLE
[packages/cli] Improve cloud provider session lifecycle

### DIFF
--- a/.changeset/cloud-providers-p-flag.md
+++ b/.changeset/cloud-providers-p-flag.md
@@ -1,0 +1,7 @@
+---
+"@actionbookdev/cli": minor
+---
+
+Add cloud browser provider support via `-p / --provider`.
+
+Supported providers: Driver, Hyperbrowser, Browseruse. Each provider reads its own `<PROVIDER>_API_KEY` from the caller's shell, and `browser restart` mints a fresh remote session while preserving the local `session_id`.

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "urlencoding",
+ "uuid",
  "which",
 ]
 
@@ -1309,6 +1310,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1800,17 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+dependencies = [
+ "js-sys",
+ "sha1_smol",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -70,11 +70,13 @@ harness = true
 
 [profile.release]
 opt-level = "z"
-# Full LTO on the current macOS/Rust toolchain can produce a release binary
-# that gets SIGKILL'ed before browser commands even reach the daemon. Keep the
-# release build stripped and size-focused, but disable LTO so installed
-# binaries remain runnable.
-lto = false
+# Full (`lto = true`) LTO on the current macOS/Rust toolchain produces a
+# release binary that gets SIGKILL'ed before browser commands even reach the
+# daemon — likely a miscompilation or signal-handler interaction we have not
+# root-caused yet. Thin LTO keeps most of the size win without tripping the
+# crash, and preserves cross-crate inlining so opt-level="z" still pays off.
+# TODO: track down the SIGKILL root cause and switch back to `lto = true`.
+lto = "thin"
 codegen-units = 1
 strip = true
 panic = "abort"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -70,7 +70,11 @@ harness = true
 
 [profile.release]
 opt-level = "z"
-lto = true
+# Full LTO on the current macOS/Rust toolchain can produce a release binary
+# that gets SIGKILL'ed before browser commands even reach the daemon. Keep the
+# release build stripped and size-focused, but disable LTO so installed
+# binaries remain runnable.
+lto = false
 codegen-units = 1
 strip = true
 panic = "abort"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -54,6 +54,7 @@ dirs = "6"
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v5"] }
 
 
 [dev-dependencies]

--- a/packages/cli/src/browser/navigation/goto.rs
+++ b/packages/cli/src/browser/navigation/goto.rs
@@ -170,10 +170,21 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let to_url = super::get_tab_url(&cdp, &target_id).await;
     let title = super::get_tab_title(&cdp, &target_id).await;
 
-    // Clear snapshot RefCache — page changed, old backendNodeIds are invalid
+    // Clear snapshot RefCache — page changed, old backendNodeIds are invalid.
+    // Also refresh the registry's TabEntry so downstream consumers (restart
+    // preserving open_url, list-sessions summary, etc.) see the navigated URL
+    // instead of the stale launch-time URL. Without this, a session restart
+    // after a `goto` would rewind the user to whatever page the browser
+    // booted on.
     {
         let mut reg = registry.lock().await;
         reg.clear_ref_cache(&cmd.session, &cmd.tab);
+        if let Some(entry) = reg.get_mut(&cmd.session)
+            && let Some(tab) = entry.tabs.iter_mut().find(|t| t.id.0 == cmd.tab)
+        {
+            tab.url = to_url.clone();
+            tab.title = title.clone();
+        }
     }
 
     ActionResult::ok(json!({

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -35,7 +35,7 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode, provider_session) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -67,6 +67,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             entry.chrome_process.take(),
             profile,
             entry_mode,
+            entry.provider_session.take(),
         )
     };
     // Registry lock released here — slow I/O below won't block other sessions.
@@ -91,6 +92,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
+    }
+    if let Some(provider_session) = provider_session {
+        crate::browser::session::provider::close_provider_session(&provider_session).await;
     }
 
     // Remove non-default profile directory after Chrome has fully exited.

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::action_result::ActionResult;
-use crate::daemon::registry::SharedRegistry;
+use crate::daemon::registry::{SessionState, SharedRegistry};
 use crate::output::ResponseContext;
 use crate::types::Mode;
 
@@ -34,35 +34,18 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let provider_session = {
-        let reg = registry.lock().await;
-        match reg.get(&cmd.session) {
-            Some(entry) => entry.provider_session.clone(),
-            None => {
-                return ActionResult::fatal_with_hint(
-                    "SESSION_NOT_FOUND",
-                    format!("session '{}' not found", cmd.session),
-                    "run `actionbook browser list-sessions` to see available sessions",
-                );
-            }
-        }
-    };
-
-    if let Some(provider_session) = provider_session.as_ref()
-        && let Err(err) =
-            crate::browser::session::provider::close_provider_session(provider_session).await
-    {
-        return ActionResult::fatal_with_hint(
-            err.error_code(),
-            format!("failed to close provider session for '{}': {err}", cmd.session),
-            err.hint(),
-        );
-    }
-
-    // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
+    // ── Phase 1: reserve the close under the registry lock. ──
+    //
+    // Grab the provider handle (if any) AND flip the entry to `Closing`
+    // atomically. A second `browser close` call arriving while the first
+    // is still mid-flight (two agents racing, a retry timer firing on
+    // top of a slow provider PUT, etc.) must NOT issue its own provider
+    // stop — once the first call succeeds the remote session is gone,
+    // and the second stop would either 404 or kill a new session that
+    // reused the same provider ID.
+    let (provider_session, prior_status) = {
         let mut reg = registry.lock().await;
-        let mut entry = match reg.remove(&cmd.session) {
+        let entry = match reg.get_mut(&cmd.session) {
             Some(e) => e,
             None => {
                 return ActionResult::fatal_with_hint(
@@ -70,6 +53,60 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                     format!("session '{}' not found", cmd.session),
                     "run `actionbook browser list-sessions` to see available sessions",
                 );
+            }
+        };
+        if entry.status == SessionState::Closing {
+            return ActionResult::fatal_with_hint(
+                "SESSION_CLOSING",
+                format!("session '{}' is already closing", cmd.session),
+                "wait for the in-flight close to finish, then run `actionbook browser list-sessions`",
+            );
+        }
+        let handle = entry.provider_session.clone();
+        let prior = entry.status;
+        entry.status = SessionState::Closing;
+        (handle, prior)
+    };
+
+    // ── Phase 2: remote provider stop (slow, network-bound). ──
+    //
+    // No lock held here — other sessions can proceed concurrently, and
+    // the short-circuit above prevents duplicate stops on *this* session.
+    if let Some(provider_session) = provider_session.as_ref()
+        && let Err(err) =
+            crate::browser::session::provider::close_provider_session(provider_session).await
+    {
+        // Revert state so the caller can retry. Without this the entry
+        // would stay stuck in Closing forever on a transient network blip.
+        {
+            let mut reg = registry.lock().await;
+            if let Some(entry) = reg.get_mut(&cmd.session) {
+                entry.status = prior_status;
+            }
+        }
+        return ActionResult::fatal_with_hint(
+            err.error_code(),
+            format!("failed to close provider session for '{}': {err}", cmd.session),
+            err.hint(),
+        );
+    }
+
+    // ── Phase 3: local teardown under the registry lock. ──
+    // Extract everything from registry then release the lock before slow I/O.
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
+        let mut reg = registry.lock().await;
+        let mut entry = match reg.remove(&cmd.session) {
+            Some(e) => e,
+            None => {
+                // Phase 1 set status=Closing, so this should be unreachable
+                // under normal operation — another path would have to forcibly
+                // evict the entry while we were in Phase 2. Treat it as success
+                // from the caller's perspective: the remote is already stopped.
+                return ActionResult::ok(json!({
+                    "session_id": cmd.session,
+                    "status": "closed",
+                    "closed_tabs": 0,
+                }));
             }
         };
         let tabs = entry.tabs_count();
@@ -160,6 +197,13 @@ mod tests {
     use crate::types::{Mode, SessionId};
 
     fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+        spawn_single_response_server_with_delay(response, Duration::from_millis(0))
+    }
+
+    fn spawn_single_response_server_with_delay(
+        response: &'static str,
+        delay: Duration,
+    ) -> (String, thread::JoinHandle<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
         let addr = listener.local_addr().expect("mock server addr");
         let handle = thread::spawn(move || {
@@ -191,6 +235,9 @@ mod tests {
                 }
             }
 
+            if !delay.is_zero() {
+                thread::sleep(delay);
+            }
             stream
                 .write_all(response.as_bytes())
                 .expect("write response");
@@ -271,7 +318,90 @@ mod tests {
         assert!(request.to_ascii_lowercase().contains("content-length: 0"));
 
         let reg = registry.lock().await;
-        assert!(reg.get("hyp1").is_some(), "session should remain for retry");
+        let entry = reg.get("hyp1").expect("session should remain for retry");
+        assert_eq!(
+            entry.status,
+            SessionState::Running,
+            "state must be reverted to Running on failure so retries can proceed",
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_close_second_caller_short_circuits() {
+        // Two simultaneous `browser close s1` calls: only the first may
+        // issue a provider stop. The second must short-circuit with
+        // SESSION_CLOSING — no duplicate PUT, no race on provider teardown.
+        //
+        // Invariant: the mock server accepts exactly one connection. If
+        // the second caller reached the provider stop path it would
+        // block forever on connect (the listener is already drained),
+        // so we wrap it in a timeout to turn that into a test failure.
+        let (base_url, request_handle) = spawn_single_response_server_with_delay(
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+            Duration::from_millis(400),
+        );
+        let registry = new_shared_registry();
+        insert_cloud_session(
+            &registry,
+            "hyp1",
+            make_provider_session(
+                "hyperbrowser",
+                "hb-session-1",
+                ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
+                ]),
+            ),
+        )
+        .await;
+
+        let reg_a = registry.clone();
+        let a_handle = tokio::spawn(async move {
+            execute(
+                &Cmd {
+                    session: "hyp1".to_string(),
+                },
+                &reg_a,
+            )
+            .await
+        });
+
+        // Give caller A time to mark the entry Closing and enter the
+        // slow provider PUT.
+        tokio::time::sleep(Duration::from_millis(75)).await;
+
+        let b_result = tokio::time::timeout(
+            Duration::from_secs(2),
+            execute(
+                &Cmd {
+                    session: "hyp1".to_string(),
+                },
+                &registry,
+            ),
+        )
+        .await
+        .expect("second caller must not block on provider stop");
+
+        match b_result {
+            ActionResult::Fatal { code, .. } => assert_eq!(code, "SESSION_CLOSING"),
+            other => panic!("expected SESSION_CLOSING fatal, got {other:?}"),
+        }
+
+        let a_result = a_handle.await.expect("join A");
+        assert!(
+            matches!(a_result, ActionResult::Ok { .. }),
+            "caller A should succeed, got {a_result:?}",
+        );
+
+        // Exactly one provider stop hit the mock server.
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-session-1/stop HTTP/1.1"));
+
+        let reg = registry.lock().await;
+        assert!(
+            reg.get("hyp1").is_none(),
+            "session should be removed after successful close",
+        );
     }
 
     #[tokio::test]

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -34,8 +34,33 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    let provider_session = {
+        let reg = registry.lock().await;
+        match reg.get(&cmd.session) {
+            Some(entry) => entry.provider_session.clone(),
+            None => {
+                return ActionResult::fatal_with_hint(
+                    "SESSION_NOT_FOUND",
+                    format!("session '{}' not found", cmd.session),
+                    "run `actionbook browser list-sessions` to see available sessions",
+                );
+            }
+        }
+    };
+
+    if let Some(provider_session) = provider_session.as_ref()
+        && let Err(err) =
+            crate::browser::session::provider::close_provider_session(provider_session).await
+    {
+        return ActionResult::fatal_with_hint(
+            err.error_code(),
+            format!("failed to close provider session for '{}': {err}", cmd.session),
+            err.hint(),
+        );
+    }
+
     // Extract everything from registry then release the lock before slow I/O.
-    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode, provider_session) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -67,7 +92,6 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             entry.chrome_process.take(),
             profile,
             entry_mode,
-            entry.provider_session.take(),
         )
     };
     // Registry lock released here — slow I/O below won't block other sessions.
@@ -92,9 +116,6 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
-    }
-    if let Some(provider_session) = provider_session {
-        crate::browser::session::provider::close_provider_session(&provider_session).await;
     }
 
     // Remove non-default profile directory after Chrome has fully exited.
@@ -124,4 +145,168 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         "status": "closed",
         "closed_tabs": closed_tabs,
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::browser::session::provider::{ProviderEnv, ProviderSession};
+    use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
+    use crate::types::{Mode, SessionId};
+
+    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        request.extend_from_slice(&buf[..n]);
+                        if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        break;
+                    }
+                    Err(err) => panic!("read request: {err}"),
+                }
+            }
+
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            String::from_utf8(request).expect("utf8 request")
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    fn make_provider_session(
+        provider: &str,
+        session_id: &str,
+        provider_env: ProviderEnv,
+    ) -> ProviderSession {
+        ProviderSession {
+            provider: provider.to_string(),
+            session_id: session_id.to_string(),
+            provider_env,
+        }
+    }
+
+    async fn insert_cloud_session(
+        registry: &crate::daemon::registry::SharedRegistry,
+        session_id: &str,
+        provider_session: ProviderSession,
+    ) {
+        let mut entry = SessionEntry::starting(
+            SessionId::new(session_id).expect("session id"),
+            Mode::Cloud,
+            true,
+            true,
+            "profile".to_string(),
+        );
+        entry.status = SessionState::Running;
+        entry.provider = Some(provider_session.provider.clone());
+        entry.provider_session = Some(provider_session);
+        registry.lock().await.insert(entry);
+    }
+
+    #[tokio::test]
+    async fn provider_close_failure_keeps_session_for_retry() {
+        let (base_url, request_handle) = spawn_single_response_server(
+            "HTTP/1.1 500 Internal Server Error\r\nContent-Length: 12\r\n\r\nbad-provider",
+        );
+        let registry = new_shared_registry();
+        insert_cloud_session(
+            &registry,
+            "hyp1",
+            make_provider_session(
+                "hyperbrowser",
+                "hb-session-1",
+                ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
+                ]),
+            ),
+        )
+        .await;
+
+        let result = execute(
+            &Cmd {
+                session: "hyp1".to_string(),
+            },
+            &registry,
+        )
+        .await;
+
+        match result {
+            ActionResult::Fatal { code, message, .. } => {
+                assert_eq!(code, "API_SERVER_ERROR");
+                assert!(message.contains("failed to close provider session"));
+                assert!(message.contains("Hyperbrowser API server error"));
+            }
+            other => panic!("expected fatal result, got {other:?}"),
+        }
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-session-1/stop HTTP/1.1"));
+        assert!(request.to_ascii_lowercase().contains("content-length: 0"));
+
+        let reg = registry.lock().await;
+        assert!(reg.get("hyp1").is_some(), "session should remain for retry");
+    }
+
+    #[tokio::test]
+    async fn provider_close_success_removes_session() {
+        let (base_url, request_handle) =
+            spawn_single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let registry = new_shared_registry();
+        insert_cloud_session(
+            &registry,
+            "hyp1",
+            make_provider_session(
+                "hyperbrowser",
+                "hb-session-1",
+                ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
+                ]),
+            ),
+        )
+        .await;
+
+        let result = execute(
+            &Cmd {
+                session: "hyp1".to_string(),
+            },
+            &registry,
+        )
+        .await;
+        assert!(matches!(result, ActionResult::Ok { .. }));
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-session-1/stop HTTP/1.1"));
+        assert!(request.to_ascii_lowercase().contains("content-length: 0"));
+
+        let reg = registry.lock().await;
+        assert!(reg.get("hyp1").is_none(), "session should be removed");
+    }
 }

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -86,7 +86,10 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         }
         return ActionResult::fatal_with_hint(
             err.error_code(),
-            format!("failed to close provider session for '{}': {err}", cmd.session),
+            format!(
+                "failed to close provider session for '{}': {err}",
+                cmd.session
+            ),
             err.hint(),
         );
     }
@@ -196,7 +199,9 @@ mod tests {
     use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
     use crate::types::{Mode, SessionId};
 
-    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+    fn spawn_single_response_server(
+        response: &'static str,
+    ) -> (String, thread::JoinHandle<String>) {
         spawn_single_response_server_with_delay(response, Duration::from_millis(0))
     }
 

--- a/packages/cli/src/browser/session/list.rs
+++ b/packages/cli/src/browser/session/list.rs
@@ -39,6 +39,9 @@ pub async fn execute(_cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             if let Some(ref ep) = s.cdp_endpoint {
                 v["cdp_endpoint"] = json!(crate::browser::session::start::redact_endpoint(ep));
             }
+            if let Some(ref provider) = s.provider {
+                v["provider"] = json!(provider);
+            }
             v
         })
         .collect();

--- a/packages/cli/src/browser/session/mod.rs
+++ b/packages/cli/src/browser/session/mod.rs
@@ -1,5 +1,6 @@
 pub mod close;
 pub mod list;
+pub mod provider;
 pub mod restart;
 pub mod start;
 pub mod status;

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -11,7 +11,11 @@ use crate::error::CliError;
 const HYPERBROWSER_API_BASE: &str = "https://api.hyperbrowser.ai";
 const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
 const BROWSER_USE_WS_BASE: &str = "wss://connect.browser-use.com";
-const DRIVER_DEV_WS_BASE: &str = "wss://cdp.driver.dev";
+// driver.dev is a stateful provider: POST /v1/browser/session mints a session
+// and returns a per-session distributed cdpUrl (e.g. wss://do-ric1-1.lex-milan.driver.dev/...).
+// We never connect directly to driver.dev/cdp; the URL is always the one the
+// API returns. Override only if you're pointing at a private control plane.
+const DRIVER_DEV_API_BASE: &str = "https://api.driver.dev";
 
 /// Per-request snapshot of provider-related environment variables, forwarded
 /// from the CLI client process to the daemon. The daemon must NOT call
@@ -21,8 +25,15 @@ pub type ProviderEnv = BTreeMap<String, String>;
 
 /// Env-var name prefixes considered "provider config". Used by the CLI client
 /// to filter `std::env::vars()` down to the values worth forwarding.
+///
+/// `DRIVER_` is intentionally broad: driver.dev's official docs use bare
+/// `DRIVER_API_KEY`, so we forward anything starting with `DRIVER_` to keep
+/// the official-name fallback working. The downside is that an unrelated tool
+/// using a `DRIVER_*` env var will leak its value into the daemon — acceptable
+/// because (a) the daemon is local to the user and (b) we never log these
+/// values, only forward them in the IPC payload.
 pub const PROVIDER_ENV_PREFIXES: &[&str] = &[
-    "DRIVER_DEV_",
+    "DRIVER_",
     "HYPERBROWSER_",
     "BROWSER_USE_",
     "BROWSERLESS_",
@@ -188,6 +199,33 @@ pub async fn close_provider_session(session: &ProviderSession) {
                 );
             }
         }
+        "driver.dev" => {
+            // driver.dev sessions auto-stop after 1h, but we explicitly DELETE
+            // them to release billing immediately. The session_id is the same
+            // opaque string returned by POST /v1/browser/session, passed back
+            // as a query parameter.
+            match read_driver_dev_api_key(env) {
+                Ok(api_key) => {
+                    let api_base = read_trimmed_env(env, "DRIVER_DEV_API_URL")
+                        .unwrap_or_else(|| DRIVER_DEV_API_BASE.to_string());
+                    let _ = client
+                        .delete(format!(
+                            "{}/v1/browser/session",
+                            api_base.trim_end_matches('/')
+                        ))
+                        .query(&[("sessionId", session.session_id.as_str())])
+                        .header("Authorization", format!("Bearer {api_key}"))
+                        .send()
+                        .await;
+                }
+                Err(_) => {
+                    tracing::warn!(
+                        "driver.dev cleanup skipped for session '{}': no API key in stored env",
+                        session.session_id
+                    );
+                }
+            }
+        }
         "browserless" => {
             // Browserless returns a stop URL; store it directly as the cleanup handle.
             let _ = client.delete(&session.session_id).send().await;
@@ -196,32 +234,150 @@ pub async fn close_provider_session(session: &ProviderSession) {
     }
 }
 
+/// driver.dev returns HTTP 500 (instead of 401) with bodies like
+/// `{"error":"Invalid consumer token"}` for bad credentials. Sniff the body
+/// so the generic 5xx → "server error, retry" mapping doesn't kick in.
+///
+/// Conservative match: only the substrings driver.dev actually uses today,
+/// so a real upstream 5xx with the word "token" in a stack trace doesn't
+/// get reclassified.
+fn is_driver_dev_auth_failure(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    lower.contains("invalid consumer token")
+        || lower.contains("invalid token")
+        || lower.contains("invalid api key")
+        || lower.contains("unauthorized")
+}
+
+/// Read the driver.dev API key. Accepts both the namespaced
+/// `DRIVER_DEV_API_KEY` (Actionbook convention) and `DRIVER_API_KEY` (driver.dev's
+/// own docs). The namespaced one takes precedence so env collisions with another
+/// "driver" tool are explicit.
+fn read_driver_dev_api_key(env: &ProviderEnv) -> Result<String, CliError> {
+    read_trimmed_env(env, "DRIVER_DEV_API_KEY")
+        .or_else(|| read_trimmed_env(env, "DRIVER_API_KEY"))
+        .ok_or_else(|| {
+            CliError::InvalidArgument(
+                "DRIVER_DEV_API_KEY (or DRIVER_API_KEY) environment variable is not set".to_string(),
+            )
+        })
+}
+
 async fn connect_driver_dev(
     profile_name: &str,
     env: &ProviderEnv,
 ) -> Result<ProviderConnection, CliError> {
-    let cdp_endpoint = if let Some(ws_url) = read_trimmed_env(env, "DRIVER_DEV_WS_URL")
+    // Escape hatch: allow a fully-qualified WSS URL to bypass the control plane.
+    // Useful for replaying captured CDP URLs in tests, or for pointing at a
+    // private deployment that exposes a CDP socket directly.
+    if let Some(ws_url) = read_trimmed_env(env, "DRIVER_DEV_WS_URL")
         .or_else(|| read_trimmed_env(env, "DRIVER_DEV_CDP_ENDPOINT"))
     {
-        ws_url
-    } else {
-        let api_key = read_required_env(env, "DRIVER_DEV_API_KEY")?;
-        let base = read_trimmed_env(env, "DRIVER_DEV_WS_BASE_URL")
-            .unwrap_or_else(|| DRIVER_DEV_WS_BASE.to_string());
-        let mut query = vec![("token", api_key)];
-        if let Some(profile) = read_trimmed_env(env, "DRIVER_DEV_PROFILE")
-            .or_else(|| non_default_profile(profile_name))
-        {
-            query.push(("profile", profile));
+        return Ok(ProviderConnection {
+            provider: "driver.dev".to_string(),
+            cdp_endpoint: ws_url,
+            headers: Vec::new(),
+            session: None,
+        });
+    }
+
+    let api_key = read_driver_dev_api_key(env)?;
+    let api_base = read_trimmed_env(env, "DRIVER_DEV_API_URL")
+        .unwrap_or_else(|| DRIVER_DEV_API_BASE.to_string());
+
+    // Build optional session-creation body. Empty `{}` is valid; only set fields
+    // when the user actually configured them.
+    let mut body = json!({});
+    if let Some(country) = read_trimmed_env(env, "DRIVER_DEV_COUNTRY") {
+        body["country"] = json!(country);
+    }
+    if let Some(node_id) = read_trimmed_env(env, "DRIVER_DEV_NODE_ID") {
+        body["nodeId"] = json!(node_id);
+    }
+    if let Some(session_type) = read_trimmed_env(env, "DRIVER_DEV_TYPE") {
+        // Driver supports `consumer_distributed` (default) and `hosted`. Pass
+        // through verbatim — the API will reject anything else.
+        body["type"] = json!(session_type);
+    }
+    if let Some(proxy_url) = read_trimmed_env(env, "DRIVER_DEV_PROXY_URL") {
+        body["proxyUrl"] = json!(proxy_url);
+    }
+    if let Some(window_size) = read_trimmed_env(env, "DRIVER_DEV_WINDOW_SIZE") {
+        body["windowSize"] = json!(window_size);
+    }
+    if let Some(profile) = read_trimmed_env(env, "DRIVER_DEV_PROFILE")
+        .or_else(|| non_default_profile(profile_name))
+    {
+        let persist = parse_env_bool(env, "DRIVER_DEV_PROFILE_PERSIST").unwrap_or(true);
+        body["profile"] = json!({
+            "name": profile,
+            "persist": persist,
+        });
+    }
+
+    let client = build_provider_http_client()?;
+    let response = client
+        .post(format!(
+            "{}/v1/browser/session",
+            api_base.trim_end_matches('/')
+        ))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let response_text = response.text().await?;
+    if !status.is_success() {
+        // driver.dev returns HTTP 500 with `{"error":"Invalid consumer token"}`
+        // for bad credentials instead of 401. Reclassify so callers (and the
+        // LLM agent) know not to retry — a "server error" wrongly suggests
+        // transient failure.
+        if is_driver_dev_auth_failure(&response_text) {
+            return Err(CliError::ApiUnauthorized(format!(
+                "driver.dev rejected credentials ({}): {}",
+                status.as_u16(),
+                response_text.chars().take(512).collect::<String>()
+            )));
         }
-        build_ws_url(&base, &query)
-    };
+        return Err(map_provider_http_status(
+            "driver.dev",
+            status,
+            &response_text,
+        ));
+    }
+
+    let data: Value = serde_json::from_str(&response_text)?;
+    let session_id = data
+        .get("sessionId")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::ApiError(format!(
+                "driver.dev API response missing sessionId: {data}"
+            ))
+        })?
+        .to_string();
+    let cdp_endpoint = data
+        .get("cdpUrl")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::ApiError(format!("driver.dev API response missing cdpUrl: {data}"))
+        })?
+        .to_string();
 
     Ok(ProviderConnection {
         provider: "driver.dev".to_string(),
         cdp_endpoint,
         headers: Vec::new(),
-        session: None,
+        session: Some(ProviderSession {
+            provider: "driver.dev".to_string(),
+            session_id,
+            // provider_env is filled in by connect_provider() so close/restart
+            // can talk to api.driver.dev later even when the calling shell
+            // no longer has DRIVER_DEV_API_KEY exported.
+            provider_env: ProviderEnv::new(),
+        }),
     })
 }
 
@@ -554,6 +710,69 @@ mod tests {
             Some(false)
         );
         assert_eq!(parse_env_bool(&env, "MISSING"), None);
+    }
+
+    #[tokio::test]
+    async fn driver_dev_ws_url_override_short_circuits_api_call() {
+        // The DRIVER_DEV_WS_URL escape hatch must bypass api.driver.dev so
+        // that offline tests / private deployments work without hitting the
+        // network. This also pins the env-map vs process-env contract: even
+        // if the daemon process has DRIVER_DEV_WS_URL exported, the per-request
+        // env map is what's used.
+        let env = env_with(&[(
+            "DRIVER_DEV_WS_URL",
+            "wss://example.test/devtools/browser/abc",
+        )]);
+        let connection = connect_driver_dev(crate::config::DEFAULT_PROFILE, &env)
+            .await
+            .expect("driver.dev connection should build from override");
+        assert_eq!(connection.provider, "driver.dev");
+        assert_eq!(
+            connection.cdp_endpoint,
+            "wss://example.test/devtools/browser/abc"
+        );
+        // Override path is "stateless"-like — no provider session to clean up.
+        assert!(connection.session.is_none());
+    }
+
+    #[test]
+    fn driver_dev_auth_failure_sniffer_catches_known_strings() {
+        assert!(is_driver_dev_auth_failure(
+            r#"{"error":"Invalid consumer token"}"#
+        ));
+        assert!(is_driver_dev_auth_failure(r#"{"error":"invalid token"}"#));
+        assert!(is_driver_dev_auth_failure(r#"{"error":"unauthorized"}"#));
+        // Not auth: a generic upstream 500 should still go through the
+        // ApiServerError path so the agent knows it's safe to retry.
+        assert!(!is_driver_dev_auth_failure(
+            r#"{"error":"upstream timeout"}"#
+        ));
+        assert!(!is_driver_dev_auth_failure(
+            r#"{"error":"node selection failed"}"#
+        ));
+    }
+
+    #[test]
+    fn driver_dev_api_key_falls_back_to_official_name() {
+        // Actionbook uses DRIVER_DEV_API_KEY to namespace; driver.dev's docs
+        // use DRIVER_API_KEY. Accept both, with the namespaced one winning.
+        let env = env_with(&[("DRIVER_API_KEY", "official-name-key")]);
+        assert_eq!(
+            read_driver_dev_api_key(&env).expect("falls back"),
+            "official-name-key"
+        );
+
+        let env = env_with(&[
+            ("DRIVER_DEV_API_KEY", "namespaced"),
+            ("DRIVER_API_KEY", "official"),
+        ]);
+        assert_eq!(
+            read_driver_dev_api_key(&env).expect("namespaced wins"),
+            "namespaced"
+        );
+
+        let env = ProviderEnv::new();
+        assert!(read_driver_dev_api_key(&env).is_err());
     }
 
     #[test]

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -1,0 +1,451 @@
+use std::env;
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+use crate::error::CliError;
+
+const HYPERBROWSER_API_BASE: &str = "https://api.hyperbrowser.ai";
+const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
+const BROWSER_USE_WS_BASE: &str = "wss://connect.browser-use.com";
+const DRIVER_DEV_WS_BASE: &str = "wss://cdp.driver.dev";
+
+/// HTTP request timeout for cloud provider control-plane API calls.
+/// Provider APIs occasionally hang; without an explicit timeout the daemon
+/// thread is stuck indefinitely waiting on `connect_provider`.
+const PROVIDER_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn build_provider_http_client() -> Result<reqwest::Client, CliError> {
+    reqwest::Client::builder()
+        .timeout(PROVIDER_HTTP_TIMEOUT)
+        .connect_timeout(Duration::from_secs(10))
+        .build()
+        .map_err(CliError::from)
+}
+
+/// Map an HTTP status code to a typed CliError so that callers (and the LLM
+/// consumer) can distinguish auth, rate-limit and server errors from generic
+/// API errors. The body is included in the message verbatim — provider APIs
+/// already redact secrets in their error responses.
+fn map_provider_http_status(provider: &str, status: StatusCode, body: &str) -> CliError {
+    let snippet = body.chars().take(512).collect::<String>();
+    match status {
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => CliError::ApiUnauthorized(format!(
+            "{provider} API rejected credentials ({}): {snippet}",
+            status.as_u16()
+        )),
+        StatusCode::TOO_MANY_REQUESTS => CliError::ApiRateLimited(format!(
+            "{provider} API rate-limited ({}): {snippet}",
+            status.as_u16()
+        )),
+        s if s.is_server_error() => CliError::ApiServerError(format!(
+            "{provider} API server error ({}): {snippet}",
+            status.as_u16()
+        )),
+        s => CliError::ApiError(format!(
+            "{provider} API error ({}): {snippet}",
+            s.as_u16()
+        )),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderSession {
+    pub provider: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProviderConnection {
+    pub provider: String,
+    pub cdp_endpoint: String,
+    pub headers: Vec<(String, String)>,
+    pub session: Option<ProviderSession>,
+}
+
+pub fn normalize_provider_name(raw: &str) -> Option<&'static str> {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "driver" | "driver.dev" => Some("driver.dev"),
+        "hyperbrowser" => Some("hyperbrowser"),
+        "browseruse" | "browser-use" => Some("browseruse"),
+        "browserless" => Some("browserless"),
+        _ => None,
+    }
+}
+
+pub fn supported_providers() -> &'static str {
+    "driver.dev, hyperbrowser, browseruse, browserless"
+}
+
+pub async fn connect_provider(
+    provider_name: &str,
+    profile_name: &str,
+    _headless: bool,
+    stealth: bool,
+) -> Result<ProviderConnection, CliError> {
+    let provider = normalize_provider_name(provider_name).ok_or_else(|| {
+        CliError::InvalidArgument(format!(
+            "unknown provider '{provider_name}'. Supported providers: {}",
+            supported_providers()
+        ))
+    })?;
+
+    match provider {
+        "driver.dev" => connect_driver_dev(profile_name).await,
+        "hyperbrowser" => connect_hyperbrowser(profile_name).await,
+        "browseruse" => connect_browser_use(profile_name).await,
+        "browserless" => connect_browserless(stealth).await,
+        _ => Err(CliError::InvalidArgument(format!(
+            "unknown provider '{provider_name}'. Supported providers: {}",
+            supported_providers()
+        ))),
+    }
+}
+
+pub async fn close_provider_session(session: &ProviderSession) {
+    // Use a short, bounded timeout for cleanup so a hung provider API can't
+    // block daemon shutdown or session restarts.
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .connect_timeout(Duration::from_secs(5))
+        .build()
+    {
+        Ok(c) => c,
+        Err(err) => {
+            tracing::warn!(
+                "failed to build cleanup client for provider '{}': {err}",
+                session.provider
+            );
+            return;
+        }
+    };
+    match session.provider.as_str() {
+        "hyperbrowser" => {
+            if let Some(api_key) = read_trimmed_env("HYPERBROWSER_API_KEY") {
+                let api_base = read_trimmed_env("HYPERBROWSER_API_URL")
+                    .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
+                let _ = client
+                    .put(format!(
+                        "{}/api/session/{}/stop",
+                        api_base.trim_end_matches('/'),
+                        session.session_id
+                    ))
+                    .header("x-api-key", api_key)
+                    .send()
+                    .await;
+            }
+        }
+        "browserless" => {
+            // Browserless returns a stop URL; store it directly as the cleanup handle.
+            let _ = client.delete(&session.session_id).send().await;
+        }
+        _ => {}
+    }
+}
+
+async fn connect_driver_dev(profile_name: &str) -> Result<ProviderConnection, CliError> {
+    let cdp_endpoint = if let Some(ws_url) = read_trimmed_env("DRIVER_DEV_WS_URL")
+        .or_else(|| read_trimmed_env("DRIVER_DEV_CDP_ENDPOINT"))
+    {
+        ws_url
+    } else {
+        let api_key = read_required_env("DRIVER_DEV_API_KEY")?;
+        let base = read_trimmed_env("DRIVER_DEV_WS_BASE_URL")
+            .unwrap_or_else(|| DRIVER_DEV_WS_BASE.to_string());
+        let mut query = vec![("token", api_key)];
+        if let Some(profile) =
+            read_trimmed_env("DRIVER_DEV_PROFILE").or_else(|| non_default_profile(profile_name))
+        {
+            query.push(("profile", profile));
+        }
+        build_ws_url(&base, &query)
+    };
+
+    Ok(ProviderConnection {
+        provider: "driver.dev".to_string(),
+        cdp_endpoint,
+        headers: Vec::new(),
+        session: None,
+    })
+}
+
+async fn connect_hyperbrowser(profile_name: &str) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env("HYPERBROWSER_API_KEY")?;
+    let api_base = read_trimmed_env("HYPERBROWSER_API_URL")
+        .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
+    let use_proxy = parse_env_bool("HYPERBROWSER_USE_PROXY").unwrap_or(false);
+    let persist_changes = parse_env_bool("HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
+    let profile_id =
+        read_trimmed_env("HYPERBROWSER_PROFILE_ID").or_else(|| non_default_profile(profile_name));
+
+    let mut body = json!({ "useProxy": use_proxy });
+    if let Some(profile_id) = profile_id {
+        body["profile"] = json!({
+            "id": normalize_hyperbrowser_profile_id(&profile_id)?,
+            "persistChanges": persist_changes,
+        });
+    }
+
+    let client = build_provider_http_client()?;
+    let response = client
+        .post(format!("{}/api/session", api_base.trim_end_matches('/')))
+        .header("x-api-key", &api_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let response_text = response.text().await?;
+    if !status.is_success() {
+        return Err(map_provider_http_status(
+            "Hyperbrowser",
+            status,
+            &response_text,
+        ));
+    }
+
+    let data: Value = serde_json::from_str(&response_text)?;
+    let session_id = data
+        .get("id")
+        .or_else(|| data.get("sessionId"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::ApiError(format!(
+                "Hyperbrowser API returned incomplete session data: {data}"
+            ))
+        })?
+        .to_string();
+    let cdp_endpoint = data
+        .get("wsEndpoint")
+        .or_else(|| data.get("sessionWebsocketUrl"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::ApiError(format!(
+                "Hyperbrowser API returned incomplete session data: {data}"
+            ))
+        })?
+        .to_string();
+
+    Ok(ProviderConnection {
+        provider: "hyperbrowser".to_string(),
+        cdp_endpoint,
+        headers: Vec::new(),
+        session: Some(ProviderSession {
+            provider: "hyperbrowser".to_string(),
+            session_id,
+        }),
+    })
+}
+
+async fn connect_browser_use(profile_name: &str) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env("BROWSER_USE_API_KEY")?;
+    let base =
+        read_trimmed_env("BROWSER_USE_WS_URL").unwrap_or_else(|| BROWSER_USE_WS_BASE.to_string());
+
+    let mut query = vec![("apiKey", api_key)];
+    if let Some(value) = read_trimmed_env("BROWSER_USE_PROXY_COUNTRY_CODE") {
+        query.push(("proxyCountryCode", value));
+    }
+    if let Some(value) =
+        read_trimmed_env("BROWSER_USE_PROFILE_ID").or_else(|| non_default_profile(profile_name))
+    {
+        query.push(("profileId", value));
+    }
+    if let Some(value) = read_trimmed_env("BROWSER_USE_TIMEOUT") {
+        query.push(("timeout", value));
+    }
+    if let Some(value) = read_trimmed_env("BROWSER_USE_BROWSER_SCREEN_WIDTH") {
+        query.push(("browserScreenWidth", value));
+    }
+    if let Some(value) = read_trimmed_env("BROWSER_USE_BROWSER_SCREEN_HEIGHT") {
+        query.push(("browserScreenHeight", value));
+    }
+
+    Ok(ProviderConnection {
+        provider: "browseruse".to_string(),
+        cdp_endpoint: build_ws_url(&base, &query),
+        headers: Vec::new(),
+        session: None,
+    })
+}
+
+async fn connect_browserless(stealth: bool) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env("BROWSERLESS_API_KEY")?;
+    let api_base =
+        read_trimmed_env("BROWSERLESS_API_URL").unwrap_or_else(|| BROWSERLESS_API_BASE.to_string());
+    let browser_type =
+        read_trimmed_env("BROWSERLESS_BROWSER_TYPE").unwrap_or_else(|| "chromium".to_string());
+    let ttl = read_trimmed_env("BROWSERLESS_TTL").unwrap_or_else(|| "300000".to_string());
+    let use_stealth = parse_env_bool("BROWSERLESS_STEALTH").unwrap_or(stealth);
+
+    if !matches!(browser_type.as_str(), "chromium" | "chrome") {
+        return Err(CliError::InvalidArgument(format!(
+            "BROWSERLESS_BROWSER_TYPE '{browser_type}' is not supported; use chromium or chrome"
+        )));
+    }
+
+    let client = build_provider_http_client()?;
+    let response = client
+        .post(format!("{}/session", api_base.trim_end_matches('/')))
+        .query(&[("token", api_key.as_str())])
+        .header("Content-Type", "application/json")
+        .json(&json!({
+            "ttl": ttl.parse::<u64>().map_err(|_| {
+                CliError::InvalidArgument(format!("invalid BROWSERLESS_TTL: {ttl}"))
+            })?,
+            "stealth": use_stealth,
+            "browser": browser_type,
+        }))
+        .send()
+        .await?;
+
+    let status = response.status();
+    let response_text = response.text().await?;
+    if !status.is_success() {
+        return Err(map_provider_http_status(
+            "Browserless",
+            status,
+            &response_text,
+        ));
+    }
+
+    let data: Value = serde_json::from_str(&response_text)?;
+    let cdp_endpoint = data
+        .get("connect")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CliError::ApiError("Browserless response missing 'connect' URL".to_string())
+        })?
+        .to_string();
+    let stop_url = data
+        .get("stop")
+        .and_then(Value::as_str)
+        .ok_or_else(|| CliError::ApiError("Browserless response missing 'stop' URL".to_string()))?
+        .to_string();
+
+    Ok(ProviderConnection {
+        provider: "browserless".to_string(),
+        cdp_endpoint,
+        headers: Vec::new(),
+        session: Some(ProviderSession {
+            provider: "browserless".to_string(),
+            session_id: stop_url,
+        }),
+    })
+}
+
+fn build_ws_url(base: &str, query: &[(&str, String)]) -> String {
+    if query.is_empty() {
+        return base.to_string();
+    }
+
+    let separator = if base.contains('?') { '&' } else { '?' };
+    let query_string = query
+        .iter()
+        .map(|(key, value)| format!("{key}={}", urlencoding::encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{base}{separator}{query_string}")
+}
+
+fn read_trimmed_env(name: &str) -> Option<String> {
+    env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+fn read_required_env(name: &str) -> Result<String, CliError> {
+    read_trimmed_env(name)
+        .ok_or_else(|| CliError::InvalidArgument(format!("{name} environment variable is not set")))
+}
+
+fn parse_env_bool(name: &str) -> Option<bool> {
+    read_trimmed_env(name).and_then(|value| match value.to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Some(true),
+        "0" | "false" | "no" | "off" => Some(false),
+        _ => None,
+    })
+}
+
+fn non_default_profile(profile_name: &str) -> Option<String> {
+    let trimmed = profile_name.trim();
+    if trimmed.is_empty() || trimmed == crate::config::DEFAULT_PROFILE {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn normalize_hyperbrowser_profile_id(profile_id: &str) -> Result<String, CliError> {
+    let raw = profile_id.trim();
+    if raw.is_empty() {
+        return Err(CliError::InvalidArgument(
+            "hyperbrowser profile id must not be empty".to_string(),
+        ));
+    }
+
+    match Uuid::parse_str(raw) {
+        Ok(uuid) => Ok(uuid.to_string()),
+        Err(_) => Ok(
+            Uuid::new_v5(&Uuid::NAMESPACE_URL, format!("actionbook:{raw}").as_bytes()).to_string(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_provider_aliases() {
+        assert_eq!(normalize_provider_name("driver"), Some("driver.dev"));
+        assert_eq!(normalize_provider_name("driver.dev"), Some("driver.dev"));
+        assert_eq!(normalize_provider_name("browser-use"), Some("browseruse"));
+        assert_eq!(normalize_provider_name("browseruse"), Some("browseruse"));
+        assert_eq!(
+            normalize_provider_name("hyperbrowser"),
+            Some("hyperbrowser")
+        );
+        assert_eq!(normalize_provider_name("browserless"), Some("browserless"));
+        assert_eq!(normalize_provider_name("unknown"), None);
+    }
+
+    #[test]
+    fn builds_ws_urls_with_query_parameters() {
+        let url = build_ws_url(
+            "wss://connect.browser-use.com",
+            &[
+                ("apiKey", "key-123".to_string()),
+                ("proxyCountryCode", "us".to_string()),
+            ],
+        );
+
+        assert_eq!(
+            url,
+            "wss://connect.browser-use.com?apiKey=key-123&proxyCountryCode=us"
+        );
+    }
+
+    #[test]
+    fn hyperbrowser_profile_ids_are_normalized_to_uuid() {
+        let normalized = normalize_hyperbrowser_profile_id("user-42").expect("normalized uuid");
+        assert!(Uuid::parse_str(&normalized).is_ok());
+        assert_eq!(
+            normalized,
+            Uuid::new_v5(&Uuid::NAMESPACE_URL, b"actionbook:user-42").to_string()
+        );
+    }
+
+    #[test]
+    fn keeps_explicit_uuid_profile_ids() {
+        let raw = "550e8400-e29b-41d4-a716-446655440000";
+        assert_eq!(
+            normalize_hyperbrowser_profile_id(raw).expect("uuid"),
+            raw.to_string()
+        );
+    }
+}

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
-use reqwest::header::CONTENT_LENGTH;
 use reqwest::StatusCode;
+use reqwest::header::CONTENT_LENGTH;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
@@ -32,11 +32,7 @@ pub type ProviderEnv = BTreeMap<String, String>;
 /// using a `DRIVER_*` env var will leak its value into the daemon — acceptable
 /// because (a) the daemon is local to the user and (b) we never log these
 /// values, only forward them in the IPC payload.
-pub const PROVIDER_ENV_PREFIXES: &[&str] = &[
-    "DRIVER_",
-    "HYPERBROWSER_",
-    "BROWSER_USE_",
-];
+pub const PROVIDER_ENV_PREFIXES: &[&str] = &["DRIVER_", "HYPERBROWSER_", "BROWSER_USE_"];
 
 /// Collect every env var on the current process whose name starts with one of
 /// the provider prefixes. Called from the CLI client (NOT the daemon) right
@@ -83,10 +79,7 @@ fn map_provider_http_status(provider: &str, status: StatusCode, body: &str) -> C
             "{provider} API server error ({}): {snippet}",
             status.as_u16()
         )),
-        s => CliError::ApiError(format!(
-            "{provider} API error ({}): {snippet}",
-            s.as_u16()
-        )),
+        s => CliError::ApiError(format!("{provider} API error ({}): {snippet}", s.as_u16())),
     }
 }
 
@@ -297,7 +290,8 @@ fn read_driver_dev_api_key(env: &ProviderEnv) -> Result<String, CliError> {
         .or_else(|| read_trimmed_env(env, "DRIVER_API_KEY"))
         .ok_or_else(|| {
             CliError::InvalidArgument(
-                "DRIVER_DEV_API_KEY (or DRIVER_API_KEY) environment variable is not set".to_string(),
+                "DRIVER_DEV_API_KEY (or DRIVER_API_KEY) environment variable is not set"
+                    .to_string(),
             )
         })
 }
@@ -344,8 +338,8 @@ async fn connect_driver_dev(
     if let Some(window_size) = read_trimmed_env(env, "DRIVER_DEV_WINDOW_SIZE") {
         body["windowSize"] = json!(window_size);
     }
-    if let Some(profile) = read_trimmed_env(env, "DRIVER_DEV_PROFILE")
-        .or_else(|| non_default_profile(profile_name))
+    if let Some(profile) =
+        read_trimmed_env(env, "DRIVER_DEV_PROFILE").or_else(|| non_default_profile(profile_name))
     {
         let persist = parse_env_bool(env, "DRIVER_DEV_PROFILE_PERSIST").unwrap_or(true);
         body["profile"] = json!({
@@ -394,9 +388,7 @@ async fn connect_driver_dev(
     let cdp_endpoint = data
         .get("cdpUrl")
         .and_then(Value::as_str)
-        .ok_or_else(|| {
-            CliError::ApiError(format!("driver API response missing cdpUrl: {data}"))
-        })?
+        .ok_or_else(|| CliError::ApiError(format!("driver API response missing cdpUrl: {data}")))?
         .to_string();
 
     Ok(ProviderConnection {
@@ -635,7 +627,9 @@ mod tests {
 
     use super::*;
 
-    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+    fn spawn_single_response_server(
+        response: &'static str,
+    ) -> (String, thread::JoinHandle<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
         let addr = listener.local_addr().expect("mock server addr");
         let handle = thread::spawn(move || {
@@ -820,9 +814,15 @@ mod tests {
             .await
             .expect("browseruse connection");
         assert_eq!(connection.provider, "browseruse");
-        assert_eq!(connection.cdp_endpoint, "wss://cdp.browser-use.test/session-1");
         assert_eq!(
-            connection.session.as_ref().map(|session| session.session_id.as_str()),
+            connection.cdp_endpoint,
+            "wss://cdp.browser-use.test/session-1"
+        );
+        assert_eq!(
+            connection
+                .session
+                .as_ref()
+                .map(|session| session.session_id.as_str()),
             Some("bu-s-1")
         );
 

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -136,7 +136,10 @@ pub async fn connect_provider(
         ))
     })?;
 
-    let mut connection = match provider {
+    // Each helper stamps `env` directly onto its `ProviderSession` so the
+    // descriptor is always fully populated when it leaves the helper. No
+    // post-hoc fix-up is needed here.
+    let connection = match provider {
         "driver" => connect_driver_dev(profile_name, env).await?,
         "hyperbrowser" => connect_hyperbrowser(profile_name, env).await?,
         "browseruse" => connect_browser_use(profile_name, env).await?,
@@ -148,12 +151,6 @@ pub async fn connect_provider(
         }
     };
 
-    // Persist the env snapshot on the session descriptor so close/restart can
-    // talk to the provider's control plane later, even if the calling shell
-    // no longer has the keys exported.
-    if let Some(session) = connection.session.as_mut() {
-        session.provider_env = env.clone();
-    }
     Ok(connection)
 }
 
@@ -267,12 +264,28 @@ pub async fn close_provider_session(session: &ProviderSession) -> Result<(), Cli
 /// Conservative match: only the substrings driver.dev actually uses today,
 /// so a real upstream 5xx with the word "token" in a stack trace doesn't
 /// get reclassified.
+///
+/// Both branches log at info level so we can tell from daemon logs which
+/// classification fired when a user reports "I set the key but keep getting
+/// server error" (or vice versa). We only log a short prefix of the body to
+/// avoid leaking anything sensitive that upstream might echo back.
 fn is_driver_dev_auth_failure(body: &str) -> bool {
     let lower = body.to_ascii_lowercase();
-    lower.contains("invalid consumer token")
+    let hit = lower.contains("invalid consumer token")
         || lower.contains("invalid token")
         || lower.contains("invalid api key")
-        || lower.contains("unauthorized")
+        || lower.contains("unauthorized");
+    let snippet: String = body.chars().take(120).collect();
+    if hit {
+        tracing::info!(
+            "driver.dev response classified as auth failure (→ ApiUnauthorized): {snippet}"
+        );
+    } else {
+        tracing::info!(
+            "driver.dev response classified as server error (→ ApiServerError): {snippet}"
+        );
+    }
+    hit
 }
 
 /// Read the driver.dev API key. Accepts both the namespaced
@@ -393,10 +406,10 @@ async fn connect_driver_dev(
         session: Some(ProviderSession {
             provider: "driver".to_string(),
             session_id,
-            // provider_env is filled in by connect_provider() so close/restart
-            // can talk to api.driver.dev later even when the calling shell
-            // no longer has DRIVER_DEV_API_KEY exported.
-            provider_env: ProviderEnv::new(),
+            // Snapshot the env so close/restart can talk to api.driver.dev
+            // later even when the calling shell no longer has
+            // DRIVER_DEV_API_KEY exported.
+            provider_env: env.clone(),
         }),
     })
 }
@@ -469,7 +482,7 @@ async fn connect_hyperbrowser(
         session: Some(ProviderSession {
             provider: "hyperbrowser".to_string(),
             session_id,
-            provider_env: ProviderEnv::new(),
+            provider_env: env.clone(),
         }),
     })
 }
@@ -558,7 +571,7 @@ async fn connect_browser_use(
         session: Some(ProviderSession {
             provider: "browseruse".to_string(),
             session_id,
-            provider_env: ProviderEnv::new(),
+            provider_env: env.clone(),
         }),
     })
 }

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use reqwest::header::CONTENT_LENGTH;
 use reqwest::StatusCode;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -9,8 +10,7 @@ use uuid::Uuid;
 use crate::error::CliError;
 
 const HYPERBROWSER_API_BASE: &str = "https://api.hyperbrowser.ai";
-const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
-const BROWSER_USE_WS_BASE: &str = "wss://connect.browser-use.com";
+const BROWSER_USE_API_BASE: &str = "https://api.browser-use.com/api/v3";
 // driver.dev is a stateful provider: POST /v1/browser/session mints a session
 // and returns a per-session distributed cdpUrl (e.g. wss://do-ric1-1.lex-milan.driver.dev/...).
 // We never connect directly to driver.dev/cdp; the URL is always the one the
@@ -36,7 +36,6 @@ pub const PROVIDER_ENV_PREFIXES: &[&str] = &[
     "DRIVER_",
     "HYPERBROWSER_",
     "BROWSER_USE_",
-    "BROWSERLESS_",
 ];
 
 /// Collect every env var on the current process whose name starts with one of
@@ -112,23 +111,22 @@ pub struct ProviderConnection {
 
 pub fn normalize_provider_name(raw: &str) -> Option<&'static str> {
     match raw.trim().to_ascii_lowercase().as_str() {
-        "driver" | "driver.dev" => Some("driver.dev"),
+        "driver" => Some("driver"),
         "hyperbrowser" => Some("hyperbrowser"),
         "browseruse" | "browser-use" => Some("browseruse"),
-        "browserless" => Some("browserless"),
         _ => None,
     }
 }
 
 pub fn supported_providers() -> &'static str {
-    "driver.dev, hyperbrowser, browseruse, browserless"
+    "driver, hyperbrowser, browseruse"
 }
 
 pub async fn connect_provider(
     provider_name: &str,
     profile_name: &str,
     _headless: bool,
-    stealth: bool,
+    _stealth: bool,
     env: &ProviderEnv,
 ) -> Result<ProviderConnection, CliError> {
     let provider = normalize_provider_name(provider_name).ok_or_else(|| {
@@ -139,10 +137,9 @@ pub async fn connect_provider(
     })?;
 
     let mut connection = match provider {
-        "driver.dev" => connect_driver_dev(profile_name, env).await?,
+        "driver" => connect_driver_dev(profile_name, env).await?,
         "hyperbrowser" => connect_hyperbrowser(profile_name, env).await?,
         "browseruse" => connect_browser_use(profile_name, env).await?,
-        "browserless" => connect_browserless(stealth, env).await?,
         _ => {
             return Err(CliError::InvalidArgument(format!(
                 "unknown provider '{provider_name}'. Supported providers: {}",
@@ -160,7 +157,7 @@ pub async fn connect_provider(
     Ok(connection)
 }
 
-pub async fn close_provider_session(session: &ProviderSession) {
+pub async fn close_provider_session(session: &ProviderSession) -> Result<(), CliError> {
     // Use a short, bounded timeout for cleanup so a hung provider API can't
     // block daemon shutdown or session restarts.
     let client = match reqwest::Client::builder()
@@ -169,37 +166,37 @@ pub async fn close_provider_session(session: &ProviderSession) {
         .build()
     {
         Ok(c) => c,
-        Err(err) => {
-            tracing::warn!(
-                "failed to build cleanup client for provider '{}': {err}",
-                session.provider
-            );
-            return;
-        }
+        Err(err) => return Err(CliError::from(err)),
     };
     let env = &session.provider_env;
     match session.provider.as_str() {
         "hyperbrowser" => {
-            if let Some(api_key) = read_trimmed_env(env, "HYPERBROWSER_API_KEY") {
-                let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
-                    .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
-                let _ = client
-                    .put(format!(
-                        "{}/api/session/{}/stop",
-                        api_base.trim_end_matches('/'),
-                        session.session_id
-                    ))
-                    .header("x-api-key", api_key)
-                    .send()
-                    .await;
-            } else {
-                tracing::warn!(
-                    "hyperbrowser cleanup skipped for session '{}': no API key in stored env",
+            let api_key = read_required_env(env, "HYPERBROWSER_API_KEY")?;
+            let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
+                .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
+            let response = client
+                .put(format!(
+                    "{}/api/session/{}/stop",
+                    api_base.trim_end_matches('/'),
                     session.session_id
-                );
+                ))
+                .header("x-api-key", api_key)
+                // Hyperbrowser's edge rejects empty stop requests unless the
+                // client sends an explicit zero-length Content-Length header.
+                .header(CONTENT_LENGTH, "0")
+                .send()
+                .await?;
+            let status = response.status();
+            let response_text = response.text().await?;
+            if !status.is_success() {
+                return Err(map_provider_http_status(
+                    "Hyperbrowser",
+                    status,
+                    &response_text,
+                ));
             }
         }
-        "driver.dev" => {
+        "driver" => {
             // driver.dev sessions auto-stop after 1h, but we explicitly DELETE
             // them to release billing immediately. The session_id is the same
             // opaque string returned by POST /v1/browser/session, passed back
@@ -208,7 +205,7 @@ pub async fn close_provider_session(session: &ProviderSession) {
                 Ok(api_key) => {
                     let api_base = read_trimmed_env(env, "DRIVER_DEV_API_URL")
                         .unwrap_or_else(|| DRIVER_DEV_API_BASE.to_string());
-                    let _ = client
+                    let response = client
                         .delete(format!(
                             "{}/v1/browser/session",
                             api_base.trim_end_matches('/')
@@ -216,22 +213,51 @@ pub async fn close_provider_session(session: &ProviderSession) {
                         .query(&[("sessionId", session.session_id.as_str())])
                         .header("Authorization", format!("Bearer {api_key}"))
                         .send()
-                        .await;
+                        .await?;
+                    let status = response.status();
+                    let response_text = response.text().await?;
+                    if !status.is_success() {
+                        if is_driver_dev_auth_failure(&response_text) {
+                            return Err(CliError::ApiUnauthorized(format!(
+                                "driver rejected credentials ({}): {}",
+                                status.as_u16(),
+                                response_text.chars().take(512).collect::<String>()
+                            )));
+                        }
+                        return Err(map_provider_http_status("driver", status, &response_text));
+                    }
                 }
-                Err(_) => {
-                    tracing::warn!(
-                        "driver.dev cleanup skipped for session '{}': no API key in stored env",
-                        session.session_id
-                    );
-                }
+                Err(err) => return Err(err),
             }
         }
-        "browserless" => {
-            // Browserless returns a stop URL; store it directly as the cleanup handle.
-            let _ = client.delete(&session.session_id).send().await;
+        "browseruse" => {
+            let api_key = read_required_env(env, "BROWSER_USE_API_KEY")?;
+            let api_base = read_trimmed_env(env, "BROWSER_USE_API_URL")
+                .unwrap_or_else(|| BROWSER_USE_API_BASE.to_string());
+            let response = client
+                .patch(format!(
+                    "{}/browsers/{}",
+                    api_base.trim_end_matches('/'),
+                    session.session_id
+                ))
+                .header("X-Browser-Use-API-Key", api_key)
+                .header("Content-Type", "application/json")
+                .json(&json!({ "action": "stop" }))
+                .send()
+                .await?;
+            let status = response.status();
+            let response_text = response.text().await?;
+            if !status.is_success() {
+                return Err(map_provider_http_status(
+                    "Browser Use",
+                    status,
+                    &response_text,
+                ));
+            }
         }
         _ => {}
     }
+    Ok(())
 }
 
 /// driver.dev returns HTTP 500 (instead of 401) with bodies like
@@ -274,7 +300,7 @@ async fn connect_driver_dev(
         .or_else(|| read_trimmed_env(env, "DRIVER_DEV_CDP_ENDPOINT"))
     {
         return Ok(ProviderConnection {
-            provider: "driver.dev".to_string(),
+            provider: "driver".to_string(),
             cdp_endpoint: ws_url,
             headers: Vec::new(),
             session: None,
@@ -336,16 +362,12 @@ async fn connect_driver_dev(
         // transient failure.
         if is_driver_dev_auth_failure(&response_text) {
             return Err(CliError::ApiUnauthorized(format!(
-                "driver.dev rejected credentials ({}): {}",
+                "driver rejected credentials ({}): {}",
                 status.as_u16(),
                 response_text.chars().take(512).collect::<String>()
             )));
         }
-        return Err(map_provider_http_status(
-            "driver.dev",
-            status,
-            &response_text,
-        ));
+        return Err(map_provider_http_status("driver", status, &response_text));
     }
 
     let data: Value = serde_json::from_str(&response_text)?;
@@ -353,25 +375,23 @@ async fn connect_driver_dev(
         .get("sessionId")
         .and_then(Value::as_str)
         .ok_or_else(|| {
-            CliError::ApiError(format!(
-                "driver.dev API response missing sessionId: {data}"
-            ))
+            CliError::ApiError(format!("driver API response missing sessionId: {data}"))
         })?
         .to_string();
     let cdp_endpoint = data
         .get("cdpUrl")
         .and_then(Value::as_str)
         .ok_or_else(|| {
-            CliError::ApiError(format!("driver.dev API response missing cdpUrl: {data}"))
+            CliError::ApiError(format!("driver API response missing cdpUrl: {data}"))
         })?
         .to_string();
 
     Ok(ProviderConnection {
-        provider: "driver.dev".to_string(),
+        provider: "driver".to_string(),
         cdp_endpoint,
         headers: Vec::new(),
         session: Some(ProviderSession {
-            provider: "driver.dev".to_string(),
+            provider: "driver".to_string(),
             session_id,
             // provider_env is filled in by connect_provider() so close/restart
             // can talk to api.driver.dev later even when the calling shell
@@ -458,67 +478,46 @@ async fn connect_browser_use(
     profile_name: &str,
     env: &ProviderEnv,
 ) -> Result<ProviderConnection, CliError> {
-    let api_key = read_required_env(env, "BROWSER_USE_API_KEY")?;
-    let base = read_trimmed_env(env, "BROWSER_USE_WS_URL")
-        .unwrap_or_else(|| BROWSER_USE_WS_BASE.to_string());
+    if let Some(ws_url) = read_trimmed_env(env, "BROWSER_USE_WS_URL") {
+        return Ok(ProviderConnection {
+            provider: "browseruse".to_string(),
+            cdp_endpoint: ws_url,
+            headers: Vec::new(),
+            session: None,
+        });
+    }
 
-    let mut query = vec![("apiKey", api_key)];
+    let api_key = read_required_env(env, "BROWSER_USE_API_KEY")?;
+    let api_base = read_trimmed_env(env, "BROWSER_USE_API_URL")
+        .unwrap_or_else(|| BROWSER_USE_API_BASE.to_string());
+
+    let mut body = json!({});
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
-        query.push(("proxyCountryCode", value));
+        body["proxyCountryCode"] = json!(value);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROFILE_ID")
         .or_else(|| non_default_profile(profile_name))
     {
-        query.push(("profileId", value));
+        body["profileId"] = json!(value);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_TIMEOUT") {
-        query.push(("timeout", value));
+        body["timeout"] = json!(parse_env_u64("BROWSER_USE_TIMEOUT", &value)?);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_BROWSER_SCREEN_WIDTH") {
-        query.push(("browserScreenWidth", value));
+        body["browserScreenWidth"] =
+            json!(parse_env_u64("BROWSER_USE_BROWSER_SCREEN_WIDTH", &value)?);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_BROWSER_SCREEN_HEIGHT") {
-        query.push(("browserScreenHeight", value));
-    }
-
-    Ok(ProviderConnection {
-        provider: "browseruse".to_string(),
-        cdp_endpoint: build_ws_url(&base, &query),
-        headers: Vec::new(),
-        session: None,
-    })
-}
-
-async fn connect_browserless(
-    stealth: bool,
-    env: &ProviderEnv,
-) -> Result<ProviderConnection, CliError> {
-    let api_key = read_required_env(env, "BROWSERLESS_API_KEY")?;
-    let api_base = read_trimmed_env(env, "BROWSERLESS_API_URL")
-        .unwrap_or_else(|| BROWSERLESS_API_BASE.to_string());
-    let browser_type = read_trimmed_env(env, "BROWSERLESS_BROWSER_TYPE")
-        .unwrap_or_else(|| "chromium".to_string());
-    let ttl = read_trimmed_env(env, "BROWSERLESS_TTL").unwrap_or_else(|| "300000".to_string());
-    let use_stealth = parse_env_bool(env, "BROWSERLESS_STEALTH").unwrap_or(stealth);
-
-    if !matches!(browser_type.as_str(), "chromium" | "chrome") {
-        return Err(CliError::InvalidArgument(format!(
-            "BROWSERLESS_BROWSER_TYPE '{browser_type}' is not supported; use chromium or chrome"
-        )));
+        body["browserScreenHeight"] =
+            json!(parse_env_u64("BROWSER_USE_BROWSER_SCREEN_HEIGHT", &value)?);
     }
 
     let client = build_provider_http_client()?;
     let response = client
-        .post(format!("{}/session", api_base.trim_end_matches('/')))
-        .query(&[("token", api_key.as_str())])
+        .post(format!("{}/browsers", api_base.trim_end_matches('/')))
+        .header("X-Browser-Use-API-Key", &api_key)
         .header("Content-Type", "application/json")
-        .json(&json!({
-            "ttl": ttl.parse::<u64>().map_err(|_| {
-                CliError::InvalidArgument(format!("invalid BROWSERLESS_TTL: {ttl}"))
-            })?,
-            "stealth": use_stealth,
-            "browser": browser_type,
-        }))
+        .json(&body)
         .send()
         .await?;
 
@@ -526,50 +525,42 @@ async fn connect_browserless(
     let response_text = response.text().await?;
     if !status.is_success() {
         return Err(map_provider_http_status(
-            "Browserless",
+            "Browser Use",
             status,
             &response_text,
         ));
     }
 
     let data: Value = serde_json::from_str(&response_text)?;
-    let cdp_endpoint = data
-        .get("connect")
+    let session_id = data
+        .get("id")
         .and_then(Value::as_str)
         .ok_or_else(|| {
-            CliError::ApiError("Browserless response missing 'connect' URL".to_string())
+            CliError::ApiError(format!(
+                "Browser Use API returned incomplete session data: {data}"
+            ))
         })?
         .to_string();
-    let stop_url = data
-        .get("stop")
+    let cdp_endpoint = data
+        .get("cdpUrl")
         .and_then(Value::as_str)
-        .ok_or_else(|| CliError::ApiError("Browserless response missing 'stop' URL".to_string()))?
+        .ok_or_else(|| {
+            CliError::ApiError(format!(
+                "Browser Use API returned incomplete session data: {data}"
+            ))
+        })?
         .to_string();
 
     Ok(ProviderConnection {
-        provider: "browserless".to_string(),
+        provider: "browseruse".to_string(),
         cdp_endpoint,
         headers: Vec::new(),
         session: Some(ProviderSession {
-            provider: "browserless".to_string(),
-            session_id: stop_url,
+            provider: "browseruse".to_string(),
+            session_id,
             provider_env: ProviderEnv::new(),
         }),
     })
-}
-
-fn build_ws_url(base: &str, query: &[(&str, String)]) -> String {
-    if query.is_empty() {
-        return base.to_string();
-    }
-
-    let separator = if base.contains('?') { '&' } else { '?' };
-    let query_string = query
-        .iter()
-        .map(|(key, value)| format!("{key}={}", urlencoding::encode(value)))
-        .collect::<Vec<_>>()
-        .join("&");
-    format!("{base}{separator}{query_string}")
 }
 
 fn read_trimmed_env(env: &ProviderEnv, name: &str) -> Option<String> {
@@ -589,6 +580,12 @@ fn parse_env_bool(env: &ProviderEnv, name: &str) -> Option<bool> {
         "0" | "false" | "no" | "off" => Some(false),
         _ => None,
     })
+}
+
+fn parse_env_u64(name: &str, value: &str) -> Result<u64, CliError> {
+    value
+        .parse::<u64>()
+        .map_err(|_| CliError::InvalidArgument(format!("invalid {name}: {value}")))
 }
 
 fn non_default_profile(profile_name: &str) -> Option<String> {
@@ -618,36 +615,80 @@ fn normalize_hyperbrowser_profile_id(profile_id: &str) -> Result<String, CliErro
 
 #[cfg(test)]
 mod tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
     use super::*;
+
+    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        request.extend_from_slice(&buf[..n]);
+                        if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        break;
+                    }
+                    Err(err) => panic!("read request: {err}"),
+                }
+            }
+
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            String::from_utf8(request).expect("utf8 request")
+        });
+        (format!("http://{}", addr), handle)
+    }
 
     #[test]
     fn normalizes_provider_aliases() {
-        assert_eq!(normalize_provider_name("driver"), Some("driver.dev"));
-        assert_eq!(normalize_provider_name("driver.dev"), Some("driver.dev"));
+        assert_eq!(normalize_provider_name("driver"), Some("driver"));
         assert_eq!(normalize_provider_name("browser-use"), Some("browseruse"));
         assert_eq!(normalize_provider_name("browseruse"), Some("browseruse"));
         assert_eq!(
             normalize_provider_name("hyperbrowser"),
             Some("hyperbrowser")
         );
-        assert_eq!(normalize_provider_name("browserless"), Some("browserless"));
+        assert_eq!(normalize_provider_name("driver.dev"), None);
         assert_eq!(normalize_provider_name("unknown"), None);
     }
 
-    #[test]
-    fn builds_ws_urls_with_query_parameters() {
-        let url = build_ws_url(
-            "wss://connect.browser-use.com",
-            &[
-                ("apiKey", "key-123".to_string()),
-                ("proxyCountryCode", "us".to_string()),
-            ],
-        );
+    #[tokio::test]
+    async fn driver_dev_provider_name_is_rejected() {
+        let err = connect_provider(
+            "driver.dev",
+            crate::config::DEFAULT_PROFILE,
+            false,
+            true,
+            &ProviderEnv::new(),
+        )
+        .await
+        .expect_err("driver.dev alias should be rejected");
 
-        assert_eq!(
-            url,
-            "wss://connect.browser-use.com?apiKey=key-123&proxyCountryCode=us"
-        );
+        assert!(matches!(err, CliError::InvalidArgument(_)));
+        assert!(err.to_string().contains("unknown provider 'driver.dev'"));
     }
 
     #[test]
@@ -726,13 +767,137 @@ mod tests {
         let connection = connect_driver_dev(crate::config::DEFAULT_PROFILE, &env)
             .await
             .expect("driver.dev connection should build from override");
-        assert_eq!(connection.provider, "driver.dev");
+        assert_eq!(connection.provider, "driver");
         assert_eq!(
             connection.cdp_endpoint,
             "wss://example.test/devtools/browser/abc"
         );
         // Override path is "stateless"-like — no provider session to clean up.
         assert!(connection.session.is_none());
+    }
+
+    #[test]
+    fn browser_use_ws_url_override_is_stateless() {
+        let env = env_with(&[(
+            "BROWSER_USE_WS_URL",
+            "wss://connect.browser-use.com?apiKey=bu-key",
+        )]);
+        let rt = tokio::runtime::Runtime::new().expect("runtime");
+        let connection = rt
+            .block_on(connect_browser_use(crate::config::DEFAULT_PROFILE, &env))
+            .expect("browseruse connection");
+        assert_eq!(connection.provider, "browseruse");
+        assert!(connection.session.is_none());
+    }
+
+    #[tokio::test]
+    async fn connect_browser_use_creates_provider_session_via_api() {
+        let (base_url, request_handle) = spawn_single_response_server(
+            "HTTP/1.1 201 Created\r\nContent-Type: application/json\r\nContent-Length: 81\r\n\r\n{\"id\":\"bu-s-1\",\"cdpUrl\":\"wss://cdp.browser-use.test/session-1\",\"status\":\"active\"}",
+        );
+        let env = env_with(&[
+            ("BROWSER_USE_API_URL", &base_url),
+            ("BROWSER_USE_API_KEY", "bu-key"),
+            ("BROWSER_USE_TIMEOUT", "30"),
+            ("BROWSER_USE_BROWSER_SCREEN_WIDTH", "1440"),
+            ("BROWSER_USE_BROWSER_SCREEN_HEIGHT", "900"),
+        ]);
+
+        let connection = connect_browser_use(crate::config::DEFAULT_PROFILE, &env)
+            .await
+            .expect("browseruse connection");
+        assert_eq!(connection.provider, "browseruse");
+        assert_eq!(connection.cdp_endpoint, "wss://cdp.browser-use.test/session-1");
+        assert_eq!(
+            connection.session.as_ref().map(|session| session.session_id.as_str()),
+            Some("bu-s-1")
+        );
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("POST /browsers HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("x-browser-use-api-key: bu-key")
+        );
+        assert!(request.contains("\"timeout\":30"));
+        assert!(request.contains("\"browserScreenWidth\":1440"));
+        assert!(request.contains("\"browserScreenHeight\":900"));
+    }
+
+    #[tokio::test]
+    async fn close_driver_session_calls_delete_endpoint() {
+        let (base_url, request_handle) =
+            spawn_single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let session = ProviderSession {
+            provider: "driver".to_string(),
+            session_id: "driver-s-1".to_string(),
+            provider_env: env_with(&[
+                ("DRIVER_DEV_API_URL", &base_url),
+                ("DRIVER_DEV_API_KEY", "driver-key"),
+            ]),
+        };
+
+        close_provider_session(&session)
+            .await
+            .expect("driver close should succeed");
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("DELETE /v1/browser/session?sessionId=driver-s-1 HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("authorization: bearer driver-key")
+        );
+    }
+
+    #[tokio::test]
+    async fn close_browser_use_session_calls_patch_endpoint() {
+        let (base_url, request_handle) =
+            spawn_single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let session = ProviderSession {
+            provider: "browseruse".to_string(),
+            session_id: "bu-s-1".to_string(),
+            provider_env: env_with(&[
+                ("BROWSER_USE_API_URL", &base_url),
+                ("BROWSER_USE_API_KEY", "bu-key"),
+            ]),
+        };
+
+        close_provider_session(&session)
+            .await
+            .expect("browseruse close should succeed");
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PATCH /browsers/bu-s-1 HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("x-browser-use-api-key: bu-key")
+        );
+        assert!(request.contains("\"action\":\"stop\""));
+    }
+
+    #[tokio::test]
+    async fn close_hyperbrowser_session_sends_zero_length_body() {
+        let (base_url, request_handle) =
+            spawn_single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let session = ProviderSession {
+            provider: "hyperbrowser".to_string(),
+            session_id: "hb-s-1".to_string(),
+            provider_env: env_with(&[
+                ("HYPERBROWSER_API_URL", &base_url),
+                ("HYPERBROWSER_API_KEY", "hb-key"),
+            ]),
+        };
+
+        close_provider_session(&session)
+            .await
+            .expect("hyperbrowser close should succeed");
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-s-1/stop HTTP/1.1"));
+        assert!(request.to_ascii_lowercase().contains("content-length: 0"));
     }
 
     #[test]

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -1,7 +1,8 @@
-use std::env;
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use uuid::Uuid;
 
@@ -11,6 +12,34 @@ const HYPERBROWSER_API_BASE: &str = "https://api.hyperbrowser.ai";
 const BROWSERLESS_API_BASE: &str = "https://production-sfo.browserless.io";
 const BROWSER_USE_WS_BASE: &str = "wss://connect.browser-use.com";
 const DRIVER_DEV_WS_BASE: &str = "wss://cdp.driver.dev";
+
+/// Per-request snapshot of provider-related environment variables, forwarded
+/// from the CLI client process to the daemon. The daemon must NOT call
+/// `std::env::var` for provider config: its own environment is frozen at
+/// daemon-spawn time and almost never matches the user's current shell.
+pub type ProviderEnv = BTreeMap<String, String>;
+
+/// Env-var name prefixes considered "provider config". Used by the CLI client
+/// to filter `std::env::vars()` down to the values worth forwarding.
+pub const PROVIDER_ENV_PREFIXES: &[&str] = &[
+    "DRIVER_DEV_",
+    "HYPERBROWSER_",
+    "BROWSER_USE_",
+    "BROWSERLESS_",
+];
+
+/// Collect every env var on the current process whose name starts with one of
+/// the provider prefixes. Called from the CLI client (NOT the daemon) right
+/// before sending a Start/Restart action.
+pub fn collect_provider_env_from_process() -> ProviderEnv {
+    std::env::vars()
+        .filter(|(name, _)| {
+            PROVIDER_ENV_PREFIXES
+                .iter()
+                .any(|prefix| name.starts_with(prefix))
+        })
+        .collect()
+}
 
 /// HTTP request timeout for cloud provider control-plane API calls.
 /// Provider APIs occasionally hang; without an explicit timeout the daemon
@@ -51,10 +80,15 @@ fn map_provider_http_status(provider: &str, status: StatusCode, body: &str) -> C
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderSession {
     pub provider: String,
     pub session_id: String,
+    /// Snapshot of the provider env vars used to start this session. Carried
+    /// forward so close/restart can talk to the provider control plane even
+    /// when the user's current shell no longer has the keys exported.
+    #[serde(default)]
+    pub provider_env: ProviderEnv,
 }
 
 #[derive(Debug, Clone)]
@@ -84,6 +118,7 @@ pub async fn connect_provider(
     profile_name: &str,
     _headless: bool,
     stealth: bool,
+    env: &ProviderEnv,
 ) -> Result<ProviderConnection, CliError> {
     let provider = normalize_provider_name(provider_name).ok_or_else(|| {
         CliError::InvalidArgument(format!(
@@ -92,16 +127,26 @@ pub async fn connect_provider(
         ))
     })?;
 
-    match provider {
-        "driver.dev" => connect_driver_dev(profile_name).await,
-        "hyperbrowser" => connect_hyperbrowser(profile_name).await,
-        "browseruse" => connect_browser_use(profile_name).await,
-        "browserless" => connect_browserless(stealth).await,
-        _ => Err(CliError::InvalidArgument(format!(
-            "unknown provider '{provider_name}'. Supported providers: {}",
-            supported_providers()
-        ))),
+    let mut connection = match provider {
+        "driver.dev" => connect_driver_dev(profile_name, env).await?,
+        "hyperbrowser" => connect_hyperbrowser(profile_name, env).await?,
+        "browseruse" => connect_browser_use(profile_name, env).await?,
+        "browserless" => connect_browserless(stealth, env).await?,
+        _ => {
+            return Err(CliError::InvalidArgument(format!(
+                "unknown provider '{provider_name}'. Supported providers: {}",
+                supported_providers()
+            )));
+        }
+    };
+
+    // Persist the env snapshot on the session descriptor so close/restart can
+    // talk to the provider's control plane later, even if the calling shell
+    // no longer has the keys exported.
+    if let Some(session) = connection.session.as_mut() {
+        session.provider_env = env.clone();
     }
+    Ok(connection)
 }
 
 pub async fn close_provider_session(session: &ProviderSession) {
@@ -121,10 +166,11 @@ pub async fn close_provider_session(session: &ProviderSession) {
             return;
         }
     };
+    let env = &session.provider_env;
     match session.provider.as_str() {
         "hyperbrowser" => {
-            if let Some(api_key) = read_trimmed_env("HYPERBROWSER_API_KEY") {
-                let api_base = read_trimmed_env("HYPERBROWSER_API_URL")
+            if let Some(api_key) = read_trimmed_env(env, "HYPERBROWSER_API_KEY") {
+                let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
                     .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
                 let _ = client
                     .put(format!(
@@ -135,6 +181,11 @@ pub async fn close_provider_session(session: &ProviderSession) {
                     .header("x-api-key", api_key)
                     .send()
                     .await;
+            } else {
+                tracing::warn!(
+                    "hyperbrowser cleanup skipped for session '{}': no API key in stored env",
+                    session.session_id
+                );
             }
         }
         "browserless" => {
@@ -145,18 +196,21 @@ pub async fn close_provider_session(session: &ProviderSession) {
     }
 }
 
-async fn connect_driver_dev(profile_name: &str) -> Result<ProviderConnection, CliError> {
-    let cdp_endpoint = if let Some(ws_url) = read_trimmed_env("DRIVER_DEV_WS_URL")
-        .or_else(|| read_trimmed_env("DRIVER_DEV_CDP_ENDPOINT"))
+async fn connect_driver_dev(
+    profile_name: &str,
+    env: &ProviderEnv,
+) -> Result<ProviderConnection, CliError> {
+    let cdp_endpoint = if let Some(ws_url) = read_trimmed_env(env, "DRIVER_DEV_WS_URL")
+        .or_else(|| read_trimmed_env(env, "DRIVER_DEV_CDP_ENDPOINT"))
     {
         ws_url
     } else {
-        let api_key = read_required_env("DRIVER_DEV_API_KEY")?;
-        let base = read_trimmed_env("DRIVER_DEV_WS_BASE_URL")
+        let api_key = read_required_env(env, "DRIVER_DEV_API_KEY")?;
+        let base = read_trimmed_env(env, "DRIVER_DEV_WS_BASE_URL")
             .unwrap_or_else(|| DRIVER_DEV_WS_BASE.to_string());
         let mut query = vec![("token", api_key)];
-        if let Some(profile) =
-            read_trimmed_env("DRIVER_DEV_PROFILE").or_else(|| non_default_profile(profile_name))
+        if let Some(profile) = read_trimmed_env(env, "DRIVER_DEV_PROFILE")
+            .or_else(|| non_default_profile(profile_name))
         {
             query.push(("profile", profile));
         }
@@ -171,14 +225,17 @@ async fn connect_driver_dev(profile_name: &str) -> Result<ProviderConnection, Cl
     })
 }
 
-async fn connect_hyperbrowser(profile_name: &str) -> Result<ProviderConnection, CliError> {
-    let api_key = read_required_env("HYPERBROWSER_API_KEY")?;
-    let api_base = read_trimmed_env("HYPERBROWSER_API_URL")
+async fn connect_hyperbrowser(
+    profile_name: &str,
+    env: &ProviderEnv,
+) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env(env, "HYPERBROWSER_API_KEY")?;
+    let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
         .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
-    let use_proxy = parse_env_bool("HYPERBROWSER_USE_PROXY").unwrap_or(false);
-    let persist_changes = parse_env_bool("HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
-    let profile_id =
-        read_trimmed_env("HYPERBROWSER_PROFILE_ID").or_else(|| non_default_profile(profile_name));
+    let use_proxy = parse_env_bool(env, "HYPERBROWSER_USE_PROXY").unwrap_or(false);
+    let persist_changes = parse_env_bool(env, "HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
+    let profile_id = read_trimmed_env(env, "HYPERBROWSER_PROFILE_ID")
+        .or_else(|| non_default_profile(profile_name));
 
     let mut body = json!({ "useProxy": use_proxy });
     if let Some(profile_id) = profile_id {
@@ -236,31 +293,35 @@ async fn connect_hyperbrowser(profile_name: &str) -> Result<ProviderConnection, 
         session: Some(ProviderSession {
             provider: "hyperbrowser".to_string(),
             session_id,
+            provider_env: ProviderEnv::new(),
         }),
     })
 }
 
-async fn connect_browser_use(profile_name: &str) -> Result<ProviderConnection, CliError> {
-    let api_key = read_required_env("BROWSER_USE_API_KEY")?;
-    let base =
-        read_trimmed_env("BROWSER_USE_WS_URL").unwrap_or_else(|| BROWSER_USE_WS_BASE.to_string());
+async fn connect_browser_use(
+    profile_name: &str,
+    env: &ProviderEnv,
+) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env(env, "BROWSER_USE_API_KEY")?;
+    let base = read_trimmed_env(env, "BROWSER_USE_WS_URL")
+        .unwrap_or_else(|| BROWSER_USE_WS_BASE.to_string());
 
     let mut query = vec![("apiKey", api_key)];
-    if let Some(value) = read_trimmed_env("BROWSER_USE_PROXY_COUNTRY_CODE") {
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
         query.push(("proxyCountryCode", value));
     }
-    if let Some(value) =
-        read_trimmed_env("BROWSER_USE_PROFILE_ID").or_else(|| non_default_profile(profile_name))
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROFILE_ID")
+        .or_else(|| non_default_profile(profile_name))
     {
         query.push(("profileId", value));
     }
-    if let Some(value) = read_trimmed_env("BROWSER_USE_TIMEOUT") {
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_TIMEOUT") {
         query.push(("timeout", value));
     }
-    if let Some(value) = read_trimmed_env("BROWSER_USE_BROWSER_SCREEN_WIDTH") {
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_BROWSER_SCREEN_WIDTH") {
         query.push(("browserScreenWidth", value));
     }
-    if let Some(value) = read_trimmed_env("BROWSER_USE_BROWSER_SCREEN_HEIGHT") {
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_BROWSER_SCREEN_HEIGHT") {
         query.push(("browserScreenHeight", value));
     }
 
@@ -272,14 +333,17 @@ async fn connect_browser_use(profile_name: &str) -> Result<ProviderConnection, C
     })
 }
 
-async fn connect_browserless(stealth: bool) -> Result<ProviderConnection, CliError> {
-    let api_key = read_required_env("BROWSERLESS_API_KEY")?;
-    let api_base =
-        read_trimmed_env("BROWSERLESS_API_URL").unwrap_or_else(|| BROWSERLESS_API_BASE.to_string());
-    let browser_type =
-        read_trimmed_env("BROWSERLESS_BROWSER_TYPE").unwrap_or_else(|| "chromium".to_string());
-    let ttl = read_trimmed_env("BROWSERLESS_TTL").unwrap_or_else(|| "300000".to_string());
-    let use_stealth = parse_env_bool("BROWSERLESS_STEALTH").unwrap_or(stealth);
+async fn connect_browserless(
+    stealth: bool,
+    env: &ProviderEnv,
+) -> Result<ProviderConnection, CliError> {
+    let api_key = read_required_env(env, "BROWSERLESS_API_KEY")?;
+    let api_base = read_trimmed_env(env, "BROWSERLESS_API_URL")
+        .unwrap_or_else(|| BROWSERLESS_API_BASE.to_string());
+    let browser_type = read_trimmed_env(env, "BROWSERLESS_BROWSER_TYPE")
+        .unwrap_or_else(|| "chromium".to_string());
+    let ttl = read_trimmed_env(env, "BROWSERLESS_TTL").unwrap_or_else(|| "300000".to_string());
+    let use_stealth = parse_env_bool(env, "BROWSERLESS_STEALTH").unwrap_or(stealth);
 
     if !matches!(browser_type.as_str(), "chromium" | "chrome") {
         return Err(CliError::InvalidArgument(format!(
@@ -333,6 +397,7 @@ async fn connect_browserless(stealth: bool) -> Result<ProviderConnection, CliErr
         session: Some(ProviderSession {
             provider: "browserless".to_string(),
             session_id: stop_url,
+            provider_env: ProviderEnv::new(),
         }),
     })
 }
@@ -351,20 +416,19 @@ fn build_ws_url(base: &str, query: &[(&str, String)]) -> String {
     format!("{base}{separator}{query_string}")
 }
 
-fn read_trimmed_env(name: &str) -> Option<String> {
-    env::var(name)
-        .ok()
+fn read_trimmed_env(env: &ProviderEnv, name: &str) -> Option<String> {
+    env.get(name)
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
 }
 
-fn read_required_env(name: &str) -> Result<String, CliError> {
-    read_trimmed_env(name)
+fn read_required_env(env: &ProviderEnv, name: &str) -> Result<String, CliError> {
+    read_trimmed_env(env, name)
         .ok_or_else(|| CliError::InvalidArgument(format!("{name} environment variable is not set")))
 }
 
-fn parse_env_bool(name: &str) -> Option<bool> {
-    read_trimmed_env(name).and_then(|value| match value.to_ascii_lowercase().as_str() {
+fn parse_env_bool(env: &ProviderEnv, name: &str) -> Option<bool> {
+    read_trimmed_env(env, name).and_then(|value| match value.to_ascii_lowercase().as_str() {
         "1" | "true" | "yes" | "on" => Some(true),
         "0" | "false" | "no" | "off" => Some(false),
         _ => None,
@@ -447,5 +511,62 @@ mod tests {
             normalize_hyperbrowser_profile_id(raw).expect("uuid"),
             raw.to_string()
         );
+    }
+
+    fn env_with(entries: &[(&str, &str)]) -> ProviderEnv {
+        entries
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn read_trimmed_env_returns_value_from_map() {
+        let env = env_with(&[("DRIVER_DEV_API_KEY", "  key-1  ")]);
+        assert_eq!(
+            read_trimmed_env(&env, "DRIVER_DEV_API_KEY"),
+            Some("key-1".to_string())
+        );
+    }
+
+    #[test]
+    fn read_trimmed_env_treats_blank_as_missing() {
+        let env = env_with(&[("DRIVER_DEV_API_KEY", "   ")]);
+        assert_eq!(read_trimmed_env(&env, "DRIVER_DEV_API_KEY"), None);
+    }
+
+    #[test]
+    fn read_required_env_errors_when_missing() {
+        let env = ProviderEnv::new();
+        let err = read_required_env(&env, "DRIVER_DEV_API_KEY").unwrap_err();
+        assert!(matches!(err, CliError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn parse_env_bool_understands_truthy_values() {
+        let env = env_with(&[
+            ("HYPERBROWSER_USE_PROXY", "true"),
+            ("HYPERBROWSER_PERSIST_CHANGES", "0"),
+        ]);
+        assert_eq!(parse_env_bool(&env, "HYPERBROWSER_USE_PROXY"), Some(true));
+        assert_eq!(
+            parse_env_bool(&env, "HYPERBROWSER_PERSIST_CHANGES"),
+            Some(false)
+        );
+        assert_eq!(parse_env_bool(&env, "MISSING"), None);
+    }
+
+    #[test]
+    fn collect_provider_env_from_process_filters_by_prefix() {
+        // Smoke test: should never panic, should not include unrelated vars.
+        let env = collect_provider_env_from_process();
+        for name in env.keys() {
+            assert!(
+                PROVIDER_ENV_PREFIXES
+                    .iter()
+                    .any(|prefix| name.starts_with(prefix)),
+                "unexpected env var leaked into provider env: {name}"
+            );
+        }
     }
 }

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -27,11 +27,12 @@ pub type ProviderEnv = BTreeMap<String, String>;
 /// to filter `std::env::vars()` down to the values worth forwarding.
 ///
 /// `DRIVER_` is intentionally broad: driver.dev's official docs use bare
-/// `DRIVER_API_KEY`, so we forward anything starting with `DRIVER_` to keep
-/// the official-name fallback working. The downside is that an unrelated tool
-/// using a `DRIVER_*` env var will leak its value into the daemon — acceptable
-/// because (a) the daemon is local to the user and (b) we never log these
-/// values, only forward them in the IPC payload.
+/// `DRIVER_API_KEY` (the auth credential), so we forward anything starting
+/// with `DRIVER_` to pick it up alongside the namespaced `DRIVER_DEV_*`
+/// tuning knobs. The downside is that an unrelated tool using a `DRIVER_*`
+/// env var will leak its value into the daemon — acceptable because (a) the
+/// daemon is local to the user and (b) we never log these values, only
+/// forward them in the IPC payload.
 pub const PROVIDER_ENV_PREFIXES: &[&str] = &["DRIVER_", "HYPERBROWSER_", "BROWSER_USE_"];
 
 /// Collect every env var on the current process whose name starts with one of
@@ -281,19 +282,13 @@ fn is_driver_dev_auth_failure(body: &str) -> bool {
     hit
 }
 
-/// Read the driver.dev API key. Accepts both the namespaced
-/// `DRIVER_DEV_API_KEY` (Actionbook convention) and `DRIVER_API_KEY` (driver.dev's
-/// own docs). The namespaced one takes precedence so env collisions with another
-/// "driver" tool are explicit.
+/// Read the driver.dev API key from `DRIVER_API_KEY`, matching driver.dev's
+/// official docs. Only this name is accepted — see PR #507 discussion for the
+/// decision to drop the `DRIVER_DEV_API_KEY` alias.
 fn read_driver_dev_api_key(env: &ProviderEnv) -> Result<String, CliError> {
-    read_trimmed_env(env, "DRIVER_DEV_API_KEY")
-        .or_else(|| read_trimmed_env(env, "DRIVER_API_KEY"))
-        .ok_or_else(|| {
-            CliError::InvalidArgument(
-                "DRIVER_DEV_API_KEY (or DRIVER_API_KEY) environment variable is not set"
-                    .to_string(),
-            )
-        })
+    read_trimmed_env(env, "DRIVER_API_KEY").ok_or_else(|| {
+        CliError::InvalidArgument("DRIVER_API_KEY environment variable is not set".to_string())
+    })
 }
 
 async fn connect_driver_dev(
@@ -400,7 +395,7 @@ async fn connect_driver_dev(
             session_id,
             // Snapshot the env so close/restart can talk to api.driver.dev
             // later even when the calling shell no longer has
-            // DRIVER_DEV_API_KEY exported.
+            // DRIVER_API_KEY exported.
             provider_env: env.clone(),
         }),
     })
@@ -726,23 +721,23 @@ mod tests {
 
     #[test]
     fn read_trimmed_env_returns_value_from_map() {
-        let env = env_with(&[("DRIVER_DEV_API_KEY", "  key-1  ")]);
+        let env = env_with(&[("DRIVER_API_KEY", "  key-1  ")]);
         assert_eq!(
-            read_trimmed_env(&env, "DRIVER_DEV_API_KEY"),
+            read_trimmed_env(&env, "DRIVER_API_KEY"),
             Some("key-1".to_string())
         );
     }
 
     #[test]
     fn read_trimmed_env_treats_blank_as_missing() {
-        let env = env_with(&[("DRIVER_DEV_API_KEY", "   ")]);
-        assert_eq!(read_trimmed_env(&env, "DRIVER_DEV_API_KEY"), None);
+        let env = env_with(&[("DRIVER_API_KEY", "   ")]);
+        assert_eq!(read_trimmed_env(&env, "DRIVER_API_KEY"), None);
     }
 
     #[test]
     fn read_required_env_errors_when_missing() {
         let env = ProviderEnv::new();
-        let err = read_required_env(&env, "DRIVER_DEV_API_KEY").unwrap_err();
+        let err = read_required_env(&env, "DRIVER_API_KEY").unwrap_err();
         assert!(matches!(err, CliError::InvalidArgument(_)));
     }
 
@@ -847,7 +842,7 @@ mod tests {
             session_id: "driver-s-1".to_string(),
             provider_env: env_with(&[
                 ("DRIVER_DEV_API_URL", &base_url),
-                ("DRIVER_DEV_API_KEY", "driver-key"),
+                ("DRIVER_API_KEY", "driver-key"),
             ]),
         };
 
@@ -931,23 +926,19 @@ mod tests {
     }
 
     #[test]
-    fn driver_dev_api_key_falls_back_to_official_name() {
-        // Actionbook uses DRIVER_DEV_API_KEY to namespace; driver.dev's docs
-        // use DRIVER_API_KEY. Accept both, with the namespaced one winning.
+    fn driver_dev_api_key_reads_from_driver_api_key() {
+        // Only the official-docs name is accepted — see PR #507 for the
+        // decision to drop the `DRIVER_DEV_API_KEY` alias.
         let env = env_with(&[("DRIVER_API_KEY", "official-name-key")]);
         assert_eq!(
-            read_driver_dev_api_key(&env).expect("falls back"),
+            read_driver_dev_api_key(&env).expect("reads the key"),
             "official-name-key"
         );
 
-        let env = env_with(&[
-            ("DRIVER_DEV_API_KEY", "namespaced"),
-            ("DRIVER_API_KEY", "official"),
-        ]);
-        assert_eq!(
-            read_driver_dev_api_key(&env).expect("namespaced wins"),
-            "namespaced"
-        );
+        // The retired namespaced name must NOT be honored: that would
+        // resurrect the silent fallback we just removed.
+        let env = env_with(&[("DRIVER_DEV_API_KEY", "stale")]);
+        assert!(read_driver_dev_api_key(&env).is_err());
 
         let env = ProviderEnv::new();
         assert!(read_driver_dev_api_key(&env).is_err());

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -46,7 +46,19 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let (mode, headless, stealth, profile, open_url, cdp_endpoint, headers, cdp, chrome_process);
+    let (
+        mode,
+        headless,
+        stealth,
+        profile,
+        open_url,
+        cdp_endpoint,
+        provider,
+        headers,
+        provider_session,
+        cdp,
+        chrome_process,
+    );
     {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
@@ -65,11 +77,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         profile = entry.profile.clone();
         open_url = entry.tabs.first().map(|t| t.url.clone());
         cdp_endpoint = entry.cdp_endpoint.clone();
+        provider = entry.provider.clone();
         headers = entry
             .headers
             .iter()
             .map(|(k, v)| format!("{k}:{v}"))
             .collect::<Vec<_>>();
+        provider_session = entry.provider_session.clone();
         cdp = entry.cdp.take();
         chrome_process = entry.chrome_process.take();
 
@@ -84,6 +98,49 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
     }
+    // Stateful providers (Hyperbrowser, Browserless) hand back a session
+    // descriptor whose lifetime is bound to the remote control plane —
+    // tearing it down here is mandatory before we mint a fresh one. Stateless
+    // providers (driver.dev, browseruse) embed credentials in the WSS URL
+    // itself and have no per-session handle to release.
+    let had_provider_session = provider_session.is_some();
+    if let Some(provider_session) = provider_session {
+        crate::browser::session::provider::close_provider_session(&provider_session).await;
+    }
+
+    // Restart credential-reuse policy:
+    //
+    //   stateless provider (provider.is_some() && !had_provider_session)
+    //     → reuse the original cdp_endpoint + headers and DROP the provider
+    //       flag from the start command. This avoids re-running
+    //       `connect_provider`, which would re-read env vars and could pick
+    //       up a different API key / profile / proxy than the one the
+    //       session was originally launched with. The provider tag is
+    //       re-applied to the new registry entry below so observability
+    //       survives the round-trip.
+    //
+    //   stateful provider (had_provider_session)
+    //     → the old remote session is gone, so we MUST mint a new one. Pass
+    //       --provider through and clear cdp_endpoint/headers so
+    //       `start::execute` walks the provider connect path.
+    //
+    //   plain cloud (no provider)
+    //     → unchanged: reuse cdp_endpoint + headers verbatim.
+    let is_stateless_provider_reuse = provider.is_some() && !had_provider_session;
+    let preserved_provider_tag = if is_stateless_provider_reuse {
+        provider.clone()
+    } else {
+        None
+    };
+
+    let (effective_cdp_endpoint, effective_provider, effective_headers) =
+        if is_stateless_provider_reuse {
+            (cdp_endpoint, None, headers)
+        } else if had_provider_session {
+            (None, provider, vec![])
+        } else {
+            (cdp_endpoint, provider, headers)
+        };
 
     let start_cmd = super::start::Cmd {
         mode: Some(mode),
@@ -93,14 +150,30 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         profile: Some(profile),
         executable_path: None,
         open_url,
-        cdp_endpoint,
-        header: headers,
+        cdp_endpoint: effective_cdp_endpoint,
+        provider: effective_provider,
+        header: effective_headers,
         session: None,
         set_session_id: Some(cmd.session.clone()),
         stealth,
     };
 
     let result = super::start::execute(&start_cmd, registry).await;
+
+    // Re-apply the provider tag for stateless reuse, so the restarted entry
+    // still reports `provider=driver.dev` (etc) and so subsequent
+    // `find_cloud_session_by_provider` lookups continue to match.
+    if let Some(provider_tag) = preserved_provider_tag
+        && let ActionResult::Ok { ref data } = result
+        && let Some(new_session_id) = data
+            .pointer("/session/session_id")
+            .and_then(|v| v.as_str())
+    {
+        let mut reg = registry.lock().await;
+        if let Some(entry) = reg.get_mut(new_session_id) {
+            entry.provider = Some(provider_tag);
+        }
+    }
 
     match result {
         ActionResult::Ok { data } => {

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -82,7 +82,27 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         headless = entry.headless;
         stealth = entry.stealth;
         profile = entry.profile.clone();
-        open_url = entry.tabs.first().map(|t| t.url.clone());
+        // The registry's tab.url is captured at session-launch time and only
+        // refreshed by `list-tabs`. After a `goto`, the in-memory copy is
+        // stale. Worse, some cloud providers (driver.dev) launch with a
+        // `data:text/html,<title>...` watermark page that the L3 security
+        // check rejects on re-navigation. So:
+        //   - If the saved URL is a dangerous scheme (`data:`, `javascript:`),
+        //     drop it. Restart will boot the new session to its provider
+        //     default and the user can `goto` again from there.
+        //   - `about:blank` is also dropped to avoid an unnecessary navigation.
+        open_url = entry.tabs.first().and_then(|t| {
+            let lower = t.url.to_ascii_lowercase();
+            if lower.is_empty()
+                || lower == "about:blank"
+                || lower.starts_with("data:")
+                || lower.starts_with("javascript:")
+            {
+                None
+            } else {
+                Some(t.url.clone())
+            }
+        });
         cdp_endpoint = entry.cdp_endpoint.clone();
         provider = entry.provider.clone();
         headers = entry
@@ -108,11 +128,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
     }
-    // Stateful providers (Hyperbrowser, Browserless) hand back a session
-    // descriptor whose lifetime is bound to the remote control plane —
+    // Stateful providers (Hyperbrowser, Browserless, driver.dev) hand back a
+    // session descriptor whose lifetime is bound to the remote control plane —
     // tearing it down here is mandatory before we mint a fresh one. Stateless
-    // providers (driver.dev, browseruse) embed credentials in the WSS URL
-    // itself and have no per-session handle to release.
+    // providers (browseruse) embed credentials in the WSS URL itself and have
+    // no per-session handle to release.
     let had_provider_session = provider_session.is_some();
     if let Some(provider_session) = provider_session {
         crate::browser::session::provider::close_provider_session(&provider_session).await;

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -84,7 +84,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         profile = entry.profile.clone();
         // The registry's tab.url is captured at session-launch time and only
         // refreshed by `list-tabs`. After a `goto`, the in-memory copy is
-        // stale. Worse, some cloud providers (driver.dev) launch with a
+        // stale. Worse, some cloud providers (driver) launch with a
         // `data:text/html,<title>...` watermark page that the L3 security
         // check rejects on re-navigation. So:
         //   - If the saved URL is a dangerous scheme (`data:`, `javascript:`),
@@ -128,14 +128,21 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(child) = chrome_process {
         crate::daemon::chrome_reaper::kill_and_reap_async(child).await;
     }
-    // Stateful providers (Hyperbrowser, Browserless, driver.dev) hand back a
-    // session descriptor whose lifetime is bound to the remote control plane —
-    // tearing it down here is mandatory before we mint a fresh one. Stateless
-    // providers (browseruse) embed credentials in the WSS URL itself and have
-    // no per-session handle to release.
+    // Provider-managed cloud sessions hand back a session descriptor whose
+    // lifetime is bound to the remote control plane. Tear it down here before
+    // minting a fresh one. The only remaining stateless path is an explicit
+    // Browser Use WS override, which has no provider session handle to release.
     let had_provider_session = provider_session.is_some();
     if let Some(provider_session) = provider_session {
-        crate::browser::session::provider::close_provider_session(&provider_session).await;
+        if let Err(err) =
+            crate::browser::session::provider::close_provider_session(&provider_session).await
+        {
+            tracing::warn!(
+                "failed to close provider session '{}' for provider '{}' during restart: {err}",
+                provider_session.session_id,
+                provider_session.provider
+            );
+        }
     }
 
     // Restart credential-reuse policy:
@@ -204,7 +211,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let result = super::start::execute(&start_cmd, registry).await;
 
     // Re-apply the provider tag for stateless reuse, so the restarted entry
-    // still reports `provider=driver.dev` (etc) and so subsequent
+    // still reports `provider=driver` (etc) and so subsequent
     // `find_cloud_session_by_provider` lookups continue to match.
     if let Some(provider_tag) = preserved_provider_tag
         && let ActionResult::Ok { ref data } = result

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -111,9 +111,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             .map(|(k, v)| format!("{k}:{v}"))
             .collect::<Vec<_>>();
         provider_session = entry.provider_session.clone();
-        saved_provider_env = provider_session
-            .as_ref()
-            .map(|s| s.provider_env.clone());
+        saved_provider_env = provider_session.as_ref().map(|s| s.provider_env.clone());
         cdp = entry.cdp.take();
         chrome_process = entry.chrome_process.take();
 
@@ -133,16 +131,15 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // minting a fresh one. The only remaining stateless path is an explicit
     // Browser Use WS override, which has no provider session handle to release.
     let had_provider_session = provider_session.is_some();
-    if let Some(provider_session) = provider_session {
-        if let Err(err) =
+    if let Some(provider_session) = provider_session
+        && let Err(err) =
             crate::browser::session::provider::close_provider_session(&provider_session).await
-        {
-            tracing::warn!(
-                "failed to close provider session '{}' for provider '{}' during restart: {err}",
-                provider_session.session_id,
-                provider_session.provider
-            );
-        }
+    {
+        tracing::warn!(
+            "failed to close provider session '{}' for provider '{}' during restart: {err}",
+            provider_session.session_id,
+            provider_session.provider
+        );
     }
 
     // Restart credential-reuse policy:
@@ -188,10 +185,8 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // at start time so restarts from a different shell don't break.
     let effective_provider_env = if !cmd.provider_env.is_empty() {
         cmd.provider_env.clone()
-    } else if let Some(saved) = saved_provider_env {
-        saved
     } else {
-        ProviderEnv::new()
+        saved_provider_env.unwrap_or_default()
     };
 
     let start_cmd = super::start::Cmd {
@@ -218,9 +213,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // `find_cloud_session_by_provider` lookups continue to match.
     if let Some(provider_tag) = preserved_provider_tag
         && let ActionResult::Ok { ref data } = result
-        && let Some(new_session_id) = data
-            .pointer("/session/session_id")
-            .and_then(|v| v.as_str())
+        && let Some(new_session_id) = data.pointer("/session/session_id").and_then(|v| v.as_str())
     {
         let mut reg = registry.lock().await;
         if let Some(entry) = reg.get_mut(new_session_id) {

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::action_result::ActionResult;
+use crate::browser::session::provider::ProviderEnv;
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
 
@@ -19,6 +20,11 @@ pub struct Cmd {
     #[arg(long)]
     #[serde(rename = "session_id")]
     pub session: String,
+    /// Provider env vars forwarded from the CLI client (see start::Cmd::provider_env).
+    /// Used for stateful provider restarts that need to mint a fresh session.
+    #[arg(skip)]
+    #[serde(default)]
+    pub provider_env: ProviderEnv,
 }
 
 pub const COMMAND_NAME: &str = "browser restart";
@@ -56,6 +62,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         provider,
         headers,
         provider_session,
+        saved_provider_env,
         cdp,
         chrome_process,
     );
@@ -84,6 +91,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             .map(|(k, v)| format!("{k}:{v}"))
             .collect::<Vec<_>>();
         provider_session = entry.provider_session.clone();
+        saved_provider_env = provider_session
+            .as_ref()
+            .map(|s| s.provider_env.clone());
         cdp = entry.cdp.take();
         chrome_process = entry.chrome_process.take();
 
@@ -142,6 +152,18 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             (cdp_endpoint, provider, headers)
         };
 
+    // Stateful restart needs provider env to mint a fresh remote session.
+    // Prefer the env the user supplied with the restart call (latest shell
+    // state) so credential rotation works; fall back to the snapshot we saved
+    // at start time so restarts from a different shell don't break.
+    let effective_provider_env = if !cmd.provider_env.is_empty() {
+        cmd.provider_env.clone()
+    } else if let Some(saved) = saved_provider_env {
+        saved
+    } else {
+        ProviderEnv::new()
+    };
+
     let start_cmd = super::start::Cmd {
         mode: Some(mode),
         // Restart preserves the session's effective runtime settings and
@@ -156,6 +178,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         session: None,
         set_session_id: Some(cmd.session.clone()),
         stealth,
+        provider_env: effective_provider_env,
     };
 
     let result = super::start::execute(&start_cmd, registry).await;

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -82,9 +82,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         headless = entry.headless;
         stealth = entry.stealth;
         profile = entry.profile.clone();
-        // The registry's tab.url is captured at session-launch time and only
-        // refreshed by `list-tabs`. After a `goto`, the in-memory copy is
-        // stale. Worse, some cloud providers (driver) launch with a
+        // tab.url is refreshed on `goto` (see browser/navigation/goto.rs)
+        // and by `list-tabs`, so it reflects the most recent navigation.
+        // Some cloud providers (driver) launch with a
         // `data:text/html,<title>...` watermark page that the L3 security
         // check rejects on re-navigation. So:
         //   - If the saved URL is a dangerous scheme (`data:`, `javascript:`),
@@ -158,8 +158,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     //
     //   stateful provider (had_provider_session)
     //     → the old remote session is gone, so we MUST mint a new one. Pass
-    //       --provider through and clear cdp_endpoint/headers so
-    //       `start::execute` walks the provider connect path.
+    //       --provider through and clear cdp_endpoint so `start::execute`
+    //       walks the provider connect path. Keep the user-supplied headers
+    //       — provider helpers (`connect_driver_dev` etc.) only inject auth
+    //       on top, and callers that needed custom CDP headers for the
+    //       initial connect will still need them for the reconnect.
     //
     //   plain cloud (no provider)
     //     → unchanged: reuse cdp_endpoint + headers verbatim.
@@ -174,7 +177,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         if is_stateless_provider_reuse {
             (cdp_endpoint, None, headers)
         } else if had_provider_session {
-            (None, provider, vec![])
+            (None, provider, headers)
         } else {
             (cdp_endpoint, provider, headers)
         };

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -219,6 +219,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                         "retry after a few seconds or use browser status to check",
                     );
                 }
+                SessionState::Closing => {
+                    return ActionResult::fatal_with_hint(
+                        "SESSION_CLOSING",
+                        format!("session '{}' is being closed, please wait", sid),
+                        "retry after a few seconds or use browser status to check",
+                    );
+                }
                 SessionState::Closed => {
                     // Closed session — fall through to create a new one with this ID
                 }
@@ -285,7 +292,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                                 "retry after a few seconds or use browser status to check",
                             );
                         }
-                        SessionState::Closed => None,
+                        // `find_cloud_session_by_provider` filters on
+                        // `is_active()`, which excludes both Closing and
+                        // Closed — these arms exist only to keep the match
+                        // exhaustive.
+                        SessionState::Closing | SessionState::Closed => None,
                     }
                 } else {
                     None
@@ -310,9 +321,27 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 tracing::info!(
                     "cloud provider session '{stale_session_id}' health check failed, reconnecting"
                 );
-                let mut reg = registry.lock().await;
-                reg.remove(&stale_session_id);
-                drop(reg);
+                // Take the stale entry out of the registry *and* best-effort
+                // close its remote provider session. A failed `Target.getTargets`
+                // can mean the remote is dead, but it can also mean the WS is
+                // wedged while the paid remote browser is still alive — without
+                // the explicit close, that's a billed orphan session, which is
+                // the exact leak this PR is trying to prevent elsewhere.
+                let stale_entry = {
+                    let mut reg = registry.lock().await;
+                    reg.remove(&stale_session_id)
+                };
+                if let Some(entry) = stale_entry
+                    && let Some(ps) = entry.provider_session.as_ref()
+                    && let Err(err) =
+                        crate::browser::session::provider::close_provider_session(ps).await
+                {
+                    tracing::warn!(
+                        "failed to clean up stale provider session '{}' for provider '{}': {err}",
+                        ps.session_id,
+                        ps.provider
+                    );
+                }
             }
 
             let provider_connection = match connect_provider(
@@ -412,7 +441,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                         "retry after a few seconds or use browser status to check",
                     );
                 }
-                SessionState::Closed => unreachable!("closed sessions are excluded from lookup"),
+                SessionState::Closing | SessionState::Closed => {
+                    unreachable!("inactive sessions are excluded from lookup via is_active()")
+                }
             }
         } else {
             match reg.reserve_session_start(
@@ -705,10 +736,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             "mode": mode.to_string(),
             "status": "running",
             "headless": headless,
-            // Local CDP URLs don't carry secrets, but go through redact_endpoint
-            // for consistency with cloud paths so the rule is "all cdp_endpoint
-            // emissions are redacted, period."
-            "cdp_endpoint": redact_endpoint(&ws_url),
+            // Local loopback CDP URLs must be emitted verbatim so the caller
+            // can actually connect (e.g. `chrome --remote-debugging-port` or
+            // DevTools). `endpoint_for_mode` skips redaction for non-cloud
+            // modes and keeps it for cloud.
+            "cdp_endpoint": endpoint_for_mode(mode, &ws_url),
         },
         "tab": {
             "tab_id": first_short_id,
@@ -797,10 +829,10 @@ async fn reuse_running_session(
             "mode": entry.mode.to_string(),
             "status": entry.status.to_string(),
             "headless": entry.headless,
-            // Cloud reuse: entry.ws_url contains the raw provider WSS URL,
-            // which embeds tokens (e.g. Hyperbrowser JWT) as query params.
-            // Always redact before emitting to stdout.
-            "cdp_endpoint": redact_endpoint(&entry.ws_url),
+            // Cloud ws_urls embed tokens (e.g. Hyperbrowser JWT) as query
+            // params and must be redacted; local loopback ws_urls must be
+            // emitted verbatim so the caller can actually attach.
+            "cdp_endpoint": endpoint_for_mode(entry.mode, &entry.ws_url),
         },
         "tab": {
             "tab_id": target.first_tab_id,
@@ -926,7 +958,9 @@ async fn execute_cloud(
                         "retry after a few seconds or use browser status to check",
                     );
                 }
-                SessionState::Closed => {}
+                // Closing / Closed are filtered by `find_cloud_session_by_endpoint`
+                // via `is_active()`; these arms only satisfy exhaustiveness.
+                SessionState::Closing | SessionState::Closed => {}
             }
         }
     }
@@ -1037,8 +1071,16 @@ async fn execute_cloud(
     let first_title = tabs.first().map(|t| t.2.clone()).unwrap_or_default();
 
     // ── Finalize registry entry ──
+    // Race window: the placeholder reserved at the top of this function can be
+    // removed by a concurrent `close`/`restart` while we were busy minting the
+    // remote session. In that case the local `provider_session` variable holds
+    // a handle the registry never got to see — no other caller will ever
+    // release it — so we must tear it down here before returning, otherwise
+    // the cloud browser leaks and keeps billing.
     let mut reg = registry.lock().await;
     let Some(entry) = reg.get_mut(session_id.as_str()) else {
+        drop(reg);
+        cleanup_provider_session_if_any(&provider_session).await;
         return ActionResult::fatal(
             "SESSION_NOT_FOUND",
             format!(
@@ -1432,6 +1474,24 @@ fn redact_query_string(query: &str) -> String {
         .join("&")
 }
 
+/// Emit a CDP endpoint for the given mode.
+///
+/// Local endpoints (`ws://127.0.0.1:PORT/devtools/browser/<uuid>`) carry no
+/// secrets: the UUID segment is just Chrome's internal target ID, and
+/// connecting still requires local loopback access. Running these through
+/// `redact_endpoint` turns them into `ws://127.0.0.1:PORT/devt***`, which is
+/// not actionable — the user can't attach to the truncated URL. So local
+/// sessions emit the verbatim ws_url and cloud sessions always go through
+/// redaction (provider WSS URLs embed API keys as query params and tokens
+/// as path segments).
+pub fn endpoint_for_mode(mode: Mode, endpoint: &str) -> String {
+    if mode == Mode::Cloud {
+        redact_endpoint(endpoint)
+    } else {
+        endpoint.to_string()
+    }
+}
+
 /// Redact a CDP endpoint for safe display.
 ///
 /// - Query parameters whose keys appear in `SECRET_QUERY_KEYS` are masked to
@@ -1518,6 +1578,32 @@ mod redact_tests {
         let url = "example.com/ws?token=secret";
         // No scheme — pass through unchanged (best-effort).
         assert_eq!(redact_endpoint(url), "example.com/ws?token=secret");
+    }
+
+    use super::endpoint_for_mode;
+    use crate::types::Mode;
+
+    #[test]
+    fn endpoint_for_mode_keeps_local_ws_verbatim() {
+        // A real local Chrome CDP URL has a long devtools/browser path that
+        // `redact_endpoint` would truncate to `/devt***`. The caller can't
+        // attach to that, so local mode must emit the URL untouched.
+        let url = "ws://127.0.0.1:9222/devtools/browser/abc-123-def-456-opaque-guid";
+        assert_eq!(endpoint_for_mode(Mode::Local, url), url);
+        assert_eq!(endpoint_for_mode(Mode::Extension, url), url);
+    }
+
+    #[test]
+    fn endpoint_for_mode_redacts_cloud_ws_with_apikey() {
+        // Cloud URLs must still be redacted so the daemon never echoes a
+        // provider API key back to stdout.
+        let url = "wss://connect.browser-use.com?apiKey=super-secret-token";
+        let emitted = endpoint_for_mode(Mode::Cloud, url);
+        assert!(
+            !emitted.contains("super-secret-token"),
+            "cloud endpoint must be redacted: {emitted}",
+        );
+        assert!(emitted.contains("apiKey=***"), "expected mask: {emitted}");
     }
 }
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -26,7 +26,23 @@ Examples:
   actionbook browser start --session research --open-url https://google.com
   actionbook browser start --headless --profile scraper
   actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
-  actionbook browser start -p hyperbrowser
+
+Cloud providers (-p / --provider):
+  driver          requires DRIVER_DEV_API_KEY (or DRIVER_API_KEY)   # driver.dev
+  hyperbrowser    requires HYPERBROWSER_API_KEY                     # hyperbrowser.ai
+  browseruse      requires BROWSER_USE_API_KEY                      # browser-use.com
+
+  -p <name> implies --mode cloud and is mutually exclusive with
+  --cdp-endpoint and --mode local/extension. The daemon reads each
+  provider's env vars from the CLI caller's shell, not its own
+  process env. Each provider also reads optional tuning vars
+  (profile, proxy, country, window size, ...) — see docs.
+
+Provider examples:
+  export HYPERBROWSER_API_KEY=...
+  actionbook browser start -p hyperbrowser --session s1
+  actionbook browser start -p driver --open-url https://example.com
+  actionbook browser restart --session s1    # provider sessions: mints a fresh remote
 
 --session: get-or-create — reuses an existing session with the given ID, or creates one if not found.
 --set-session-id: always creates — fails if the ID is already in use.
@@ -51,8 +67,15 @@ pub struct Cmd {
     /// Connect to existing CDP endpoint
     #[arg(long)]
     pub cdp_endpoint: Option<String>,
-    /// Launch a provider-managed cloud browser session
-    #[arg(short = 'p', long)]
+    /// Cloud browser provider (implies --mode cloud).
+    ///
+    /// `-p <name>` is mutually exclusive with `--cdp-endpoint` and
+    /// `--mode local/extension`. Each provider reads its own
+    /// `<PROVIDER>_API_KEY` from the CLI caller's shell env — the
+    /// daemon's env was frozen at spawn time and is not consulted.
+    /// Sessions are stateful: `browser restart --session <id>` mints
+    /// a fresh remote session and preserves the session_id.
+    #[arg(short = 'p', long, value_parser = provider_value_parser())]
     pub provider: Option<String>,
     /// Headers for CDP endpoint (KEY:VALUE), may be repeated
     #[arg(long)]
@@ -81,6 +104,29 @@ pub struct Cmd {
 
 fn default_stealth() -> bool {
     true
+}
+
+/// clap value parser for `-p / --provider`.
+///
+/// Using `PossibleValuesParser` (rather than a `ValueEnum`) keeps the
+/// `Cmd.provider` field as `Option<String>`, so config/env merging in
+/// `resolve_start_command` can stay on untyped strings. The per-value
+/// `help` text is what gives agents a single-pass, self-contained
+/// `--help` output: they see the allowed names *and* the required
+/// auth env var in the same line. The alias on `browseruse` preserves
+/// the historical `browser-use` spelling; `normalize_provider_name`
+/// re-normalizes it at `execute()` time so the daemon-side IPC path
+/// keeps the same validation as the CLI-side one.
+fn provider_value_parser() -> clap::builder::PossibleValuesParser {
+    use clap::builder::PossibleValue;
+    clap::builder::PossibleValuesParser::new([
+        PossibleValue::new("driver")
+            .help("driver.dev — requires DRIVER_DEV_API_KEY (or DRIVER_API_KEY)"),
+        PossibleValue::new("hyperbrowser").help("hyperbrowser.ai — requires HYPERBROWSER_API_KEY"),
+        PossibleValue::new("browseruse")
+            .aliases(["browser-use"])
+            .help("browser-use.com — requires BROWSER_USE_API_KEY"),
+    ])
 }
 
 pub const COMMAND_NAME: &str = "browser start";

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -859,14 +859,14 @@ async fn fail_reserved_start(
 /// branch in `execute_cloud` must funnel through this helper, otherwise we
 /// leak paid provider sessions.
 async fn cleanup_provider_session_if_any(provider_session: &Option<ProviderSession>) {
-    if let Some(ps) = provider_session {
-        if let Err(err) = crate::browser::session::provider::close_provider_session(ps).await {
-            tracing::warn!(
-                "failed to clean up provider session '{}' for provider '{}': {err}",
-                ps.session_id,
-                ps.provider
-            );
-        }
+    if let Some(ps) = provider_session
+        && let Err(err) = crate::browser::session::provider::close_provider_session(ps).await
+    {
+        tracing::warn!(
+            "failed to clean up provider session '{}' for provider '{}': {err}",
+            ps.session_id,
+            ps.provider
+        );
     }
 }
 
@@ -905,6 +905,12 @@ fn cleanup_chrome_process(mut chrome_process: Option<Child>) {
 ///
 /// Cloud sessions connect directly to a remote CDP endpoint via WebSocket
 /// with optional auth headers. No local Chrome process is launched.
+///
+/// The argument list is wider than clippy's 7-arg heuristic because all of
+/// these inputs are resolved by the caller (either from the CLI `start`
+/// command or from a `restart` handoff) and have no natural grouping —
+/// folding them into a struct would just be a lint-placation rename.
+#[allow(clippy::too_many_arguments)]
 async fn execute_cloud(
     cmd: &Cmd,
     registry: &SharedRegistry,
@@ -1546,7 +1552,10 @@ mod redact_tests {
         let red = redact_endpoint(url);
         assert!(!red.contains("super-secret-token"), "leaked token: {red}");
         assert!(red.contains("apiKey=***"), "expected mask: {red}");
-        assert!(red.contains("proxyCountryCode=us"), "kept non-secret: {red}");
+        assert!(
+            red.contains("proxyCountryCode=us"),
+            "kept non-secret: {red}"
+        );
     }
 
     #[test]
@@ -1562,7 +1571,10 @@ mod redact_tests {
     fn redacts_long_path_segment() {
         let url = "wss://cloud.example.com/connect/very-long-opaque-token-segment";
         let red = redact_endpoint(url);
-        assert!(!red.contains("very-long-opaque-token-segment"), "leaked: {red}");
+        assert!(
+            !red.contains("very-long-opaque-token-segment"),
+            "leaked: {red}"
+        );
         assert!(red.starts_with("wss://cloud.example.com/"));
         assert!(red.ends_with("***"));
     }
@@ -1619,7 +1631,9 @@ mod provider_start_tests {
     use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
     use crate::types::SessionId;
 
-    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+    fn spawn_single_response_server(
+        response: &'static str,
+    ) -> (String, thread::JoinHandle<String>) {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
         let addr = listener.local_addr().expect("mock server addr");
         let handle = thread::spawn(move || {
@@ -1818,7 +1832,10 @@ mod provider_start_tests {
         }
 
         let reg = registry.lock().await;
-        assert!(reg.get("bs1").is_none(), "failed start should clean placeholder");
+        assert!(
+            reg.get("bs1").is_none(),
+            "failed start should clean placeholder"
+        );
         assert_eq!(
             reg.get("dr3").map(|entry| entry.status),
             Some(SessionState::Starting)

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -694,7 +694,10 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             "mode": mode.to_string(),
             "status": "running",
             "headless": headless,
-            "cdp_endpoint": ws_url,
+            // Local CDP URLs don't carry secrets, but go through redact_endpoint
+            // for consistency with cloud paths so the rule is "all cdp_endpoint
+            // emissions are redacted, period."
+            "cdp_endpoint": redact_endpoint(&ws_url),
         },
         "tab": {
             "tab_id": first_short_id,
@@ -783,7 +786,10 @@ async fn reuse_running_session(
             "mode": entry.mode.to_string(),
             "status": entry.status.to_string(),
             "headless": entry.headless,
-            "cdp_endpoint": entry.ws_url,
+            // Cloud reuse: entry.ws_url contains the raw provider WSS URL,
+            // which embeds tokens (e.g. Hyperbrowser JWT) as query params.
+            // Always redact before emitting to stdout.
+            "cdp_endpoint": redact_endpoint(&entry.ws_url),
         },
         "tab": {
             "tab_id": target.first_tab_id,

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::action_result::ActionResult;
+use crate::browser::session::provider::{
+    ProviderSession, connect_provider, normalize_provider_name, supported_providers,
+};
 use crate::config;
 use crate::config::DEFAULT_PROFILE;
 use crate::daemon::browser;
@@ -23,6 +26,8 @@ Examples:
   actionbook browser start --session research --open-url https://google.com
   actionbook browser start --headless --profile scraper
   actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
+  actionbook browser start -p hyperbrowser
+  actionbook browser start --provider browserless
 
 --session: get-or-create — reuses an existing session with the given ID, or creates one if not found.
 --set-session-id: always creates — fails if the ID is already in use.
@@ -47,6 +52,9 @@ pub struct Cmd {
     /// Connect to existing CDP endpoint
     #[arg(long)]
     pub cdp_endpoint: Option<String>,
+    /// Launch a provider-managed cloud browser session
+    #[arg(short = 'p', long)]
+    pub provider: Option<String>,
     /// Headers for CDP endpoint (KEY:VALUE), may be repeated
     #[arg(long)]
     pub header: Vec<String>,
@@ -100,11 +108,35 @@ pub fn context(_cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let mode = cmd.mode.unwrap_or_else(|| {
-        config::load_config()
-            .map(|c| c.browser.mode)
-            .unwrap_or(Mode::Local)
-    });
+    let provider_name = match cmd.provider.as_deref() {
+        Some(provider_name) => match normalize_provider_name(provider_name) {
+            Some(provider) => Some(provider),
+            None => {
+                return ActionResult::fatal(
+                    "INVALID_ARGUMENT",
+                    format!(
+                        "unknown provider '{provider_name}'. Supported providers: {}",
+                        supported_providers()
+                    ),
+                );
+            }
+        },
+        None => None,
+    };
+    // Mode resolution precedence:
+    //   1. --provider implies cloud (validated against any explicit --mode below)
+    //   2. explicit --mode flag
+    //   3. config file's browser.mode
+    //   4. Local default
+    let mode = if provider_name.is_some() {
+        Mode::Cloud
+    } else {
+        cmd.mode.unwrap_or_else(|| {
+            config::load_config()
+                .map(|c| c.browser.mode)
+                .unwrap_or(Mode::Local)
+        })
+    };
     let headless = cmd.headless.unwrap_or(false);
     let profile_name = cmd.profile.as_deref().unwrap_or(DEFAULT_PROFILE);
     let cdp_endpoint = cmd.cdp_endpoint.as_deref();
@@ -116,8 +148,24 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         );
     }
 
-    // Cloud mode requires --cdp-endpoint
-    if mode == Mode::Cloud && cdp_endpoint.is_none() {
+    if provider_name.is_some() && cdp_endpoint.is_some() {
+        return ActionResult::fatal_with_hint(
+            "INVALID_ARGUMENT",
+            "--provider cannot be used together with --cdp-endpoint".to_string(),
+            "use --provider by itself, or use --mode cloud --cdp-endpoint to connect to an existing remote browser",
+        );
+    }
+
+    if provider_name.is_some() && matches!(cmd.mode, Some(Mode::Local) | Some(Mode::Extension)) {
+        return ActionResult::fatal_with_hint(
+            "INVALID_ARGUMENT",
+            "--provider requires cloud mode".to_string(),
+            "remove --mode local/extension, or use --mode cloud with --provider",
+        );
+    }
+
+    // Cloud mode requires --cdp-endpoint unless a provider is selected.
+    if mode == Mode::Cloud && cdp_endpoint.is_none() && provider_name.is_none() {
         return ActionResult::fatal_with_hint(
             "MISSING_CDP_ENDPOINT",
             "--mode cloud requires --cdp-endpoint",
@@ -176,6 +224,99 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
     // ── Cloud mode ──────────────────────────────────────────────────
     if mode == Mode::Cloud {
+        if let Some(provider_name) = provider_name {
+            // Provider session reuse: lookup is keyed on (provider, profile),
+            // but presence in the registry only proves the entry was once
+            // healthy. The remote browser may have been killed by the
+            // provider's idle reaper or torn down out-of-band, so we always
+            // probe with `Target.getTargets` before reusing — same pattern as
+            // `find_cloud_session_by_endpoint` further down.
+            let reuse_candidate = {
+                let reg = registry.lock().await;
+                if effective_set_id.is_none()
+                    && let Some(existing) =
+                        reg.find_cloud_session_by_provider(provider_name, profile_name)
+                {
+                    match existing.status {
+                        SessionState::Running => Some((
+                            ReuseTarget {
+                                session_id: existing.id.as_str().to_string(),
+                                first_tab_id: existing
+                                    .tabs
+                                    .first()
+                                    .map(|tab| tab.id.0.clone())
+                                    .unwrap_or_default(),
+                                first_native_id: existing
+                                    .tabs
+                                    .first()
+                                    .map(|tab| tab.native_id.clone())
+                                    .unwrap_or_default(),
+                                cdp: existing.cdp.clone(),
+                                cdp_port: existing.cdp_port,
+                            },
+                            existing.cdp.clone(),
+                        )),
+                        SessionState::Starting => {
+                            return ActionResult::fatal_with_hint(
+                                "SESSION_STARTING",
+                                format!(
+                                    "session for provider '{provider_name}' and profile '{profile_name}' is starting, please wait"
+                                ),
+                                "retry after a few seconds or use browser status to check",
+                            );
+                        }
+                        SessionState::Closed => None,
+                    }
+                } else {
+                    None
+                }
+            };
+
+            if let Some((target, cdp)) = reuse_candidate {
+                let stale_session_id = target.session_id.clone();
+                let healthy = match cdp.as_ref() {
+                    Some(cdp) => cdp
+                        .execute_browser("Target.getTargets", json!({}))
+                        .await
+                        .is_ok(),
+                    None => false,
+                };
+                if healthy {
+                    return reuse_running_session(cmd, registry, target).await;
+                }
+                // Stale entry — drop it before falling through to a fresh
+                // provider connect, otherwise the next reuse attempt will
+                // race against the same dead session.
+                tracing::info!(
+                    "cloud provider session '{stale_session_id}' health check failed, reconnecting"
+                );
+                let mut reg = registry.lock().await;
+                reg.remove(&stale_session_id);
+                drop(reg);
+            }
+
+            let provider_connection =
+                match connect_provider(provider_name, profile_name, headless, cmd.stealth).await {
+                    Ok(connection) => connection,
+                    Err(err) => return ActionResult::fatal(err.error_code(), err.to_string()),
+                };
+
+            let mut combined_headers = provider_connection.headers.clone();
+            combined_headers.extend(headers.clone());
+
+            return execute_cloud(
+                cmd,
+                registry,
+                &provider_connection.cdp_endpoint,
+                &combined_headers,
+                profile_name,
+                headless,
+                Some(provider_connection.provider.as_str()),
+                provider_connection.session.clone(),
+            )
+            .await;
+        }
+
         return execute_cloud(
             cmd,
             registry,
@@ -183,6 +324,8 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             &headers,
             profile_name,
             headless,
+            None,
+            None,
         )
         .await;
     }
@@ -645,6 +788,30 @@ async fn fail_reserved_start(
     ActionResult::fatal(code, message)
 }
 
+/// Tear down a provider-side session as part of a failed cloud start.
+///
+/// `panic = "abort"` means we cannot rely on `Drop` for this — every error
+/// branch in `execute_cloud` must funnel through this helper, otherwise we
+/// leak paid provider sessions.
+async fn cleanup_provider_session_if_any(provider_session: &Option<ProviderSession>) {
+    if let Some(ps) = provider_session {
+        crate::browser::session::provider::close_provider_session(ps).await;
+    }
+}
+
+/// Helper that pairs `cleanup_provider_session_if_any` with `fail_reserved_start`
+/// so all four error branches in `execute_cloud` reduce to a single call.
+async fn fail_reserved_cloud_start(
+    registry: &SharedRegistry,
+    session_id: &SessionId,
+    provider_session: &Option<ProviderSession>,
+    code: &str,
+    message: String,
+) -> ActionResult {
+    cleanup_provider_session_if_any(provider_session).await;
+    fail_reserved_start(registry, session_id, code, message).await
+}
+
 async fn fail_reserved_start_with_chrome(
     registry: &SharedRegistry,
     session_id: &SessionId,
@@ -674,6 +841,8 @@ async fn execute_cloud(
     headers: &[(String, String)],
     profile_name: &str,
     headless: bool,
+    provider_name: Option<&str>,
+    provider_session: Option<ProviderSession>,
 ) -> ActionResult {
     let ws_url = match ensure_scheme_or_fatal(cdp_endpoint) {
         Ok(u) => u,
@@ -743,7 +912,14 @@ async fn execute_cloud(
     let cdp = match CdpSession::connect_with_headers(&ws_url, headers).await {
         Ok(c) => c,
         Err(e) => {
-            return fail_reserved_start(registry, &session_id, e.error_code(), e.to_string()).await;
+            return fail_reserved_cloud_start(
+                registry,
+                &session_id,
+                &provider_session,
+                e.error_code(),
+                e.to_string(),
+            )
+            .await;
         }
     };
 
@@ -751,7 +927,14 @@ async fn execute_cloud(
     let tabs = match discover_tabs_via_cdp(&cdp).await {
         Ok(t) => t,
         Err(e) => {
-            return fail_reserved_start(registry, &session_id, "CDP_ERROR", e.to_string()).await;
+            return fail_reserved_cloud_start(
+                registry,
+                &session_id,
+                &provider_session,
+                "CDP_ERROR",
+                e.to_string(),
+            )
+            .await;
         }
     };
 
@@ -761,9 +944,10 @@ async fn execute_cloud(
         match create_tab_via_cdp(&cdp, open_url).await {
             Ok(tab) => vec![tab],
             Err(e) => {
-                return fail_reserved_start(
+                return fail_reserved_cloud_start(
                     registry,
                     &session_id,
+                    &provider_session,
                     "CDP_ERROR",
                     format!("failed to create initial tab: {e}"),
                 )
@@ -789,6 +973,7 @@ async fn execute_cloud(
         let final_url = match ensure_scheme_or_fatal(url) {
             Ok(u) => u,
             Err(e) => {
+                cleanup_provider_session_if_any(&provider_session).await;
                 registry.lock().await.remove(session_id.as_str());
                 return e;
             }
@@ -833,6 +1018,8 @@ async fn execute_cloud(
     entry.cdp = Some(cdp);
     entry.cdp_endpoint = Some(cdp_endpoint.to_string());
     entry.headers = headers.to_vec();
+    entry.provider = provider_name.map(|provider| provider.to_string());
+    entry.provider_session = provider_session;
 
     // Create per-session data directory for artifacts (snapshots, etc.)
     let session_data_dir = config::session_data_dir(session_id.as_str());
@@ -851,6 +1038,7 @@ async fn execute_cloud(
             "status": "running",
             "headless": headless,
             "cdp_endpoint": redact_endpoint(cdp_endpoint),
+            "provider": provider_name,
         },
         "tab": {
             "tab_id": first_short_id,
@@ -1124,6 +1312,7 @@ fn make_session_response(
             "status": entry.status.to_string(),
             "headless": entry.headless,
             "cdp_endpoint": redact_endpoint(cdp_endpoint),
+            "provider": entry.provider,
         },
         "tab": {
             "tab_id": first_tab.map(|t| t.id.0.as_str()).unwrap_or(""),
@@ -1159,23 +1348,133 @@ fn parse_headers(raw: &[String]) -> Result<Vec<(String, String)>, ActionResult> 
         .collect()
 }
 
-/// Redact a CDP endpoint for safe display (mask auth tokens in query/path).
-pub fn redact_endpoint(endpoint: &str) -> String {
-    // Simple redaction: if the endpoint contains a token-like path segment, mask it
-    if let Some(idx) = endpoint.find("://") {
-        let after_scheme = &endpoint[idx + 3..];
-        // Find host:port boundary
-        if let Some(slash_idx) = after_scheme.find('/') {
-            let host_port = &after_scheme[..slash_idx];
-            let path = &after_scheme[slash_idx..];
-            // Redact path if it looks like a token (long alphanumeric)
-            let redacted_path = if path.len() > 10 {
-                format!("/{}***", &path[1..5.min(path.len())])
+/// Query parameter names that are treated as secrets and fully redacted in
+/// `redact_endpoint`. Match is case-insensitive. Provider WSS endpoints carry
+/// the API key directly in the query string, so this list is what stops the
+/// daemon from echoing credentials back to logs/responses.
+const SECRET_QUERY_KEYS: &[&str] = &[
+    "apikey",
+    "api_key",
+    "api-key",
+    "token",
+    "access_token",
+    "accesstoken",
+    "auth",
+    "authorization",
+    "key",
+    "password",
+    "secret",
+    "x-api-key",
+];
+
+fn is_secret_query_key(key: &str) -> bool {
+    let lower = key.to_ascii_lowercase();
+    SECRET_QUERY_KEYS.contains(&lower.as_str())
+}
+
+fn redact_query_string(query: &str) -> String {
+    query
+        .split('&')
+        .map(|pair| {
+            if let Some((key, _value)) = pair.split_once('=') {
+                if is_secret_query_key(key) {
+                    format!("{key}=***")
+                } else {
+                    pair.to_string()
+                }
             } else {
-                path.to_string()
-            };
-            return format!("{}{}{}", &endpoint[..idx + 3], host_port, redacted_path);
-        }
+                pair.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Redact a CDP endpoint for safe display.
+///
+/// - Query parameters whose keys appear in `SECRET_QUERY_KEYS` are masked to
+///   `key=***` (this is where every cloud provider currently puts the API key).
+/// - Long path segments are replaced with a short prefix + `***` so that
+///   token-in-path schemes (e.g. `/connect/<token>`) are also redacted.
+/// - Scheme, host:port and the rest of the URL structure are preserved so
+///   the redacted form is still useful for debugging.
+pub fn redact_endpoint(endpoint: &str) -> String {
+    let Some(scheme_end) = endpoint.find("://") else {
+        return endpoint.to_string();
+    };
+    let scheme = &endpoint[..scheme_end + 3];
+    let after_scheme = &endpoint[scheme_end + 3..];
+
+    // Split off the query string first so we can redact it independently.
+    let (path_part, query_part) = match after_scheme.find('?') {
+        Some(q_idx) => (&after_scheme[..q_idx], Some(&after_scheme[q_idx + 1..])),
+        None => (after_scheme, None),
+    };
+
+    // Split host:port from path.
+    let (host_port, path) = match path_part.find('/') {
+        Some(slash_idx) => (&path_part[..slash_idx], &path_part[slash_idx..]),
+        None => (path_part, ""),
+    };
+
+    let redacted_path = if path.len() > 10 {
+        // Path looks like it carries an opaque token; keep the first few chars
+        // for context and mask the rest.
+        let prefix_end = 5.min(path.len());
+        format!("{}***", &path[..prefix_end])
+    } else {
+        path.to_string()
+    };
+
+    let mut out = format!("{scheme}{host_port}{redacted_path}");
+    if let Some(query) = query_part {
+        out.push('?');
+        out.push_str(&redact_query_string(query));
     }
-    endpoint.to_string()
+    out
+}
+
+#[cfg(test)]
+mod redact_tests {
+    use super::redact_endpoint;
+
+    #[test]
+    fn redacts_apikey_query_param() {
+        let url = "wss://connect.browser-use.com?apiKey=super-secret-token&proxyCountryCode=us";
+        let red = redact_endpoint(url);
+        assert!(!red.contains("super-secret-token"), "leaked token: {red}");
+        assert!(red.contains("apiKey=***"), "expected mask: {red}");
+        assert!(red.contains("proxyCountryCode=us"), "kept non-secret: {red}");
+    }
+
+    #[test]
+    fn redacts_token_query_param_case_insensitive() {
+        let url = "wss://cdp.driver.dev?Token=abc123def456&profile=foo";
+        let red = redact_endpoint(url);
+        assert!(!red.contains("abc123def456"), "leaked token: {red}");
+        assert!(red.contains("Token=***"));
+        assert!(red.contains("profile=foo"));
+    }
+
+    #[test]
+    fn redacts_long_path_segment() {
+        let url = "wss://browserless.io/connect/very-long-opaque-token-segment";
+        let red = redact_endpoint(url);
+        assert!(!red.contains("very-long-opaque-token-segment"), "leaked: {red}");
+        assert!(red.starts_with("wss://browserless.io/"));
+        assert!(red.ends_with("***"));
+    }
+
+    #[test]
+    fn keeps_short_path_unchanged() {
+        let url = "wss://example.com/ws";
+        assert_eq!(redact_endpoint(url), "wss://example.com/ws");
+    }
+
+    #[test]
+    fn handles_endpoint_without_scheme() {
+        let url = "example.com/ws?token=secret";
+        // No scheme — pass through unchanged (best-effort).
+        assert_eq!(redact_endpoint(url), "example.com/ws?token=secret");
+    }
 }

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -28,9 +28,9 @@ Examples:
   actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
 
 Cloud providers (-p / --provider):
-  driver          requires DRIVER_DEV_API_KEY (or DRIVER_API_KEY)   # driver.dev
-  hyperbrowser    requires HYPERBROWSER_API_KEY                     # hyperbrowser.ai
-  browseruse      requires BROWSER_USE_API_KEY                      # browser-use.com
+  driver          requires DRIVER_API_KEY          # driver.dev
+  hyperbrowser    requires HYPERBROWSER_API_KEY    # hyperbrowser.ai
+  browseruse      requires BROWSER_USE_API_KEY     # browser-use.com
 
   -p <name> implies --mode cloud and is mutually exclusive with
   --cdp-endpoint and --mode local/extension. The daemon reads each
@@ -92,7 +92,7 @@ pub struct Cmd {
     #[serde(default = "default_stealth")]
     pub stealth: bool,
     /// Snapshot of provider env vars forwarded from the CLI client to the
-    /// daemon (DRIVER_DEV_*, HYPERBROWSER_*, BROWSER_USE_*).
+    /// daemon (DRIVER_*, HYPERBROWSER_*, BROWSER_USE_*).
     /// The daemon must NOT read these from its own process env — its env was
     /// frozen at daemon-spawn time and rarely matches the user's current shell.
     /// This field is populated automatically in `main.rs` before the action is
@@ -120,8 +120,7 @@ fn default_stealth() -> bool {
 fn provider_value_parser() -> clap::builder::PossibleValuesParser {
     use clap::builder::PossibleValue;
     clap::builder::PossibleValuesParser::new([
-        PossibleValue::new("driver")
-            .help("driver.dev — requires DRIVER_DEV_API_KEY (or DRIVER_API_KEY)"),
+        PossibleValue::new("driver").help("driver.dev — requires DRIVER_API_KEY"),
         PossibleValue::new("hyperbrowser").help("hyperbrowser.ai — requires HYPERBROWSER_API_KEY"),
         PossibleValue::new("browseruse")
             .aliases(["browser-use"])

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -27,7 +27,6 @@ Examples:
   actionbook browser start --headless --profile scraper
   actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
   actionbook browser start -p hyperbrowser
-  actionbook browser start --provider browserless
 
 --session: get-or-create — reuses an existing session with the given ID, or creates one if not found.
 --set-session-id: always creates — fails if the ID is already in use.
@@ -70,7 +69,7 @@ pub struct Cmd {
     #[serde(default = "default_stealth")]
     pub stealth: bool,
     /// Snapshot of provider env vars forwarded from the CLI client to the
-    /// daemon (DRIVER_DEV_*, HYPERBROWSER_*, BROWSER_USE_*, BROWSERLESS_*).
+    /// daemon (DRIVER_DEV_*, HYPERBROWSER_*, BROWSER_USE_*).
     /// The daemon must NOT read these from its own process env — its env was
     /// frozen at daemon-spawn time and rarely matches the user's current shell.
     /// This field is populated automatically in `main.rs` before the action is
@@ -234,6 +233,18 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // ── Cloud mode ──────────────────────────────────────────────────
     if mode == Mode::Cloud {
         if let Some(provider_name) = provider_name {
+            // Explicit session IDs can be rejected locally before we create a
+            // provider-managed browser. This is only a fast-path preflight:
+            // `execute_cloud` still performs the authoritative reserve later
+            // so concurrent starts cannot slip through.
+            if effective_set_id.is_some() {
+                let mut reg = registry.lock().await;
+                if let Err(e) = reg.generate_session_id(effective_set_id) {
+                    let hint = e.hint();
+                    return ActionResult::fatal_with_hint(e.error_code(), e.to_string(), &hint);
+                }
+            }
+
             // Provider session reuse: lookup is keyed on (provider, profile),
             // but presence in the registry only proves the entry was once
             // healthy. The remote browser may have been killed by the
@@ -817,7 +828,13 @@ async fn fail_reserved_start(
 /// leak paid provider sessions.
 async fn cleanup_provider_session_if_any(provider_session: &Option<ProviderSession>) {
     if let Some(ps) = provider_session {
-        crate::browser::session::provider::close_provider_session(ps).await;
+        if let Err(err) = crate::browser::session::provider::close_provider_session(ps).await {
+            tracing::warn!(
+                "failed to clean up provider session '{}' for provider '{}': {err}",
+                ps.session_id,
+                ps.provider
+            );
+        }
     }
 }
 
@@ -870,9 +887,10 @@ async fn execute_cloud(
         Ok(u) => u,
         Err(e) => return e,
     };
+    let effective_set_id = cmd.session.as_deref().or(cmd.set_session_id.as_deref());
 
     // ── Cloud session reuse: match on cdp_endpoint ──
-    {
+    if effective_set_id.is_none() {
         let reg = registry.lock().await;
         if let Some(existing) = reg.find_cloud_session_by_endpoint(cdp_endpoint) {
             match existing.status {
@@ -914,7 +932,6 @@ async fn execute_cloud(
     }
 
     // ── Reserve placeholder ──
-    let effective_set_id = cmd.session.as_deref().or(cmd.set_session_id.as_deref());
     let session_id = {
         let mut reg = registry.lock().await;
         match reg.reserve_session_start(
@@ -926,7 +943,10 @@ async fn execute_cloud(
             cmd.stealth,
         ) {
             Ok(sid) => sid,
-            Err(e) => return ActionResult::fatal(e.error_code(), e.to_string()),
+            Err(e) => {
+                cleanup_provider_session_if_any(&provider_session).await;
+                return ActionResult::fatal(e.error_code(), e.to_string());
+            }
         }
     };
 
@@ -1480,10 +1500,10 @@ mod redact_tests {
 
     #[test]
     fn redacts_long_path_segment() {
-        let url = "wss://browserless.io/connect/very-long-opaque-token-segment";
+        let url = "wss://cloud.example.com/connect/very-long-opaque-token-segment";
         let red = redact_endpoint(url);
         assert!(!red.contains("very-long-opaque-token-segment"), "leaked: {red}");
-        assert!(red.starts_with("wss://browserless.io/"));
+        assert!(red.starts_with("wss://cloud.example.com/"));
         assert!(red.ends_with("***"));
     }
 
@@ -1498,5 +1518,224 @@ mod redact_tests {
         let url = "example.com/ws?token=secret";
         // No scheme — pass through unchanged (best-effort).
         assert_eq!(redact_endpoint(url), "example.com/ws?token=secret");
+    }
+}
+
+#[cfg(test)]
+mod provider_start_tests {
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::thread;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::browser::session::provider::{ProviderEnv, ProviderSession};
+    use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
+    use crate::types::SessionId;
+
+    fn spawn_single_response_server(response: &'static str) -> (String, thread::JoinHandle<String>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind mock server");
+        let addr = listener.local_addr().expect("mock server addr");
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            stream
+                .set_read_timeout(Some(Duration::from_secs(2)))
+                .expect("set read timeout");
+
+            let mut request = Vec::new();
+            let mut buf = [0u8; 4096];
+            loop {
+                match stream.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        request.extend_from_slice(&buf[..n]);
+                        if request.windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    Err(err)
+                        if matches!(
+                            err.kind(),
+                            std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                        ) =>
+                    {
+                        break;
+                    }
+                    Err(err) => panic!("read request: {err}"),
+                }
+            }
+
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            String::from_utf8(request).expect("utf8 request")
+        });
+        (format!("http://{}", addr), handle)
+    }
+
+    #[tokio::test]
+    async fn conflicting_set_session_id_cleans_up_provider_session() {
+        let (base_url, request_handle) =
+            spawn_single_response_server("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n");
+        let registry = new_shared_registry();
+
+        let mut existing = SessionEntry::starting(
+            SessionId::new("hyp3").expect("session id"),
+            Mode::Cloud,
+            false,
+            true,
+            crate::config::DEFAULT_PROFILE.to_string(),
+        );
+        existing.status = SessionState::Running;
+        registry.lock().await.insert(existing);
+
+        let result = execute_cloud(
+            &Cmd {
+                mode: Some(Mode::Cloud),
+                headless: Some(false),
+                profile: None,
+                executable_path: None,
+                open_url: None,
+                cdp_endpoint: None,
+                provider: Some("hyperbrowser".to_string()),
+                header: vec![],
+                session: None,
+                set_session_id: Some("hyp3".to_string()),
+                stealth: true,
+                provider_env: ProviderEnv::new(),
+            },
+            &registry,
+            "ws://example.test/devtools/browser/fake",
+            &[],
+            crate::config::DEFAULT_PROFILE,
+            false,
+            Some("hyperbrowser"),
+            Some(ProviderSession {
+                provider: "hyperbrowser".to_string(),
+                session_id: "hb-conflict-1".to_string(),
+                provider_env: ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
+                ]),
+            }),
+        )
+        .await;
+
+        match result {
+            ActionResult::Fatal { code, message, .. } => {
+                assert_eq!(code, "SESSION_ALREADY_EXISTS");
+                assert!(message.contains("session id 'hyp3' is already in use"));
+            }
+            other => panic!("expected fatal result, got {other:?}"),
+        }
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-conflict-1/stop HTTP/1.1"));
+        assert!(request.to_ascii_lowercase().contains("content-length: 0"));
+    }
+
+    #[tokio::test]
+    async fn explicit_provider_session_conflict_fails_before_connect() {
+        let registry = new_shared_registry();
+
+        let mut existing = SessionEntry::starting(
+            SessionId::new("hyp3").expect("session id"),
+            Mode::Cloud,
+            false,
+            true,
+            crate::config::DEFAULT_PROFILE.to_string(),
+        );
+        existing.status = SessionState::Running;
+        registry.lock().await.insert(existing);
+
+        let result = execute(
+            &Cmd {
+                mode: Some(Mode::Cloud),
+                headless: Some(false),
+                profile: None,
+                executable_path: None,
+                open_url: None,
+                cdp_endpoint: None,
+                provider: Some("hyperbrowser".to_string()),
+                header: vec![],
+                session: None,
+                set_session_id: Some("hyp3".to_string()),
+                stealth: true,
+                provider_env: ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    (
+                        "HYPERBROWSER_API_URL".to_string(),
+                        "http://127.0.0.1:9".to_string(),
+                    ),
+                ]),
+            },
+            &registry,
+        )
+        .await;
+
+        match result {
+            ActionResult::Fatal { code, message, .. } => {
+                assert_eq!(code, "SESSION_ALREADY_EXISTS");
+                assert!(message.contains("session id 'hyp3' is already in use"));
+            }
+            other => panic!("expected fatal result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_set_session_id_skips_endpoint_reuse_checks() {
+        let registry = new_shared_registry();
+        let endpoint = "ws://127.0.0.1:9/devtools/browser/fake";
+
+        let mut existing = SessionEntry::starting(
+            SessionId::new("dr3").expect("session id"),
+            Mode::Cloud,
+            false,
+            true,
+            crate::config::DEFAULT_PROFILE.to_string(),
+        );
+        existing.status = SessionState::Starting;
+        existing.cdp_endpoint = Some(endpoint.to_string());
+        existing.provider = Some("browseruse".to_string());
+        registry.lock().await.insert(existing);
+
+        let result = execute_cloud(
+            &Cmd {
+                mode: Some(Mode::Cloud),
+                headless: Some(false),
+                profile: None,
+                executable_path: None,
+                open_url: None,
+                cdp_endpoint: None,
+                provider: Some("browseruse".to_string()),
+                header: vec![],
+                session: None,
+                set_session_id: Some("bs1".to_string()),
+                stealth: true,
+                provider_env: ProviderEnv::new(),
+            },
+            &registry,
+            endpoint,
+            &[],
+            crate::config::DEFAULT_PROFILE,
+            false,
+            Some("browseruse"),
+            None,
+        )
+        .await;
+
+        match result {
+            ActionResult::Fatal { code, .. } => {
+                assert_eq!(code, "CDP_CONNECTION_FAILED");
+            }
+            other => panic!("expected fatal result, got {other:?}"),
+        }
+
+        let reg = registry.lock().await;
+        assert!(reg.get("bs1").is_none(), "failed start should clean placeholder");
+        assert_eq!(
+            reg.get("dr3").map(|entry| entry.status),
+            Some(SessionState::Starting)
+        );
     }
 }

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 
 use crate::action_result::ActionResult;
 use crate::browser::session::provider::{
-    ProviderSession, connect_provider, normalize_provider_name, supported_providers,
+    ProviderEnv, ProviderSession, connect_provider, normalize_provider_name, supported_providers,
 };
 use crate::config;
 use crate::config::DEFAULT_PROFILE;
@@ -69,6 +69,15 @@ pub struct Cmd {
     #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
     #[serde(default = "default_stealth")]
     pub stealth: bool,
+    /// Snapshot of provider env vars forwarded from the CLI client to the
+    /// daemon (DRIVER_DEV_*, HYPERBROWSER_*, BROWSER_USE_*, BROWSERLESS_*).
+    /// The daemon must NOT read these from its own process env — its env was
+    /// frozen at daemon-spawn time and rarely matches the user's current shell.
+    /// This field is populated automatically in `main.rs` before the action is
+    /// sent over IPC, so callers do not need to set it.
+    #[arg(skip)]
+    #[serde(default)]
+    pub provider_env: ProviderEnv,
 }
 
 fn default_stealth() -> bool {
@@ -295,11 +304,18 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 drop(reg);
             }
 
-            let provider_connection =
-                match connect_provider(provider_name, profile_name, headless, cmd.stealth).await {
-                    Ok(connection) => connection,
-                    Err(err) => return ActionResult::fatal(err.error_code(), err.to_string()),
-                };
+            let provider_connection = match connect_provider(
+                provider_name,
+                profile_name,
+                headless,
+                cmd.stealth,
+                &cmd.provider_env,
+            )
+            .await
+            {
+                Ok(connection) => connection,
+                Err(err) => return ActionResult::fatal(err.error_code(), err.to_string()),
+            };
 
             let mut combined_headers = provider_connection.headers.clone();
             combined_headers.extend(headers.clone());

--- a/packages/cli/src/browser/session/status.rs
+++ b/packages/cli/src/browser/session/status.rs
@@ -68,6 +68,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     if let Some(ref ep) = entry.cdp_endpoint {
         session["cdp_endpoint"] = json!(crate::browser::session::start::redact_endpoint(ep));
     }
+    if let Some(ref provider) = entry.provider {
+        session["provider"] = json!(provider);
+    }
     ActionResult::ok(json!({
         "session": session,
         "tabs": tabs,

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -1114,6 +1114,8 @@ mod tests {
             "start",
             "--session",
             "my-session",
+            "-p",
+            "hyperbrowser",
             "--headless",
         ])
         .expect("browser start --session should parse");
@@ -1123,6 +1125,7 @@ mod tests {
                 command: BrowserCommands::Start(cmd),
             }) => {
                 assert_eq!(cmd.session.as_deref(), Some("my-session"));
+                assert_eq!(cmd.provider.as_deref(), Some("hyperbrowser"));
                 assert!(
                     cmd.set_session_id.is_none(),
                     "set_session_id should be None when --session is used"

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -429,7 +429,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
             ("ACTIONBOOK_BROWSER_PROFILE_NAME", Some("env-profile")),
             ("ACTIONBOOK_BROWSER_HEADLESS", Some("true")),
             ("ACTIONBOOK_BROWSER_EXECUTABLE_PATH", Some("/env/browser")),
-            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browserless")),
+            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browseruse")),
             (
                 "ACTIONBOOK_BROWSER_CDP_ENDPOINT",
                 Some("ws://127.0.0.1:9444/devtools/browser/env"),
@@ -442,7 +442,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
         assert_eq!(resolved.headless, Some(true));
         assert_eq!(resolved.profile.as_deref(), Some("env-profile"));
         assert_eq!(resolved.executable_path.as_deref(), Some("/env/browser"));
-        assert_eq!(resolved.provider.as_deref(), Some("browserless"));
+        assert_eq!(resolved.provider.as_deref(), Some("browseruse"));
         assert_eq!(
             resolved.cdp_endpoint.as_deref(),
             Some("ws://127.0.0.1:9444/devtools/browser/env")
@@ -458,7 +458,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
             ("ACTIONBOOK_BROWSER_PROFILE_NAME", Some("env-profile")),
             ("ACTIONBOOK_BROWSER_HEADLESS", Some("false")),
             ("ACTIONBOOK_BROWSER_EXECUTABLE_PATH", Some("/env/browser")),
-            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browserless")),
+            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browseruse")),
             (
                 "ACTIONBOOK_BROWSER_CDP_ENDPOINT",
                 Some("ws://127.0.0.1:9444/devtools/browser/env"),

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -382,6 +382,7 @@ mod tests {
             session: None,
             set_session_id: None,
             stealth: true,
+            provider_env: Default::default(),
         }
     }
 

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -45,6 +45,7 @@ pub(crate) struct BrowserConfig {
     pub(crate) profile_name: String,
     #[serde(alias = "executable")]
     pub(crate) executable_path: Option<String>,
+    pub(crate) provider: Option<String>,
     #[serde(alias = "cdp-endpoint", alias = "cdp_endpoint")]
     pub(crate) cdp_endpoint: Option<String>,
 }
@@ -56,6 +57,7 @@ impl Default for BrowserConfig {
             headless: false,
             profile_name: default_profile_name(),
             executable_path: None,
+            provider: None,
             cdp_endpoint: None,
         }
     }
@@ -181,6 +183,9 @@ fn migrate_config(path: &std::path::Path, raw: &toml::Value) -> Result<ConfigFil
         {
             config.browser.executable_path = Some(exec.to_string());
         }
+        if let Some(provider) = browser.get("provider").and_then(|v| v.as_str()) {
+            config.browser.provider = Some(provider.to_string());
+        }
         if let Some(cdp) = browser
             .get("cdp_endpoint")
             .or_else(|| browser.get("cdp-endpoint"))
@@ -257,15 +262,22 @@ fn normalize_optional(value: Option<String>) -> Option<String> {
 pub fn resolve_start_command(mut cmd: StartCmd) -> Result<StartCmd, CliError> {
     let config = load_config()?;
 
+    let cli_mode_explicit = cmd.mode.is_some();
     let env_mode = parse_env_mode("ACTIONBOOK_BROWSER_MODE")?;
+    let env_mode_explicit = env_mode.is_some();
     let env_profile = read_trimmed_env("ACTIONBOOK_BROWSER_PROFILE_NAME");
     let env_headless = parse_env_bool("ACTIONBOOK_BROWSER_HEADLESS")?;
     let env_executable = read_trimmed_env("ACTIONBOOK_BROWSER_EXECUTABLE_PATH");
+    let env_provider = read_trimmed_env("ACTIONBOOK_BROWSER_PROVIDER");
     let env_cdp = read_trimmed_env("ACTIONBOOK_BROWSER_CDP_ENDPOINT");
 
     let config_profile = normalize_optional(Some(config.browser.profile_name.clone()));
     let config_executable = normalize_optional(config.browser.executable_path.clone());
+    let config_provider = normalize_optional(config.browser.provider.clone());
     let config_cdp = normalize_optional(config.browser.cdp_endpoint.clone());
+    let resolved_provider = normalize_optional(cmd.provider.clone())
+        .or(env_provider)
+        .or(config_provider);
 
     let resolved_mode = cmd.mode.or(env_mode).unwrap_or(config.browser.mode);
     let resolved_headless = cmd
@@ -286,9 +298,18 @@ pub fn resolve_start_command(mut cmd: StartCmd) -> Result<StartCmd, CliError> {
     cmd.headless = Some(resolved_headless);
     cmd.profile = explicit_profile.then_some(resolved_profile);
     cmd.executable_path = env_executable.or(config_executable);
+    cmd.provider = resolved_provider.clone();
     cmd.cdp_endpoint = normalize_optional(cmd.cdp_endpoint)
         .or(env_cdp)
         .or(config_cdp);
+
+    if cmd.provider.is_some()
+        && !matches!(cmd.mode, Some(Mode::Cloud))
+        && !cli_mode_explicit
+        && !env_mode_explicit
+    {
+        cmd.mode = Some(Mode::Cloud);
+    }
 
     Ok(cmd)
 }
@@ -342,6 +363,7 @@ mod tests {
             ("ACTIONBOOK_BROWSER_PROFILE_NAME", None),
             ("ACTIONBOOK_BROWSER_HEADLESS", None),
             ("ACTIONBOOK_BROWSER_EXECUTABLE_PATH", None),
+            ("ACTIONBOOK_BROWSER_PROVIDER", None),
             ("ACTIONBOOK_BROWSER_CDP_ENDPOINT", None),
         ]);
         (tmp, guard)
@@ -355,6 +377,7 @@ mod tests {
             executable_path: None,
             open_url: None,
             cdp_endpoint: None,
+            provider: None,
             header: vec![],
             session: None,
             set_session_id: None,
@@ -394,6 +417,7 @@ mode = "extension"
 profile_name = "config-profile"
 headless = false
 executable_path = "/config/browser"
+provider = "hyperbrowser"
 cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
 "#,
         )
@@ -404,6 +428,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
             ("ACTIONBOOK_BROWSER_PROFILE_NAME", Some("env-profile")),
             ("ACTIONBOOK_BROWSER_HEADLESS", Some("true")),
             ("ACTIONBOOK_BROWSER_EXECUTABLE_PATH", Some("/env/browser")),
+            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browserless")),
             (
                 "ACTIONBOOK_BROWSER_CDP_ENDPOINT",
                 Some("ws://127.0.0.1:9444/devtools/browser/env"),
@@ -416,6 +441,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
         assert_eq!(resolved.headless, Some(true));
         assert_eq!(resolved.profile.as_deref(), Some("env-profile"));
         assert_eq!(resolved.executable_path.as_deref(), Some("/env/browser"));
+        assert_eq!(resolved.provider.as_deref(), Some("browserless"));
         assert_eq!(
             resolved.cdp_endpoint.as_deref(),
             Some("ws://127.0.0.1:9444/devtools/browser/env")
@@ -431,6 +457,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
             ("ACTIONBOOK_BROWSER_PROFILE_NAME", Some("env-profile")),
             ("ACTIONBOOK_BROWSER_HEADLESS", Some("false")),
             ("ACTIONBOOK_BROWSER_EXECUTABLE_PATH", Some("/env/browser")),
+            ("ACTIONBOOK_BROWSER_PROVIDER", Some("browserless")),
             (
                 "ACTIONBOOK_BROWSER_CDP_ENDPOINT",
                 Some("ws://127.0.0.1:9444/devtools/browser/env"),
@@ -441,6 +468,7 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
         cmd.mode = Some(Mode::Local);
         cmd.headless = Some(true);
         cmd.profile = Some("cli-profile".to_string());
+        cmd.provider = Some("hyperbrowser".to_string());
         cmd.cdp_endpoint = Some("ws://127.0.0.1:9555/devtools/browser/cli".to_string());
 
         let resolved = resolve_start_command(cmd).expect("resolve");
@@ -448,10 +476,23 @@ cdp_endpoint = "ws://127.0.0.1:9333/devtools/browser/config"
         assert_eq!(resolved.mode, Some(Mode::Local));
         assert_eq!(resolved.headless, Some(true));
         assert_eq!(resolved.profile.as_deref(), Some("cli-profile"));
+        assert_eq!(resolved.provider.as_deref(), Some("hyperbrowser"));
         assert_eq!(
             resolved.cdp_endpoint.as_deref(),
             Some("ws://127.0.0.1:9555/devtools/browser/cli")
         );
+    }
+
+    #[test]
+    fn provider_env_defaults_mode_to_cloud_when_mode_is_implicit() {
+        let _lock = test_lock();
+        let (_tmp, _guard) = make_home();
+        let _env = EnvGuard::set(&[("ACTIONBOOK_BROWSER_PROVIDER", Some("hyperbrowser"))]);
+
+        let resolved = resolve_start_command(base_cmd()).expect("resolve");
+
+        assert_eq!(resolved.provider.as_deref(), Some("hyperbrowser"));
+        assert_eq!(resolved.mode, Some(Mode::Cloud));
     }
 
     #[test]

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -6,7 +6,7 @@ use tokio::sync::Mutex;
 
 use crate::action_result::ActionResult;
 use crate::browser::observation::snapshot_transform::RefCache;
-use crate::browser::session::provider::ProviderSession;
+use crate::browser::session::provider::{ProviderSession, normalize_provider_name};
 use crate::daemon::bridge::SharedBridgeState;
 use crate::daemon::cdp_session::CdpSession;
 use crate::error::CliError;
@@ -217,10 +217,15 @@ impl SessionRegistry {
         provider: &str,
         profile: &str,
     ) -> Option<&SessionEntry> {
+        let normalized = normalize_provider_name(provider).unwrap_or(provider);
         self.sessions.values().find(|entry| {
             entry.mode == Mode::Cloud
                 && entry.status.is_active()
-                && entry.provider.as_deref() == Some(provider)
+                && entry
+                    .provider
+                    .as_deref()
+                    .unwrap_or_default()
+                    == normalized
                 && entry.profile == profile
         })
     }

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -26,10 +26,19 @@ pub struct TabEntry {
 pub enum SessionState {
     Starting,
     Running,
+    /// A `browser close` is in flight for this entry. Set atomically under the
+    /// registry lock at the start of `close::execute` so concurrent close calls
+    /// on the same session short-circuit instead of issuing a second provider
+    /// API stop (which races against the first stop's success).
+    Closing,
     Closed,
 }
 
 impl SessionState {
+    /// Active means "holds live resources that reuse/health checks can target."
+    /// `Closing` is intentionally NOT active: a session being torn down must
+    /// not be selected by reuse lookups mid-close, otherwise the agent could
+    /// attach to a handle that's about to disappear.
     pub fn is_active(self) -> bool {
         matches!(self, Self::Starting | Self::Running)
     }
@@ -40,6 +49,7 @@ impl fmt::Display for SessionState {
         match self {
             SessionState::Starting => write!(f, "starting"),
             SessionState::Running => write!(f, "running"),
+            SessionState::Closing => write!(f, "closing"),
             SessionState::Closed => write!(f, "closed"),
         }
     }
@@ -212,6 +222,12 @@ impl SessionRegistry {
         })
     }
 
+    /// Return an active cloud session that was launched via `--provider <name>` and
+    /// for the given profile. Only provider-minted sessions are eligible for reuse:
+    /// stateless WS-URL overrides (DRIVER_DEV_WS_URL / BROWSER_USE_WS_URL) are stored
+    /// with `provider = Some(...)` but `provider_session = None`, and must be
+    /// reconnected every time because their config comes from the current shell env.
+    /// Reusing them would silently ignore URL/credential changes between starts.
     pub fn find_cloud_session_by_provider(
         &self,
         provider: &str,
@@ -227,6 +243,9 @@ impl SessionRegistry {
                     .unwrap_or_default()
                     == normalized
                 && entry.profile == profile
+                // Stateless WS-URL override sessions carry no provider handle;
+                // force them to reconnect so env changes take effect.
+                && entry.provider_session.is_some()
         })
     }
 
@@ -733,5 +752,55 @@ mod tests {
             !alive,
             "Chrome process should be killed when SessionEntry is dropped"
         );
+    }
+
+    #[test]
+    fn find_cloud_session_by_provider_ignores_ws_url_overrides() {
+        // Stateless WS-URL overrides (DRIVER_DEV_WS_URL / BROWSER_USE_WS_URL)
+        // store `provider = Some(...)` so list/status UIs still show the tag,
+        // but MUST NOT be reused by `browser start -p <name>` — the user may
+        // have pointed the env var at a new endpoint or rotated a key, and
+        // silent reuse would keep attaching to the old remote browser.
+        let mut registry = SessionRegistry::new();
+        let mut entry = SessionEntry::starting(
+            SessionId::new("override-1").unwrap(),
+            Mode::Cloud,
+            false,
+            true,
+            "actionbook".to_string(),
+        );
+        entry.status = SessionState::Running;
+        entry.provider = Some("driver".to_string());
+        entry.provider_session = None; // ← override path leaves this unset
+        registry.insert(entry);
+
+        assert!(
+            registry
+                .find_cloud_session_by_provider("driver", "actionbook")
+                .is_none(),
+            "override sessions (no provider_session handle) must not be reused"
+        );
+
+        // Sanity: a provider-minted session with a handle does get reused.
+        let mut minted = SessionEntry::starting(
+            SessionId::new("minted-1").unwrap(),
+            Mode::Cloud,
+            false,
+            true,
+            "actionbook".to_string(),
+        );
+        minted.status = SessionState::Running;
+        minted.provider = Some("driver".to_string());
+        minted.provider_session = Some(ProviderSession {
+            provider: "driver".to_string(),
+            session_id: "remote-abc".to_string(),
+            provider_env: Default::default(),
+        });
+        registry.insert(minted);
+
+        let found = registry
+            .find_cloud_session_by_provider("driver", "actionbook")
+            .expect("provider-minted session should be reusable");
+        assert_eq!(found.id.as_str(), "minted-1");
     }
 }

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -6,6 +6,7 @@ use tokio::sync::Mutex;
 
 use crate::action_result::ActionResult;
 use crate::browser::observation::snapshot_transform::RefCache;
+use crate::browser::session::provider::ProviderSession;
 use crate::daemon::bridge::SharedBridgeState;
 use crate::daemon::cdp_session::CdpSession;
 use crate::error::CliError;
@@ -63,6 +64,10 @@ pub struct SessionEntry {
     pub cdp_endpoint: Option<String>,
     /// Custom headers for cloud CDP connections (e.g. auth tokens).
     pub headers: Vec<(String, String)>,
+    /// Launch-time provider name for provider-backed cloud sessions.
+    pub provider: Option<String>,
+    /// Provider-managed remote session metadata used for cleanup.
+    pub provider_session: Option<ProviderSession>,
     /// Counter for assigning short tab IDs (t1, t2, ...).
     pub next_tab_id: u32,
 }
@@ -98,6 +103,8 @@ impl SessionEntry {
             cdp: None,
             cdp_endpoint: None,
             headers: Vec::new(),
+            provider: None,
+            provider_session: None,
             next_tab_id: 1,
         }
     }
@@ -202,6 +209,19 @@ impl SessionRegistry {
             entry.mode == Mode::Cloud
                 && entry.status.is_active()
                 && entry.cdp_endpoint.as_deref() == Some(endpoint)
+        })
+    }
+
+    pub fn find_cloud_session_by_provider(
+        &self,
+        provider: &str,
+        profile: &str,
+    ) -> Option<&SessionEntry> {
+        self.sessions.values().find(|entry| {
+            entry.mode == Mode::Cloud
+                && entry.status.is_active()
+                && entry.provider.as_deref() == Some(provider)
+                && entry.profile == profile
         })
     }
 

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -53,6 +53,12 @@ pub enum CliError {
     VersionMismatch { cli: String, daemon: String },
     #[error("api error: {0}")]
     ApiError(String),
+    #[error("api unauthorized: {0}")]
+    ApiUnauthorized(String),
+    #[error("api rate limited: {0}")]
+    ApiRateLimited(String),
+    #[error("api server error: {0}")]
+    ApiServerError(String),
     #[error("internal error: {0}")]
     Internal(String),
 }
@@ -85,6 +91,9 @@ impl CliError {
             CliError::CloudConnectionLost(_) => "CLOUD_CONNECTION_LOST",
             CliError::VersionMismatch { .. } => "VERSION_MISMATCH",
             CliError::ApiError(_) => "API_ERROR",
+            CliError::ApiUnauthorized(_) => "API_UNAUTHORIZED",
+            CliError::ApiRateLimited(_) => "API_RATE_LIMITED",
+            CliError::ApiServerError(_) => "API_SERVER_ERROR",
             CliError::Internal(_) => "INTERNAL_ERROR",
         }
     }
@@ -113,6 +122,18 @@ impl CliError {
                 "the session was closed while a command was still in flight — start a new session"
                     .to_string()
             }
+            CliError::ApiUnauthorized(_) => {
+                "check the provider API key environment variable (e.g. HYPERBROWSER_API_KEY, BROWSERLESS_API_KEY) and rotate it if revoked"
+                    .to_string()
+            }
+            CliError::ApiRateLimited(_) => {
+                "the provider rejected the request due to rate limiting — back off and retry later"
+                    .to_string()
+            }
+            CliError::ApiServerError(_) => {
+                "the provider service returned a 5xx error — retry after a short delay or check the provider's status page"
+                    .to_string()
+            }
             _ => String::new(),
         }
     }
@@ -125,6 +146,8 @@ impl CliError {
                 | CliError::CloudConnectionLost(_)
                 | CliError::Timeout
                 | CliError::Http(_)
+                | CliError::ApiRateLimited(_)
+                | CliError::ApiServerError(_)
         )
     }
 }

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -123,7 +123,7 @@ impl CliError {
                     .to_string()
             }
             CliError::ApiUnauthorized(_) => {
-                "check the provider API key environment variable (e.g. HYPERBROWSER_API_KEY, DRIVER_DEV_API_KEY, BROWSER_USE_API_KEY) and rotate it if revoked"
+                "check the provider API key environment variable (e.g. HYPERBROWSER_API_KEY, DRIVER_API_KEY, BROWSER_USE_API_KEY) and rotate it if revoked"
                     .to_string()
             }
             CliError::ApiRateLimited(_) => {

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -123,7 +123,7 @@ impl CliError {
                     .to_string()
             }
             CliError::ApiUnauthorized(_) => {
-                "check the provider API key environment variable (e.g. HYPERBROWSER_API_KEY, BROWSERLESS_API_KEY) and rotate it if revoked"
+                "check the provider API key environment variable (e.g. HYPERBROWSER_API_KEY, DRIVER_DEV_API_KEY, BROWSER_USE_API_KEY) and rotate it if revoked"
                     .to_string()
             }
             CliError::ApiRateLimited(_) => {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -192,6 +192,7 @@ async fn handle_browser(
                         executable_path: None,
                         open_url: None,
                         cdp_endpoint: None,
+                        provider: None,
                         header: vec![],
                         session: None,
                         set_session_id: None,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -182,7 +182,14 @@ async fn handle_browser(
     let start = Instant::now();
     let command = match command {
         BrowserCommands::Start(cmd) => match config::resolve_start_command(cmd) {
-            Ok(cmd) => BrowserCommands::Start(cmd),
+            Ok(mut cmd) => {
+                // Forward provider env vars from the CLI client's process env
+                // to the daemon. The daemon's own env was frozen at spawn time
+                // and can't be relied on to match the user's current shell.
+                cmd.provider_env =
+                    actionbook_cli::browser::session::provider::collect_provider_env_from_process();
+                BrowserCommands::Start(cmd)
+            }
             Err(err) => {
                 let failed_command =
                     BrowserCommands::Start(actionbook_cli::browser::session::start::Cmd {
@@ -197,6 +204,7 @@ async fn handle_browser(
                         session: None,
                         set_session_id: None,
                         stealth: true,
+                        provider_env: Default::default(),
                     });
                 let result = ActionResult::fatal(err.error_code(), err.to_string());
                 let duration = start.elapsed();
@@ -212,6 +220,13 @@ async fn handle_browser(
                 std::process::exit(1);
             }
         },
+        BrowserCommands::Restart(mut cmd) => {
+            // Same env-forwarding rule applies to restart, since stateful
+            // providers re-mint their remote session and need fresh creds.
+            cmd.provider_env =
+                actionbook_cli::browser::session::provider::collect_provider_env_from_process();
+            BrowserCommands::Restart(cmd)
+        }
         other => other,
     };
 

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -282,6 +282,13 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             {
                 lines.push(format!("status: {status}"));
             }
+            if let Some(provider) = data
+                .get("session")
+                .and_then(|s| s.get("provider"))
+                .and_then(|v| v.as_str())
+            {
+                lines.push(format!("provider: {provider}"));
+            }
             if let Some(title) = data
                 .get("tab")
                 .and_then(|t| t.get("title"))
@@ -316,6 +323,9 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                 }
                 if let Some(mode) = s.get("mode").and_then(|v| v.as_str()) {
                     lines.push(format!("mode: {mode}"));
+                }
+                if let Some(provider) = s.get("provider").and_then(|v| v.as_str()) {
+                    lines.push(format!("provider: {provider}"));
                 }
                 if let Some(tabs) = s.get("tabs_count").and_then(|v| v.as_u64()) {
                     lines.push(format!("tabs: {tabs}"));


### PR DESCRIPTION
## Summary
- add and harden cloud provider session lifecycle handling across start, restart, close, status, and list flows
- standardize the driver provider name to `driver`, remove `browserless`, and tighten provider/env handling
- fix provider cleanup, explicit session-id conflicts, Browser Use session creation/stop behavior, and macOS release binary stability

## Details
- add provider-managed session support and registry metadata for cloud sessions
- fail `browser close` when provider-side cleanup fails instead of silently dropping the local session
- clean up leaked provider sessions when `--set-session-id` conflicts after provider creation
- skip cloud endpoint reuse when an explicit `--session` / `--set-session-id` is requested
- switch Browser Use to API-backed session create/stop by default, with `BROWSER_USE_WS_URL` kept as an explicit stateless override
- remove `browserless` support from provider resolution, env forwarding, config examples, and help text
- disable release LTO in `packages/cli` to avoid macOS-installed release binaries getting SIGKILLed before browser commands reach the daemon

## Validation
- `cargo test -p actionbook-cli browser::session::provider::tests -- --nocapture`
- `cargo test -p actionbook-cli browser::session::close::tests -- --nocapture`
- `cargo test -p actionbook-cli browser::session::start::provider_start_tests -- --nocapture`
- `cargo test -p actionbook-cli config::tests -- --nocapture`
- live checks with local builds for `hyperbrowser` and `driver` start/goto/close flows

## Notes
- `driver.dev` is no longer accepted as a provider name; use `driver`
- `browserless` is no longer supported
- Browser Use remote sessions now require provider-side stop instead of assuming WebSocket disconnect is sufficient