### PR TITLE
chore: add changeset for Windows Chrome cleanup patch (PR #510)

### DIFF
--- a/.changeset/windows-e2e-chrome-cleanup.md
+++ b/.changeset/windows-e2e-chrome-cleanup.md
@@ -1,0 +1,10 @@
+---
+"@actionbookdev/cli": patch
+---
+
+Fix Windows Chrome process cleanup and improve orphan recovery.
+
+- Replace NtQueryInformationProcess/ToolHelp with Win32 Job Objects for atomic termination of Chrome helper processes (renderer, GPU, utility)
+- Delete Chrome singleton lock files before orphan kill so new sessions can start even if helper processes linger
+- Add actionable error message when orphan Chrome still holds the user-data-dir lock
+- Fix 54 Windows e2e test cross-platform compatibility issues


### PR DESCRIPTION
Adds a `patch` changeset for the changes merged in PR #510.

## Changes included
- Win32 Job Objects for atomic Chrome helper process termination
- Singleton lock file cleanup before orphan kill
- 54 Windows e2e test cross-platform fixes
- Actionable orphan error message on Windows

This will bump `@actionbookdev/cli` from `1.4.0` → `1.4.1`.