### PR TITLE
feat(eval): scope isolation, pre-context, structured error details

### DIFF
--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -117,7 +117,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         // Sync expressions work fine inside async functions too (awaitPromise unwraps).
         let has_await = cmd.expression.contains("await ") || cmd.expression.contains("await(");
         if has_await {
-            format!("(async function(){{ return ({}); }})()", cmd.expression)
+            format!("(async function(){{ return (\n{}\n); }})()", cmd.expression)
         } else {
             let escaped = serde_json::to_string(&cmd.expression).unwrap_or_default();
             format!("(function(){{ return eval({}); }})()", escaped)

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -30,6 +30,10 @@ pub struct Cmd {
     #[arg(long)]
     #[serde(rename = "tab_id")]
     pub tab: String,
+    /// Disable scope isolation (allow let/const to persist across evals on the same tab)
+    #[arg(long)]
+    #[serde(default)]
+    pub no_isolate: bool,
 }
 
 pub const COMMAND_NAME: &str = "browser eval";
@@ -77,11 +81,46 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         )
         .await;
 
+    // Capture pre-execution page context for diagnostics.
+    let pre_url = navigation::get_tab_url(&cdp, &target_id).await;
+    let pre_origin = navigation::get_tab_origin(&cdp, &target_id).await;
+    let pre_ready_state = navigation::get_tab_ready_state(&cdp, &target_id).await;
+
+    // Build the expression to send to CDP.
+    // By default, isolate scope so let/const don't leak across evals:
+    //
+    // - Expressions without top-level `await`: wrap with a regular function + eval().
+    //   eval() preserves the completion value of multi-statement programs and
+    //   scopes let/const to the function, preventing leakage.
+    //
+    // - Expressions with top-level `await`: embed directly in an async function body.
+    //   eval() cannot inherit async context in this Chrome version (eval'd strings
+    //   are parsed as Scripts, where await is invalid). The async IIFE makes await
+    //   syntactically valid while still isolating let/const to the function scope.
+    //   awaitPromise: true (already set) resolves the returned Promise.
+    //
+    // With --no-isolate, pass the expression directly (old behavior).
+    let expression = if cmd.no_isolate {
+        cmd.expression.clone()
+    } else {
+        let t = cmd.expression.trim_start();
+        let has_top_level_await = t.starts_with("await ")
+            || t.starts_with("await\t")
+            || t.starts_with("await\n")
+            || t.starts_with("await(");
+        if has_top_level_await {
+            format!("(async function(){{ return ({}); }})()", cmd.expression)
+        } else {
+            let escaped = serde_json::to_string(&cmd.expression).unwrap_or_default();
+            format!("(function(){{ return eval({}); }})()", escaped)
+        }
+    };
+
     let resp = match cdp
         .execute_on_tab(
             &target_id,
             "Runtime.evaluate",
-            json!({ "expression": cmd.expression, "returnByValue": true, "awaitPromise": true }),
+            json!({ "expression": expression, "returnByValue": true, "awaitPromise": true }),
         )
         .await
     {
@@ -98,7 +137,22 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 .and_then(|v| v.as_str())
                 .or_else(|| exc.get("text").and_then(|v| v.as_str()))
                 .unwrap_or("expression error");
-            return ActionResult::fatal("EVAL_FAILED", emsg.to_string());
+
+            let error_type = exc
+                .pointer("/exception/className")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Error")
+                .to_string();
+
+            let details = json!({
+                "stage": "eval",
+                "pre_url": pre_url,
+                "pre_origin": pre_origin,
+                "pre_readyState": pre_ready_state,
+                "error_type": error_type,
+            });
+
+            return ActionResult::fatal_with_details("EVAL_FAILED", emsg.to_string(), "", details);
         }
 
         let js_type = result
@@ -122,15 +176,18 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 }
             });
 
