### PR TITLE
[packages/cli]fix: harden extension bridge startup and surface error hints

### DIFF
--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1342,8 +1342,7 @@ async fn execute_extension(
             }
         };
 
-        let deadline =
-            std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
             if bridge_state.lock().await.is_extension_connected() {
                 break;

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1321,12 +1321,17 @@ async fn execute_extension(
     profile_name: &str,
     headless: bool,
 ) -> ActionResult {
-    use crate::daemon::bridge::BRIDGE_PORT;
+    use crate::daemon::bridge::{BRIDGE_PORT, BridgeListenerStatus};
 
-    // Check bridge state from registry, then wait briefly for the extension
-    // to (re)connect. This covers the race where the daemon was auto-started
-    // by this very call and the extension has not finished its WS handshake
-    // yet (typical window: 100ms–2s after a daemon restart).
+    // Wait briefly for the bridge listener to finish binding AND for the
+    // Chrome extension to (re)connect. Two races overlap here:
+    //   1. `spawn_bridge()` now binds asynchronously so the daemon startup
+    //      does not block on port contention — when daemon + CLI are cold
+    //      started together the first request may arrive before the bind
+    //      even completes.
+    //   2. Even once the listener is up, the extension needs 100ms–2s to
+    //      complete its WS handshake (especially after a daemon restart
+    //      where the extension is in exponential-backoff reconnect).
     let bridge_ws_url = {
         let bridge_state = {
             let reg = registry.lock().await;
@@ -1344,8 +1349,21 @@ async fn execute_extension(
 
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
-            if bridge_state.lock().await.is_extension_connected() {
-                break;
+            {
+                let bs = bridge_state.lock().await;
+                match bs.listener_status() {
+                    BridgeListenerStatus::Failed => {
+                        return ActionResult::fatal_with_hint(
+                            "BRIDGE_BIND_FAILED",
+                            format!("extension bridge failed to bind port {BRIDGE_PORT}"),
+                            "another process is holding the port — stop it (e.g. a stale actionbook daemon) and retry",
+                        );
+                    }
+                    BridgeListenerStatus::Listening if bs.is_extension_connected() => {
+                        break;
+                    }
+                    _ => {}
+                }
             }
             if std::time::Instant::now() >= deadline {
                 return ActionResult::fatal_with_hint(

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1390,6 +1390,7 @@ async fn execute_extension(
         let final_url = match ensure_scheme_or_fatal(url) {
             Ok(u) => u,
             Err(e) => {
+                cdp.close().await;
                 registry.lock().await.remove(session_id.as_str());
                 return e;
             }
@@ -1406,6 +1407,7 @@ async fn execute_extension(
                 vec![(tab_id, tab_url, title)]
             }
             Err(e) => {
+                cdp.close().await;
                 return fail_reserved_start(
                     registry,
                     &session_id,
@@ -1431,6 +1433,7 @@ async fn execute_extension(
                 // here so the agent gets a clear remediation instead of a
                 // downstream -32000 error on the first real command.
                 if is_restricted_attach_scheme(&tab_url) {
+                    cdp.close().await;
                     return fail_reserved_start_with_hint(
                         registry,
                         &session_id,
@@ -1444,6 +1447,7 @@ async fn execute_extension(
             }
             Err(e) => {
                 let msg = e.to_string();
+                cdp.close().await;
                 if is_chrome_attach_restriction_error(&msg) {
                     return fail_reserved_start_with_hint(
                         registry,

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1323,24 +1323,41 @@ async fn execute_extension(
 ) -> ActionResult {
     use crate::daemon::bridge::BRIDGE_PORT;
 
-    // Check bridge state from registry.
+    // Check bridge state from registry, then wait briefly for the extension
+    // to (re)connect. This covers the race where the daemon was auto-started
+    // by this very call and the extension has not finished its WS handshake
+    // yet (typical window: 100ms–2s after a daemon restart).
     let bridge_ws_url = {
-        let reg = registry.lock().await;
-        let Some(bridge_state) = reg.bridge_state() else {
-            return ActionResult::fatal_with_hint(
-                "BRIDGE_NOT_RUNNING",
-                "extension bridge is not running",
-                "the daemon failed to start the bridge — check if port 19222 is in use",
-            );
+        let bridge_state = {
+            let reg = registry.lock().await;
+            match reg.bridge_state() {
+                Some(bs) => bs.clone(),
+                None => {
+                    return ActionResult::fatal_with_hint(
+                        "BRIDGE_NOT_RUNNING",
+                        "extension bridge is not running",
+                        "the daemon failed to start the bridge — check if port 19222 is in use",
+                    );
+                }
+            }
         };
-        let bs = bridge_state.lock().await;
-        if !bs.is_extension_connected() {
-            return ActionResult::fatal_with_hint(
-                "EXTENSION_NOT_CONNECTED",
-                "no Chrome extension is connected to the bridge",
-                "open Chrome with the Actionbook extension installed and ensure it is active",
-            );
+
+        let deadline =
+            std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            if bridge_state.lock().await.is_extension_connected() {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                return ActionResult::fatal_with_hint(
+                    "EXTENSION_NOT_CONNECTED",
+                    "no Chrome extension connected to the bridge within 5s",
+                    "open chrome://extensions, ensure the Actionbook extension is enabled and its popup shows Connected",
+                );
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
         }
+
         format!("ws://127.0.0.1:{BRIDGE_PORT}")
     };
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -980,6 +980,48 @@ async fn fail_reserved_start(
     ActionResult::fatal(code, message)
 }
 
+async fn fail_reserved_start_with_hint(
+    registry: &SharedRegistry,
+    session_id: &SessionId,
+    code: &str,
+    message: String,
+    hint: &'static str,
+) -> ActionResult {
+    registry.lock().await.remove(session_id.as_str());
+    ActionResult::fatal_with_hint(code, message, hint)
+}
+
+/// URL schemes that Chrome's `chrome.debugger.attach` refuses with -32000.
+/// Detecting them pre-/post-attach lets us surface a clean `RESTRICTED_ACTIVE_TAB`
+/// error instead of leaking Chrome's raw "Cannot access a chrome:// URL" message
+/// (or, worse, a transient "session closed" flake when the extension drops the
+/// WS on error). The list matches Chromium's debugger_api.cc restriction set.
+fn is_restricted_attach_scheme(url: &str) -> bool {
+    const RESTRICTED: &[&str] = &[
+        "chrome://",
+        "chrome-extension://",
+        "chrome-untrusted://",
+        "chrome-search://",
+        "devtools://",
+        "edge://",
+        "view-source:",
+    ];
+    RESTRICTED.iter().any(|p| url.starts_with(p))
+}
+
+/// Detects Chrome's CDP rejection when `debugger.attach` targets a restricted
+/// tab. Chrome's message is stable across versions: "Cannot access a chrome://
+/// URL" / "Cannot access a chrome-extension:// URL" / etc.
+fn is_chrome_attach_restriction_error(msg: &str) -> bool {
+    let lower = msg.to_lowercase();
+    lower.contains("cannot access")
+        && (lower.contains("chrome://")
+            || lower.contains("chrome-extension://")
+            || lower.contains("chrome-untrusted://")
+            || lower.contains("devtools://")
+            || lower.contains("edge://"))
+}
+
 /// Tear down a provider-side session as part of a failed cloud start.
 ///
 /// `panic = "abort"` means we cannot rely on `Drop` for this — every error
@@ -1384,9 +1426,34 @@ async fn execute_extension(
                 let tab_id = result["tabId"].as_i64().unwrap_or(0).to_string();
                 let tab_url = result["url"].as_str().unwrap_or("about:blank").to_string();
                 let title = result["title"].as_str().unwrap_or("").to_string();
+                // The attach may succeed but return a URL that Chrome will later
+                // refuse CDP commands on (chrome://, devtools://, ...). Catch it
+                // here so the agent gets a clear remediation instead of a
+                // downstream -32000 error on the first real command.
+                if is_restricted_attach_scheme(&tab_url) {
+                    return fail_reserved_start_with_hint(
+                        registry,
+                        &session_id,
+                        "RESTRICTED_ACTIVE_TAB",
+                        format!("active tab is a restricted URL: {tab_url}"),
+                        "pass --open-url <url>",
+                    )
+                    .await;
+                }
                 vec![(tab_id, tab_url, title)]
             }
             Err(e) => {
+                let msg = e.to_string();
+                if is_chrome_attach_restriction_error(&msg) {
+                    return fail_reserved_start_with_hint(
+                        registry,
+                        &session_id,
+                        "RESTRICTED_ACTIVE_TAB",
+                        "active tab is a restricted URL".to_string(),
+                        "pass --open-url <url>",
+                    )
+                    .await;
+                }
                 return fail_reserved_start(
                     registry,
                     &session_id,
@@ -1667,6 +1734,71 @@ pub fn redact_endpoint(endpoint: &str) -> String {
         out.push_str(&redact_query_string(query));
     }
     out
+}
+
+#[cfg(test)]
+mod restricted_scheme_tests {
+    use super::{is_chrome_attach_restriction_error, is_restricted_attach_scheme};
+
+    #[test]
+    fn restricted_schemes_match() {
+        for url in [
+            "chrome://newtab/",
+            "chrome://extensions",
+            "chrome-extension://foo/popup.html",
+            "chrome-untrusted://terminal",
+            "devtools://devtools/bundled/inspector.html",
+            "edge://settings",
+            "view-source:https://example.com",
+        ] {
+            assert!(
+                is_restricted_attach_scheme(url),
+                "should be restricted: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn normal_urls_are_not_restricted() {
+        for url in [
+            "https://mail.google.com/",
+            "http://localhost:3000",
+            "about:blank",
+            "file:///tmp/foo.html",
+        ] {
+            assert!(
+                !is_restricted_attach_scheme(url),
+                "should be allowed: {url}"
+            );
+        }
+    }
+
+    #[test]
+    fn chrome_attach_restriction_error_matches_real_cdp_message() {
+        // Shape from the user-reported transcript.
+        assert!(is_chrome_attach_restriction_error(
+            "cdp error: CDP error -32000: Cannot access a chrome:// URL"
+        ));
+        assert!(is_chrome_attach_restriction_error(
+            "CDP error -32000: Cannot access a chrome-extension:// URL"
+        ));
+        assert!(is_chrome_attach_restriction_error(
+            "Cannot access a devtools:// URL"
+        ));
+    }
+
+    #[test]
+    fn unrelated_errors_do_not_match() {
+        assert!(!is_chrome_attach_restriction_error(
+            "session closed: session was closed while command was pending"
+        ));
+        assert!(!is_chrome_attach_restriction_error(
+            "CDP error -32602: invalid params"
+        ));
+        assert!(!is_chrome_attach_restriction_error(
+            "cannot access chrome" // missing scheme marker
+        ));
+    }
 }
 
 #[cfg(test)]

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -11,8 +11,11 @@
 //!    extension; otherwise it's treated as a CDP client and all messages are
 //!    relayed bidirectionally to the extension.
 //!
-//! The bridge is spawned from `run_daemon()`. If the port is already in use the
-//! daemon still starts — only extension mode is unavailable.
+//! The bridge is spawned from `run_daemon()`. Binding the fixed port is
+//! attempted with bounded exponential backoff so transient contention
+//! (old daemon still releasing the socket, rapid restart, brief third-party
+//! use of 19222) does not permanently break extension mode. If every attempt
+//! fails the daemon still starts — only extension mode is unavailable.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -29,6 +32,12 @@ use tracing::{error, info, warn};
 
 /// Default bridge port. Must match the extension's hardcoded `ws://127.0.0.1:19222`.
 pub const BRIDGE_PORT: u16 = 19222;
+
+/// Delays (in ms) between retry attempts when binding the bridge port fails.
+/// 6 total attempts (1 immediate + 5 retries), max wait ≈ 8.6s.
+/// Sized to comfortably cover: kernel socket cleanup after a previous daemon
+/// exit, rapid daemon restart races, and brief third-party port use.
+const BIND_RETRY_DELAYS_MS: &[u64] = &[100, 500, 1_000, 2_000, 5_000];
 
 /// Protocol version for the hello handshake.
 const PROTOCOL_VERSION: &str = "0.2.0";
@@ -86,17 +95,20 @@ pub fn new_bridge_state() -> SharedBridgeState {
 
 /// Spawn the bridge server as a background tokio task.
 ///
-/// Returns the bridge state handle on success. Returns `None` if the port is
-/// already in use (daemon still starts, only extension mode is unavailable).
+/// Returns the bridge state handle on success. Returns `None` if every bind
+/// attempt fails (daemon still starts, only extension mode is unavailable).
 pub async fn spawn_bridge() -> Option<SharedBridgeState> {
     let addr = format!("127.0.0.1:{BRIDGE_PORT}");
-    let listener = match TcpListener::bind(&addr).await {
+    let listener = match bind_with_retry(&addr, BIND_RETRY_DELAYS_MS).await {
         Ok(l) => {
             info!("extension bridge listening on ws://{addr}");
             l
         }
         Err(e) => {
-            warn!("extension bridge: failed to bind {addr}: {e} — extension mode unavailable");
+            warn!(
+                "extension bridge: failed to bind {addr} after {} attempts: {e} — extension mode unavailable",
+                BIND_RETRY_DELAYS_MS.len() + 1
+            );
             return None;
         }
     };
@@ -109,6 +121,35 @@ pub async fn spawn_bridge() -> Option<SharedBridgeState> {
     });
 
     Some(state)
+}
+
+/// Bind `addr` with bounded retry. First attempt is immediate; on failure,
+/// waits `delays_ms[i]` then retries, for a total of `delays_ms.len() + 1`
+/// attempts. Returns the last error if every attempt fails.
+async fn bind_with_retry(addr: &str, delays_ms: &[u64]) -> std::io::Result<TcpListener> {
+    let mut last_err = match TcpListener::bind(addr).await {
+        Ok(l) => return Ok(l),
+        Err(e) => e,
+    };
+    let total = delays_ms.len() + 1;
+    for (i, &delay_ms) in delays_ms.iter().enumerate() {
+        info!(
+            "extension bridge: bind {addr} attempt {}/{total} failed ({last_err}) — retrying in {delay_ms}ms",
+            i + 1
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        match TcpListener::bind(addr).await {
+            Ok(l) => {
+                info!(
+                    "extension bridge: bound {addr} on attempt {}/{total}",
+                    i + 2
+                );
+                return Ok(l);
+            }
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
 }
 
 // ─── Accept Loop ────────────────────────────────────────────────────────
@@ -471,5 +512,59 @@ mod tests {
     fn test_bridge_state_extension_not_connected_by_default() {
         let state = BridgeState::new();
         assert!(!state.is_extension_connected());
+    }
+
+    // ─── bind_with_retry ────────────────────────────────────────────────
+
+    /// Grab a free port, drop the listener, and return the address string.
+    /// The port *may* be racy if another process grabs it between drop and
+    /// the caller's bind — for CI we accept the vanishingly small risk.
+    async fn ephemeral_addr() -> String {
+        let l = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = l.local_addr().unwrap();
+        drop(l);
+        format!("{addr}")
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_succeeds_immediately_when_port_is_free() {
+        let addr = ephemeral_addr().await;
+        let listener = bind_with_retry(&addr, &[50, 100]).await.expect("bind");
+        assert_eq!(listener.local_addr().unwrap().to_string(), addr);
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_recovers_when_port_releases_during_backoff() {
+        // Occupy a port, schedule release after first retry window.
+        let blocker = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = blocker.local_addr().unwrap().to_string();
+
+        tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(60)).await;
+            drop(blocker); // frees port before 2nd attempt at t=100ms
+        });
+
+        let started = std::time::Instant::now();
+        let listener = bind_with_retry(&addr, &[100, 500, 1_000])
+            .await
+            .expect("retry should succeed after port release");
+        // 2nd attempt fires at ~100ms; allow some slack for scheduler jitter.
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(90),
+            "should have waited for at least one retry"
+        );
+        assert_eq!(listener.local_addr().unwrap().to_string(), addr);
+    }
+
+    #[tokio::test]
+    async fn bind_with_retry_gives_up_when_port_stays_busy() {
+        // Hold the port for the entire retry window.
+        let _blocker = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = _blocker.local_addr().unwrap().to_string();
+
+        let err = bind_with_retry(&addr, &[20, 30, 40])
+            .await
+            .expect_err("should fail while port is held");
+        assert_eq!(err.kind(), std::io::ErrorKind::AddrInUse);
     }
 }

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -49,6 +49,21 @@ const EXTENSION_IDS: &[&str] = &[EXTENSION_ID_CWS, EXTENSION_ID_DEV];
 
 // ─── Shared State ───────────────────────────────────────────────────────
 
+/// Observable state of the bridge TCP listener.
+///
+/// Exposed so callers (e.g. `browser start --mode extension`) can distinguish
+/// "still binding, keep waiting" from "bind failed, stop waiting" without
+/// having to watch a task JoinHandle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BridgeListenerStatus {
+    /// Bind attempt in progress (initial state; stays here during backoff retries).
+    Binding,
+    /// Listener is bound and accepting connections.
+    Listening,
+    /// Every retry failed; extension mode is permanently unavailable on this daemon.
+    Failed,
+}
+
 /// Bridge state shared across connections.
 pub struct BridgeState {
     /// Send commands TO the extension WebSocket.
@@ -59,6 +74,8 @@ pub struct BridgeState {
     connection_id: u64,
     /// Last activity timestamp.
     last_activity: Instant,
+    /// Listener bind state (updated by the background bind task).
+    listener_status: BridgeListenerStatus,
 }
 
 impl BridgeState {
@@ -68,6 +85,7 @@ impl BridgeState {
             cdp_tx: None,
             connection_id: 0,
             last_activity: Instant::now(),
+            listener_status: BridgeListenerStatus::Binding,
         }
     }
 
@@ -82,6 +100,15 @@ impl BridgeState {
             .map(|tx| !tx.is_closed())
             .unwrap_or(false)
     }
+
+    /// Current listener status.
+    pub fn listener_status(&self) -> BridgeListenerStatus {
+        self.listener_status
+    }
+
+    fn set_listener_status(&mut self, status: BridgeListenerStatus) {
+        self.listener_status = status;
+    }
 }
 
 pub type SharedBridgeState = Arc<Mutex<BridgeState>>;
@@ -95,32 +122,43 @@ pub fn new_bridge_state() -> SharedBridgeState {
 
 /// Spawn the bridge server as a background tokio task.
 ///
-/// Returns the bridge state handle on success. Returns `None` if every bind
-/// attempt fails (daemon still starts, only extension mode is unavailable).
-pub async fn spawn_bridge() -> Option<SharedBridgeState> {
-    let addr = format!("127.0.0.1:{BRIDGE_PORT}");
-    let listener = match bind_with_retry(&addr, BIND_RETRY_DELAYS_MS).await {
-        Ok(l) => {
-            info!("extension bridge listening on ws://{addr}");
-            l
-        }
-        Err(e) => {
-            warn!(
-                "extension bridge: failed to bind {addr} after {} attempts: {e} — extension mode unavailable",
-                BIND_RETRY_DELAYS_MS.len() + 1
-            );
-            return None;
-        }
-    };
-
+/// Returns the bridge state handle immediately; the TCP bind (with retry
+/// backoff) runs asynchronously in a background task so callers unrelated to
+/// extension mode — e.g. `browser start --mode local`, `browser screenshot` —
+/// do not pay the bind-retry window on daemon cold start. Consumers that
+/// need the bridge to be ready (extension mode) must poll
+/// [`BridgeState::listener_status`].
+pub fn spawn_bridge() -> SharedBridgeState {
     let state = new_bridge_state();
-    let state_clone = state.clone();
+    let state_for_task = state.clone();
 
     tokio::spawn(async move {
-        accept_loop(listener, state_clone).await;
+        let addr = format!("127.0.0.1:{BRIDGE_PORT}");
+        let listener = match bind_with_retry(&addr, BIND_RETRY_DELAYS_MS).await {
+            Ok(l) => {
+                info!("extension bridge listening on ws://{addr}");
+                state_for_task
+                    .lock()
+                    .await
+                    .set_listener_status(BridgeListenerStatus::Listening);
+                l
+            }
+            Err(e) => {
+                warn!(
+                    "extension bridge: failed to bind {addr} after {} attempts: {e} — extension mode unavailable",
+                    BIND_RETRY_DELAYS_MS.len() + 1
+                );
+                state_for_task
+                    .lock()
+                    .await
+                    .set_listener_status(BridgeListenerStatus::Failed);
+                return;
+            }
+        };
+        accept_loop(listener, state_for_task).await;
     });
 
-    Some(state)
+    state
 }
 
 /// Bind `addr` with bounded retry. First attempt is immediate; on failure,
@@ -512,6 +550,23 @@ mod tests {
     fn test_bridge_state_extension_not_connected_by_default() {
         let state = BridgeState::new();
         assert!(!state.is_extension_connected());
+    }
+
+    #[test]
+    fn test_bridge_state_listener_starts_in_binding() {
+        // start --mode extension must treat a fresh state as "keep waiting",
+        // not "fail fast" — the async bind task has not run yet.
+        let state = BridgeState::new();
+        assert_eq!(state.listener_status(), BridgeListenerStatus::Binding);
+    }
+
+    #[test]
+    fn test_bridge_state_listener_status_transitions() {
+        let mut state = BridgeState::new();
+        state.set_listener_status(BridgeListenerStatus::Listening);
+        assert_eq!(state.listener_status(), BridgeListenerStatus::Listening);
+        state.set_listener_status(BridgeListenerStatus::Failed);
+        assert_eq!(state.listener_status(), BridgeListenerStatus::Failed);
     }
 
     // ─── bind_with_retry ────────────────────────────────────────────────

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
 use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -261,6 +262,11 @@ pub struct CdpSession {
     /// Wrapped in Option so `close()` can take it out, closing the channel
     /// and propagating shutdown to both reader and writer background tasks.
     writer_tx: Arc<Mutex<Option<mpsc::Sender<String>>>>,
+    /// Writer task handle. Awaited by `close()` so the graceful WS close
+    /// frame is delivered before the next caller tries to reconnect — without
+    /// it, the peer (e.g. bridge) still sees the old client as connected and
+    /// rejects the new CDP client.
+    writer_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// In-flight requests keyed by message ID.
     pending: PendingRequests,
     /// Atomic counter for generating unique message IDs.
@@ -325,7 +331,7 @@ impl CdpSession {
             Arc::new(Mutex::new(HashMap::new()));
         let tab_net_requests: TabNetRequests = Arc::new(Mutex::new(HashMap::new()));
 
-        tokio::spawn(Self::writer_loop(ws_writer, writer_rx));
+        let writer_handle = tokio::spawn(Self::writer_loop(ws_writer, writer_rx));
         tokio::spawn(Self::reader_loop(
             ws_reader,
             pending.clone(),
@@ -339,6 +345,7 @@ impl CdpSession {
 
         Ok(CdpSession {
             writer_tx: Arc::new(Mutex::new(Some(writer_tx))),
+            writer_handle: Arc::new(Mutex::new(Some(writer_handle))),
             pending,
             next_id,
             tab_sessions,
@@ -678,17 +685,29 @@ impl CdpSession {
     /// Drops the writer channel sender, which causes the writer loop to exit,
     /// which closes the WS connection, which causes the reader loop to exit,
     /// which fails all pending requests with `SessionClosed`.
+    ///
+    /// Waits for the writer task to finish so the WS close handshake has
+    /// propagated to the peer before returning. Without this, a peer like the
+    /// extension bridge may still see the old client as connected and reject
+    /// an immediately-following reconnect.
     pub async fn close(&self) {
         // Take and drop the writer sender — closes the channel.
         self.writer_tx.lock().await.take();
 
         // Fail all pending requests immediately instead of waiting for
         // the reader loop to notice the connection drop.
-        let mut map = self.pending.lock().await;
-        for (_, tx) in map.drain() {
-            let _ = tx.send(Err(CliError::SessionClosed(
-                "session was closed".to_string(),
-            )));
+        {
+            let mut map = self.pending.lock().await;
+            for (_, tx) in map.drain() {
+                let _ = tx.send(Err(CliError::SessionClosed(
+                    "session was closed".to_string(),
+                )));
+            }
+        }
+
+        // Await writer task so its Close frame has been flushed to the peer.
+        if let Some(handle) = self.writer_handle.lock().await.take() {
+            let _ = handle.await;
         }
     }
 
@@ -922,15 +941,25 @@ impl CdpSession {
     }
 
     /// Background task: forward channel messages to WS writer.
+    ///
+    /// When the channel closes (on drop / `close()`), send a WebSocket Close
+    /// frame so the peer tears down promptly. Without this, dropping the
+    /// writer half alone leaves the reader half holding the TCP connection
+    /// open; the peer never sees EOF and keeps us registered as "still
+    /// connected", which breaks immediate reconnects (e.g. the extension
+    /// bridge rejecting a second CDP client).
     async fn writer_loop<S>(mut writer: S, mut rx: mpsc::Receiver<String>)
     where
         S: SinkExt<Message> + Unpin,
     {
         while let Some(text) = rx.recv().await {
             if writer.send(Message::Text(text.into())).await.is_err() {
-                break;
+                return;
             }
         }
+        // Graceful shutdown: send Close frame then close the sink.
+        let _ = writer.send(Message::Close(None)).await;
+        let _ = writer.close().await;
     }
 }
 

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -16,6 +16,7 @@ use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http;
+use tracing::warn;
 
 use crate::error::CliError;
 
@@ -686,10 +687,13 @@ impl CdpSession {
     /// which closes the WS connection, which causes the reader loop to exit,
     /// which fails all pending requests with `SessionClosed`.
     ///
-    /// Waits for the writer task to finish so the WS close handshake has
-    /// propagated to the peer before returning. Without this, a peer like the
-    /// extension bridge may still see the old client as connected and reject
-    /// an immediately-following reconnect.
+    /// Waits up to 500ms for the writer task to finish so the WS close
+    /// handshake has propagated to the peer before returning. Without this,
+    /// a peer like the extension bridge may still see the old client as
+    /// connected and reject an immediately-following reconnect. If the
+    /// writer is stalled on network I/O (broken CDP connection, half-open
+    /// socket) we abort it so `browser close` and daemon shutdown stay
+    /// bounded — the OS reclaims the socket when the task drops.
     pub async fn close(&self) {
         // Take and drop the writer sender — closes the channel.
         self.writer_tx.lock().await.take();
@@ -705,9 +709,16 @@ impl CdpSession {
             }
         }
 
-        // Await writer task so its Close frame has been flushed to the peer.
+        // Bounded wait for the writer to flush its Close frame.
         if let Some(handle) = self.writer_handle.lock().await.take() {
-            let _ = handle.await;
+            let aborter = handle.abort_handle();
+            if tokio::time::timeout(std::time::Duration::from_millis(500), handle)
+                .await
+                .is_err()
+            {
+                aborter.abort();
+                warn!("cdp_session: writer task exceeded 500ms shutdown budget; aborted");
+            }
         }
     }
 

--- a/packages/cli/src/daemon/server.rs
+++ b/packages/cli/src/daemon/server.rs
@@ -308,9 +308,10 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     let registry = new_shared_registry();
 
     // Spawn extension bridge (non-fatal: daemon works without it).
-    if let Some(bridge_state) = super::bridge::spawn_bridge().await {
-        registry.lock().await.set_bridge_state(bridge_state);
-    }
+    // Returns immediately — the bind-with-retry happens on a background
+    // task so non-extension commands do not wait on bridge port contention.
+    let bridge_state = super::bridge::spawn_bridge();
+    registry.lock().await.set_bridge_state(bridge_state);
 
     // Handle SIGINT, SIGTERM, and SIGHUP (terminal close).
     #[cfg(unix)]
@@ -496,9 +497,8 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     let registry = new_shared_registry();
 
-    if let Some(bridge_state) = super::bridge::spawn_bridge().await {
-        registry.lock().await.set_bridge_state(bridge_state);
-    }
+    let bridge_state = super::bridge::spawn_bridge();
+    registry.lock().await.set_bridge_state(bridge_state);
 
     let mut last_activity = Instant::now();
     let idle_timeout_duration = idle_timeout();

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -241,7 +241,12 @@ pub fn format_text(
             // Emit key-value fields from data
             format_data_fields(command, data, &mut lines);
         }
-        ActionResult::Fatal { code, message, .. } => {
+        ActionResult::Fatal {
+            code,
+            message,
+            hint,
+            ..
+        } => {
             if (command == "browser new-tab" || command == "browser batch-new-tab")
                 && code == "PARTIAL_FAILURE"
             {
@@ -253,12 +258,21 @@ pub fn format_text(
             } else {
                 lines.push(format!("error {code}: {message}"));
             }
+            if !hint.is_empty() {
+                lines.push(format!("hint: {hint}"));
+            }
         }
-        ActionResult::Retryable { reason, .. } => {
+        ActionResult::Retryable { reason, hint } => {
             lines.push(format!("error RETRYABLE: {reason}"));
+            if !hint.is_empty() {
+                lines.push(format!("hint: {hint}"));
+            }
         }
-        ActionResult::UserAction { action, .. } => {
+        ActionResult::UserAction { action, hint } => {
             lines.push(format!("error USER_ACTION: {action}"));
+            if !hint.is_empty() {
+                lines.push(format!("hint: {hint}"));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Two fixes on top of the existing `bugfix/cli-extension-bridge-hardening` work that close gaps observed while running `browser start --mode extension` after a daemon auto-restart:

- **Wait for extension reconnect on `browser start --mode extension`**
  The bridge binds port 19222 100ms–2s before the Chrome extension finishes its WS handshake. The previous one-shot `is_extension_connected()` check raced that window and returned `EXTENSION_NOT_CONNECTED` even when the extension was about to connect. Now we poll every 100ms for up to 5s and clone `SharedBridgeState` out of the registry so the registry lock is not held across the wait.
- **Print the `hint` line in text output**
  `ActionResult::Fatal/Retryable/UserAction` all carry a hint the daemon writes (e.g. `pass --open-url <url>` for `RESTRICTED_ACTIVE_TAB`), but the text renderer destructured it away with `..` and only printed `error {code}: {message}`. Every daemon-side hint fix that landed earlier was silently dropped by the CLI. The renderer now appends `hint: {hint}` when hint is non-empty.

Together they turn the post-daemon-restart flow from "fails immediately with an unhelpful error" into "waits briefly and, if it still fails, surfaces the real next step."

Branch also contains three earlier commits already merged separately into the hardening line (bridge port retry, restricted-scheme surfacing, CdpSession graceful close).

## Test plan

- [ ] `cargo build --release` inside `packages/cli`
- [ ] `cargo test --lib` inside `packages/cli` (existing 14 start tests + 4 output tests still pass)
- [ ] Manual: `kill -TERM $(lsof -tiTCP:19222 -sTCP:LISTEN)` then immediately run `actionbook browser start --mode extension --set-session-id tw1` — must succeed once extension reconnects, not error on the first attempt.
- [ ] Manual: run the same command while Chrome's active tab is `chrome://newtab/` — must emit both `error RESTRICTED_ACTIVE_TAB: ...` and `hint: pass --open-url <url>` on separate lines.
- [ ] Manual: run with Actionbook extension disabled — must time out after ~5s with the new `within 5s` message and the updated hint pointing at `chrome://extensions`.