### PR TITLE
[root]chore: add changesets for CLI v1.4.2

### DIFF
--- a/.changeset/extension-bridge-startup-hardening.md
+++ b/.changeset/extension-bridge-startup-hardening.md
@@ -1,0 +1,13 @@
+---
+"@actionbookdev/cli": patch
+---
+
+Harden extension bridge startup and surface actionable error hints.
+
+- Retry bridge port bind with exponential backoff (up to ~8.6s) to recover from `TIME_WAIT` after daemon restart
+- Move bridge bind to a background task so daemon cold start is no longer blocked by extension port contention (local/cloud modes were incorrectly delayed)
+- Add `BridgeListenerStatus` (Binding / Listening / Failed) so `browser start --mode extension` can distinguish still-binding from bind-failed
+- Wait up to 5s (polling every 100ms) for the extension to reconnect on `browser start`, eliminating a race where the bridge bound slightly before the extension completed its WS handshake
+- Surface `chrome://`, `devtools://` and other restricted schemes as `RESTRICTED_ACTIVE_TAB` with hint `pass --open-url <url>` instead of an opaque debugger.attach failure
+- Close `CdpSession` WebSocket gracefully on failed session start (writer sends a Close frame, session awaits the writer task) so the bridge sees EOF and releases its 1:1 gate — previously the next start attempt would instantly fail with `SessionClosed`
+- Print `hint:` line for Fatal/Retryable/UserAction error results in text output (previously only `--json` surfaced the hint field)

--- a/.changeset/hermes-agent-integration.md
+++ b/.changeset/hermes-agent-integration.md
@@ -1,0 +1,10 @@
+---
+"@actionbookdev/cli": patch
+---
+
+Add Hermes agent integration.
+
+- New `SetupTarget::Hermes` variant invokes `hermes skills install` directly instead of routing through `npx skills add`, targeting Hermes's native skill registry at `~/.hermes/skills/`
+- Missing-binary error now points users to install Hermes (not Node.js) when the target is Hermes
+- Post-install verification parses `hermes skills list` table columns exactly (by `│` delimiter) to avoid false positives from similarly-named skills
+- `skills/actionbook/SKILL.md` gains Hermes-compatible frontmatter (`metadata.hermes.tags`, `requires_toolsets: [terminal]`, `prerequisites.commands: [actionbook]`) so the skill is discoverable via `hermes skills search` and hidden on non-terminal platforms


### PR DESCRIPTION
## Summary

Adds two patch-level changesets to trigger the CLI v1.4.2 release PR:

- **extension-bridge-startup-hardening** — covers #517 (bridge port bind retry, background bind task, restricted-tab hints, CdpSession graceful close, extension reconnect wait, hint rendering in text output)
- **hermes-agent-integration** — covers #513 (new `SetupTarget::Hermes` routing through `hermes skills install`, Hermes-compatible frontmatter on the actionbook skill)

Both entries are marked `patch`. Hermes is a new feature but we are intentionally releasing it under 1.4.2 rather than 1.5.0 for this cycle — Changesets takes the highest bump, so marking Hermes as `patch` keeps the resolved version at 1.4.2.

## Test plan

- [ ] CI "Version Packages" PR opens and bumps `packages/cli/package.json` to `1.4.2`
- [ ] CHANGELOG includes both entries under the 1.4.2 heading
- [ ] `scripts/sync-versions.js` propagates 1.4.2 to the 6 platform-specific `package.json` files
- [ ] After Version PR merges, publish workflow pushes `@actionbookdev/cli@1.4.2` + platform packages to npm and cuts a GitHub Release