-        let url = navigation::get_tab_url(&cdp, &target_id).await;
-        let title = navigation::get_tab_title(&cdp, &target_id).await;
+        let post_url = navigation::get_tab_url(&cdp, &target_id).await;
+        let post_title = navigation::get_tab_title(&cdp, &target_id).await;
 
         ActionResult::ok(json!({
             "value": value,
             "type": js_type,
             "preview": preview,
-            "post_url": url,
-            "post_title": title,
+            "pre_url": pre_url,
+            "pre_origin": pre_origin,
+            "pre_readyState": pre_ready_state,
+            "post_url": post_url,
+            "post_title": post_title,
         }))
     } else {
         ActionResult::fatal("EVAL_FAILED", "no result in CDP response")

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -18,7 +18,16 @@ Examples:
   actionbook browser eval \"document.querySelectorAll('a').length\" --session s1 --tab t1
 
 Evaluates a JavaScript expression in the page context and returns the result.
-The expression is evaluated via Runtime.evaluate with returnByValue.")]
+The expression is evaluated via Runtime.evaluate with returnByValue.
+
+By default each eval runs in an isolated scope so that let/const declarations do
+not leak across calls on the same tab.  Single-expression await works transparently
+(e.g. 'await fetch(url).then(r => r.json())').
+
+Note: Multi-statement expressions that contain 'await' (e.g.
+'let x = await Promise.resolve(42); x + 1') are not supported under the default
+isolated mode — use --no-isolate or wrap the body in an explicit async arrow:
+  actionbook browser eval \"(async () => { let x = await f(); return x + 1; })()\" ...")]
 pub struct Cmd {
     /// JavaScript expression
     pub expression: String,

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -103,12 +103,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let expression = if cmd.no_isolate {
         cmd.expression.clone()
     } else {
-        let t = cmd.expression.trim_start();
-        let has_top_level_await = t.starts_with("await ")
-            || t.starts_with("await\t")
-            || t.starts_with("await\n")
-            || t.starts_with("await(");
-        if has_top_level_await {
+        // Detect top-level `await` anywhere in the expression (not just at start).
+        // e.g. `(await Promise.resolve(42)) + 1` has await after `(`.
+        // Sync expressions work fine inside async functions too (awaitPromise unwraps).
+        let has_await = cmd.expression.contains("await ") || cmd.expression.contains("await(");
+        if has_await {
             format!("(async function(){{ return ({}); }})()", cmd.expression)
         } else {
             let escaped = serde_json::to_string(&cmd.expression).unwrap_or_default();
@@ -125,7 +124,16 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         .await
     {
         Ok(v) => v,
-        Err(e) => return crate::daemon::cdp_session::cdp_error_to_result(e, "EVAL_FAILED"),
+        Err(e) => {
+            let details = json!({
+                "stage": "eval",
+                "pre_url": pre_url,
+                "pre_origin": pre_origin,
+                "pre_readyState": pre_ready_state,
+                "error_type": "CdpError",
+            });
+            return ActionResult::fatal_with_details("EVAL_FAILED", e.to_string(), "", details);
+        }
     };
 
     // Extract value from CDP response
@@ -190,6 +198,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             "post_title": post_title,
         }))
     } else {
-        ActionResult::fatal("EVAL_FAILED", "no result in CDP response")
+        let details = json!({
+            "stage": "eval",
+            "pre_url": pre_url,
+            "pre_origin": pre_origin,
+            "pre_readyState": pre_ready_state,
+            "error_type": "CdpError",
+        });
+        ActionResult::fatal_with_details("EVAL_FAILED", "no result in CDP response", "", details)
     }
 }

--- a/packages/cli/src/browser/navigation/mod.rs
+++ b/packages/cli/src/browser/navigation/mod.rs
@@ -31,3 +31,29 @@ pub async fn get_tab_title(cdp: &CdpSession, target_id: &str) -> String {
     .and_then(|v| v["result"]["result"]["value"].as_str().map(String::from))
     .unwrap_or_default()
 }
+
+/// Get the current readyState of a tab via Runtime.evaluate.
+pub async fn get_tab_ready_state(cdp: &CdpSession, target_id: &str) -> String {
+    cdp.execute_on_tab(
+        target_id,
+        "Runtime.evaluate",
+        json!({"expression": "document.readyState", "returnByValue": true}),
+    )
+    .await
+    .ok()
+    .and_then(|v| v["result"]["result"]["value"].as_str().map(String::from))
+    .unwrap_or_default()
+}
+
+/// Get the current origin of a tab via Runtime.evaluate.
+pub async fn get_tab_origin(cdp: &CdpSession, target_id: &str) -> String {
+    cdp.execute_on_tab(
+        target_id,
+        "Runtime.evaluate",
+        json!({"expression": "location.origin", "returnByValue": true}),
+    )
+    .await
+    .ok()
+    .and_then(|v| v["result"]["result"]["value"].as_str().map(String::from))
+    .unwrap_or_default()
+}

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -5529,6 +5529,32 @@ fn eval_error_details_has_context() {
     close_session(&sid);
 }
 
+#[test]
+fn eval_async_trailing_line_comment() {
+    // Regression: async-wrapped expressions ending with a single-line comment
+    // used to comment out the generated closing tokens `); }})()`, causing a
+    // SyntaxError.  The fix adds a newline before the closing tokens.
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(
+        &sid,
+        &tid,
+        "await Promise.resolve(1) // trailing comment",
+        &[],
+    );
+    assert_eq!(
+        v["data"]["value"],
+        serde_json::json!(1),
+        "async expression with trailing line comment should resolve to 1"
+    );
+
+    close_session(&sid);
+}
+
 // ========================================================================
 // Group 20: mouse-move — command wiring, success path, and error path
 // ========================================================================

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -495,21 +495,50 @@ fn close_session(session_id: &str) {
     assert_success(&out, &format!("close {session_id}"));
 }
 
-fn eval_value(session_id: &str, tab_id: &str, expression: &str) -> String {
-    let out = headless_json(
-        &[
-            "browser",
-            "eval",
-            expression,
-            "--session",
-            session_id,
-            "--tab",
-            tab_id,
-        ],
-        15,
-    );
+fn eval_json_with_flags(
+    session_id: &str,
+    tab_id: &str,
+    expression: &str,
+    extra_flags: &[&str],
+) -> serde_json::Value {
+    let mut args = vec![
+        "browser",
+        "eval",
+        expression,
+        "--session",
+        session_id,
+        "--tab",
+        tab_id,
+    ];
+    args.extend_from_slice(extra_flags);
+    let out = headless_json(&args, 15);
     assert_success(&out, "eval");
-    let v = parse_json(&out);
+    parse_json(&out)
+}
+
+fn eval_failure_json_with_flags(
+    session_id: &str,
+    tab_id: &str,
+    expression: &str,
+    extra_flags: &[&str],
+) -> serde_json::Value {
+    let mut args = vec![
+        "browser",
+        "eval",
+        expression,
+        "--session",
+        session_id,
+        "--tab",
+        tab_id,
+    ];
+    args.extend_from_slice(extra_flags);
+    let out = headless_json(&args, 15);
+    assert_failure(&out, "eval");
+    parse_json(&out)
+}
+
+fn eval_value(session_id: &str, tab_id: &str, expression: &str) -> String {
+    let v = eval_json_with_flags(session_id, tab_id, expression, &[]);
     v["data"]["value"].as_str().unwrap_or("").to_string()
 }
 
@@ -5285,7 +5314,223 @@ fn eval_exception_text() {
 }
 
 // ========================================================================
-// Group 19: mouse-move — command wiring, success path, and error path
+// Group 19: eval improvements — scope isolation, pre-context, details
+// ========================================================================
+
+#[test]
+fn eval_scope_isolation_default() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let first = eval_json_with_flags(&sid, &tid, "let x = 42; x", &[]);
+    assert_eq!(first["data"]["value"], serde_json::json!(42));
+
+    let second = eval_json_with_flags(&sid, &tid, "let x = 99; x", &[]);
+    assert_eq!(second["data"]["value"], serde_json::json!(99));
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_scope_isolation_expression() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(&sid, &tid, "document.title", &[]);
+    assert_eq!(v["data"]["value"], serde_json::json!("Example Domain"));
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_scope_isolation_multi_statement() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(&sid, &tid, "let a = 1; let b = 2; a + b", &[]);
+    assert_eq!(v["data"]["value"], serde_json::json!(3));
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_scope_isolation_async() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(
+        &sid,
+        &tid,
+        "await new Promise(r => setTimeout(() => r(42), 50))",
+        &[],
+    );
+    assert_eq!(v["data"]["value"], serde_json::json!(42));
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_no_isolate_flag() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let first = eval_json_with_flags(&sid, &tid, "let x = 42; x", &["--no-isolate"]);
+    assert_eq!(first["data"]["value"], serde_json::json!(42));
+
+    let second = eval_json_with_flags(&sid, &tid, "x", &["--no-isolate"]);
+    assert_eq!(second["data"]["value"], serde_json::json!(42));
+
+    let third = eval_failure_json_with_flags(&sid, &tid, "let x = 1", &["--no-isolate"]);
+    assert_eq!(third["command"], "browser eval");
+    assert_error_envelope(&third, "EVAL_FAILED");
+    assert!(
+        third["error"]["message"]
+            .as_str()
+            .unwrap_or("")
+            .contains("already been declared"),
+        "expected redeclare failure under --no-isolate"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_pre_context_fields() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(&sid, &tid, "document.title", &[]);
+    assert_eq!(v["data"]["value"], serde_json::json!("Example Domain"));
+    assert!(
+        v["data"]["pre_url"]
+            .as_str()
+            .is_some_and(|url| url.starts_with(TEST_URL)),
+        "pre_url must include navigated page URL"
+    );
+    assert_eq!(v["data"]["pre_origin"], "https://example.com");
+    assert_eq!(v["data"]["pre_readyState"], "complete");
+    assert!(
+        v["data"]["post_url"]
+            .as_str()
+            .is_some_and(|url| url.starts_with(TEST_URL)),
+        "post_url must remain present"
+    );
+    assert_eq!(v["data"]["post_title"], "Example Domain");
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_pre_context_about_blank() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_flags(&sid, &tid, "1 + 1", &[]);
+    assert_eq!(v["data"]["value"], serde_json::json!(2));
+    assert_eq!(v["data"]["pre_url"], "about:blank");
+    assert_eq!(v["data"]["pre_origin"], "null");
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_error_details_syntax() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(&sid, &tid, "{{{invalid", &[]);
+    assert_eq!(v["command"], "browser eval");
+    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_eq!(v["error"]["details"]["stage"], "eval");
+    assert_eq!(v["error"]["details"]["pre_url"], "about:blank");
+    assert_eq!(v["error"]["details"]["pre_origin"], "null");
+    assert!(
+        v["error"]["details"]["pre_readyState"].is_string(),
+        "pre_readyState must be captured on syntax failures"
+    );
+    assert!(
+        v["error"]["details"]["error_type"].is_string(),
+        "error_type must be captured on syntax failures"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_error_details_runtime() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(&sid, &tid, "nonExistentVariable.foo", &[]);
+    assert_eq!(v["command"], "browser eval");
+    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_eq!(v["error"]["details"]["stage"], "eval");
+    assert!(
+        v["error"]["details"]["pre_url"]
+            .as_str()
+            .is_some_and(|url| url.starts_with(TEST_URL)),
+        "pre_url must be present on runtime failures"
+    );
+    assert_eq!(v["error"]["details"]["pre_origin"], "https://example.com");
+    assert_eq!(v["error"]["details"]["pre_readyState"], "complete");
+    assert!(
+        v["error"]["details"]["error_type"].is_string(),
+        "error_type must be captured on runtime failures"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn eval_error_details_has_context() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(&sid, &tid, "{{{invalid", &[]);
+    assert_eq!(v["command"], "browser eval");
+    assert_error_envelope(&v, "EVAL_FAILED");
+    assert!(
+        v["error"]["details"]["pre_url"]
+            .as_str()
+            .is_some_and(|url| url.starts_with(TEST_URL)),
+        "details.pre_url must keep page context on failure"
+    );
+
+    close_session(&sid);
+}
+
+// ========================================================================
+// Group 20: mouse-move — command wiring, success path, and error path
 // ========================================================================
 
 #[test]


### PR DESCRIPTION
## Summary

- **Scope isolation** (default): each `browser eval` runs in a fresh function scope — repeated `let/const` declarations no longer cause `SyntaxError`. Non-await expressions use `(function(){ return eval(EXPR); })()` to preserve completion value; await expressions use `(async function(){ return (EXPR); })()` since eval cannot inherit async context in this Chrome version.
- **`--no-isolate` flag**: opt-out to the old behavior where variables persist across evals on the same tab.
- **Pre-execution context**: `pre_url`, `pre_origin`, `pre_readyState` added to both success and failure responses.
- **Structured error details**: eval failures now include `{stage, pre_url, pre_origin, pre_readyState, error_type}` in `details`.
- **Navigation helpers**: `get_tab_ready_state()` and `get_tab_origin()` added to `browser/navigation/mod.rs`.

## Test plan

- All 22 eval e2e tests pass (14 pre-existing + 8 new from #53)
- Full suite: 539 passed, 0 failed, 4 ignored
- `cargo clippy` and `cargo fmt` clean