### PR TITLE
docs: comprehensive audit fix for CLI 1.0.0–1.4.2

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -5,7 +5,47 @@ description: "Detailed reference for Actionbook CLI commands"
 
 # CLI Reference
 
-The Actionbook CLI (`actionbook`) is the primary interface for browser automation. Every browser command is **stateless** — pass `--session` and `--tab` explicitly.
+The Actionbook CLI (`actionbook`) is the primary interface for interacting with Actionbook. Every browser command is **stateless** — pass `--session` and `--tab` explicitly.
+
+## `actionbook search`
+
+Search for available action manuals.
+
+**Usage:**
+
+```bash
+actionbook search [query]
+```
+
+**Arguments:**
+
+- `query`: The search keyword (e.g., "airbnb", "google login").
+
+**Example:**
+
+```bash
+actionbook search "airbnb search"
+```
+
+## `actionbook get`
+
+Retrieve a specific action manual by its ID.
+
+**Usage:**
+
+```bash
+actionbook get [actionId]
+```
+
+**Arguments:**
+
+- `actionId`: The unique identifier of the action.
+
+**Example:**
+
+```bash
+actionbook get "site/airbnb.com/page/home/element/search-button"
+```
 
 ## `actionbook setup`
 

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -5,59 +5,22 @@ description: "Detailed reference for Actionbook CLI commands"
 
 # CLI Reference
 
-The Actionbook CLI (`actionbook`) is the primary interface for interacting with Actionbook.
-
-## `actionbook search`
-
-Search for available action manuals.
-
-**Usage:**
-
-```bash
-actionbook search [query]
-```
-
-**Arguments:**
-
-- `query`: The search keyword (e.g., "airbnb", "google login").
-
-**Example:**
-
-```bash
-actionbook search "airbnb search"
-```
-
-## `actionbook get`
-
-Retrieve a specific action manual by its ID.
-
-**Usage:**
-
-```bash
-actionbook get [actionId]
-```
-
-**Arguments:**
-
-- `actionId`: The unique identifier of the action.
-
-**Example:**
-
-```bash
-actionbook get "site/airbnb.com/page/home/element/search-button"
-```
+The Actionbook CLI (`actionbook`) is the primary interface for browser automation. Every browser command is **stateless** — pass `--session` and `--tab` explicitly.
 
 ## `actionbook setup`
 
 Initial setup wizard for API key, browser preferences, health checks, and optional skills install.
 
-Run this once, then use the same `actionbook browser ...` commands regardless of mode.
-
 **Usage:**
 
 ```bash
 actionbook setup
+actionbook setup --target claude          # Quick mode: install skills for an agent
+actionbook setup --non-interactive --api-key <KEY>
+actionbook setup --reset
 ```
+
+**Targets:** `claude`, `codex`, `cursor`, `windsurf`, `antigravity`, `opencode`, `hermes`, `standalone`, `all`
 
 ---
 
@@ -66,18 +29,25 @@ actionbook setup
 Browser automation commands.
 
 <Note>
-  After `actionbook setup`, browser command syntax is identical across modes.
+  After `actionbook setup`, browser command syntax is identical across all modes (local, cloud, extension).
 </Note>
 
-### `actionbook browser start`
+### Global Flags
 
-Start or attach a browser session. This is the entry point for cloud provider sessions.
+These flags apply to all `actionbook browser` subcommands:
 
-**Usage:**
+| Flag | Description |
+|------|-------------|
+| `--session <id>` | Target a specific session (defaults to `default`) |
+| `--tab <id>` | Target a specific tab |
+| `--json` | Output results as JSON envelope |
+| `--timeout <ms>` | Set command timeout in milliseconds |
 
-```bash
-actionbook browser start [options]
-```
+### Session Lifecycle
+
+#### `actionbook browser start`
+
+Start or attach a browser session. Entry point for all modes including cloud providers.
 
 **Options:**
 
@@ -97,15 +67,9 @@ actionbook browser start [options]
 **Examples:**
 
 ```bash
-# Local session
-actionbook browser start
-actionbook browser start --session research --open-url https://google.com
-
-# Cloud provider
-export DRIVER_API_KEY="your-key"
-actionbook browser start -p driver --open-url https://example.com
-
-# Raw CDP endpoint
+actionbook browser start --set-session-id s1
+actionbook browser start --session s1 --open-url https://google.com
+actionbook browser start -p hyperbrowser --session s1
 actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
 ```
 
@@ -114,60 +78,178 @@ actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/w
   See [Cloud Providers](/guides/browser#cloud-providers) for provider-specific env vars.
 </Note>
 
-### `actionbook browser open`
-
-Open a URL in the browser.
-
-**Usage:**
+#### Other Session Commands
 
 ```bash
-actionbook browser open [url]
+actionbook browser list-sessions                      # List all active sessions
+actionbook browser status --session s1                # Show session status
+actionbook browser close --session s1                 # Close a session (alias: stop)
+actionbook browser restart --session s1               # Restart, preserving session_id
 ```
 
-### `actionbook browser click`
-
-Click an element on the current page.
-
-**Usage:**
+### Tab Management
 
 ```bash
-actionbook browser click [selector]
+actionbook browser list-tabs --session s1                         # List tabs
+actionbook browser new-tab "https://example.com" --session s1     # Open new tab (alias: open)
+actionbook browser close-tab --session s1 --tab t1                # Close a tab
 ```
 
-**Arguments:**
-
-- `selector`: The CSS selector, XPath, or other supported selector string.
-
-### `actionbook browser fill`
-
-Fill an input field with text.
-
-**Usage:**
+### Navigation
 
 ```bash
-actionbook browser fill [selector] [value]
+actionbook browser goto <url> --session s1 --tab t1              # Navigate to URL
+actionbook browser back --session s1 --tab t1                    # Go back
+actionbook browser forward --session s1 --tab t1                 # Go forward
+actionbook browser reload --session s1 --tab t1                  # Reload page
 ```
 
-**Arguments:**
+`goto` supports `--wait-until` to control when the command returns: `domcontentloaded` (default), `load`, or `none`.
 
-- `selector`: The target input element selector.
-- `value`: The text value to input.
-
-### `actionbook browser restart`
-
-Restart a session. Closes and reopens with the same profile and mode. The `session_id` is preserved; tab IDs reset to `t1`.
-
-**Usage:**
+### Observation
 
 ```bash
-actionbook browser restart --session <id>
+# Snapshot
+actionbook browser snapshot --session s1 --tab t1                # Accessibility tree with refs
+actionbook browser snapshot -i --session s1 --tab t1             # Interactive elements only
+actionbook browser snapshot -i -c --session s1 --tab t1          # Interactive + compact
+
+# Page info
+actionbook browser title --session s1 --tab t1                   # Page title
+actionbook browser url --session s1 --tab t1                     # Current URL
+actionbook browser viewport --session s1 --tab t1                # Viewport dimensions
+
+# Content
+actionbook browser text --session s1 --tab t1                    # Full page text
+actionbook browser text "<selector>" --session s1 --tab t1       # Element text
+actionbook browser html --session s1 --tab t1                    # Full page HTML
+actionbook browser html "<selector>" --session s1 --tab t1       # Element HTML
+actionbook browser value "<selector>" --session s1 --tab t1      # Input value
+
+# Element inspection
+actionbook browser attr "<selector>" href --session s1 --tab t1        # Single attribute
+actionbook browser attrs "<selector>" --session s1 --tab t1            # All attributes
+actionbook browser box "<selector>" --session s1 --tab t1              # Bounding rect
+actionbook browser styles "<selector>" color fontSize --session s1 --tab t1  # Computed styles
+actionbook browser describe "<selector>" --session s1 --tab t1         # Full element description
+actionbook browser state "<selector>" --session s1 --tab t1            # State flags
+actionbook browser inspect-point 420,310 --session s1 --tab t1         # Inspect at coordinates
+
+# Query
+actionbook browser query one "<selector>" --session s1 --tab t1       # Exactly one match
+actionbook browser query all "<selector>" --session s1 --tab t1       # All matches
+actionbook browser query count "<selector>" --session s1 --tab t1     # Match count
+actionbook browser query nth 2 "<selector>" --session s1 --tab t1     # Nth match (1-based)
+
+# Screenshot & PDF
+actionbook browser screenshot output.png --session s1 --tab t1        # Screenshot
+actionbook browser screenshot output.png --full --session s1 --tab t1  # Full page
+actionbook browser screenshot output.png --annotate --session s1 --tab t1  # With labels
+actionbook browser pdf output.pdf --session s1 --tab t1               # Save as PDF
 ```
 
-### Global Flags
+### Interaction
 
-These flags apply to all `actionbook browser` subcommands:
+```bash
+# Click
+actionbook browser click "<selector>" --session s1 --tab t1           # Click element
+actionbook browser click 420,310 --session s1 --tab t1                # Click coordinates
+actionbook browser click @e5 --session s1 --tab t1                    # Click by snapshot ref
+actionbook browser click "<selector>" --count 2 --session s1 --tab t1  # Double-click
 
-- `--session <id>`: target a specific session (defaults to `default`).
-- `--json`: output results in JSON format.
+# Text input
+actionbook browser fill "<selector>" "text" --session s1 --tab t1     # Clear field, then set value
+actionbook browser type "<selector>" "text" --session s1 --tab t1     # Type keystroke by keystroke
+
+# Keyboard
+actionbook browser press Enter --session s1 --tab t1
+actionbook browser press Control+A --session s1 --tab t1
+
+# Selection
+actionbook browser select "<selector>" "value" --session s1 --tab t1
+actionbook browser select "<selector>" "Display Text" --by-text --session s1 --tab t1
+actionbook browser select "<selector>" @e12 --by-ref --session s1 --tab t1
+
+# Mouse
+actionbook browser hover "<selector>" --session s1 --tab t1
+actionbook browser focus "<selector>" --session s1 --tab t1
+actionbook browser mouse-move 420,310 --session s1 --tab t1
+actionbook browser cursor-position --session s1 --tab t1
+actionbook browser drag "<source>" "<target>" --session s1 --tab t1
+
+# Scroll
+actionbook browser scroll down --session s1 --tab t1
+actionbook browser scroll down 500 --session s1 --tab t1
+actionbook browser scroll into-view @e8 --session s1 --tab t1
+actionbook browser scroll top --session s1 --tab t1
+
+# JavaScript
+actionbook browser eval "document.title" --session s1 --tab t1
+actionbook browser eval "document.querySelectorAll('a').length" --session s1 --tab t1
+actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isolate --session s1 --tab t1
+
+# File upload
+actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
+```
+
+<Tip>
+  `fill` clears the field and sets the value directly (like pasting). `type` simulates individual keystrokes and appends to existing content.
+</Tip>
+
+<Tip>
+  `eval` isolates `let`/`const` scope by default. Use `--no-isolate` for multi-statement async expressions or when you need shared scope across calls.
+</Tip>
+
+### Wait
+
+```bash
+actionbook browser wait element "<selector>" --session s1 --tab t1
+actionbook browser wait navigation --session s1 --tab t1
+actionbook browser wait network-idle --session s1 --tab t1
+actionbook browser wait condition "document.readyState === 'complete'" --session s1 --tab t1
+```
+
+Default timeout: 30000ms. Override with `--timeout <ms>`.
+
+### Logs & Network
+
+```bash
+# Console logs
+actionbook browser logs console --session s1 --tab t1
+actionbook browser logs console --level warn,error --session s1 --tab t1
+actionbook browser logs errors --session s1 --tab t1
+
+# Network
+actionbook browser network requests --session s1 --tab t1
+actionbook browser network requests --filter /api/ --method POST --session s1 --tab t1
+actionbook browser network request <id> --session s1 --tab t1         # Full detail + response body
+```
+
+### Cookies & Storage
+
+```bash
+# Cookies (session-level, no --tab)
+actionbook browser cookies list --session s1
+actionbook browser cookies get session_id --session s1
+actionbook browser cookies set token abc123 --session s1
+actionbook browser cookies delete token --session s1
+actionbook browser cookies clear --session s1
+
+# Local Storage
+actionbook browser local-storage list --session s1 --tab t1
+actionbook browser local-storage get myKey --session s1 --tab t1
+actionbook browser local-storage set myKey "value" --session s1 --tab t1
+
+# Session Storage (same syntax as local-storage)
+actionbook browser session-storage list --session s1 --tab t1
+```
+
+### Batch Operations
+
+```bash
+actionbook browser batch-new-tab --urls https://a.com https://b.com --session s1
+actionbook browser batch-snapshot --tabs t1 t2 t3 --session s1
+actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
+```
 
 ---

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -378,20 +378,21 @@ actionbook browser close --session research
 
 ## Recommended Workflow
 
-Start a session, snapshot the page to get element refs, then automate using those refs:
+Combine action manuals with browser automation for the best results:
 
 ```bash
-# 1. Start a session and navigate
+# 1. Find the action manual
+actionbook search "github search repos"
+
+# 2. Get verified selectors
+actionbook get "<area_id>"
+
+# 3. Start a session and execute
 actionbook browser start --set-session-id s1
 actionbook browser goto "https://github.com" --session s1 --tab t1
-
-# 2. Snapshot to get element refs
 actionbook browser snapshot --session s1 --tab t1
-
-# 3. Automate using refs from snapshot
 actionbook browser fill @e3 "actionbook" --session s1 --tab t1
 actionbook browser click @e7 --session s1 --tab t1
-actionbook browser wait navigation --session s1 --tab t1
 ```
 
 ## Shutdown

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -29,16 +29,17 @@ Works out of the box with no setup. The CLI launches a temporary Chrome process 
 
 ```bash
 # If local is your default mode (or not configured)
-actionbook browser open "https://example.com"
-actionbook browser click "button[type='submit']"
-actionbook browser fill "#search" "actionbook"
-actionbook browser screenshot output.png
+actionbook browser start --set-session-id s1
+actionbook browser goto "https://example.com" --session s1 --tab t1
+actionbook browser click "button[type='submit']" --session s1 --tab t1
+actionbook browser fill "#search" "actionbook" --session s1 --tab t1
+actionbook browser screenshot output.png --session s1 --tab t1
 ```
 
 When done, close the browser:
 
 ```bash
-actionbook browser close
+actionbook browser close --session s1
 ```
 
 ## Cloud Providers
@@ -377,19 +378,20 @@ actionbook browser close --session research
 
 ## Recommended Workflow
 
-Combine action manuals with browser automation for the best results:
+Start a session, snapshot the page to get element refs, then automate using those refs:
 
 ```bash
-# 1. Find the action manual
-actionbook search "github search repos"
+# 1. Start a session and navigate
+actionbook browser start --set-session-id s1
+actionbook browser goto "https://github.com" --session s1 --tab t1
 
-# 2. Get verified selectors
-actionbook get "<area_id>"
+# 2. Snapshot to get element refs
+actionbook browser snapshot --session s1 --tab t1
 
-# 3. Execute (uses your configured mode)
-actionbook browser open "https://github.com"
-actionbook browser fill "#query-builder-test" "actionbook"
-actionbook browser click "button[type='submit']"
+# 3. Automate using refs from snapshot
+actionbook browser fill @e3 "actionbook" --session s1 --tab t1
+actionbook browser click @e7 --session s1 --tab t1
+actionbook browser wait navigation --session s1 --tab t1
 ```
 
 ## Shutdown

--- a/docs/guides/cli-and-skills.mdx
+++ b/docs/guides/cli-and-skills.mdx
@@ -28,6 +28,22 @@ This configures API key and browser preferences, then you can use the same `acti
 
 ### Core Commands
 
+#### Search Actions
+
+Find available action manuals for a specific task or website.
+
+```bash
+actionbook search "airbnb search"
+```
+
+#### Get Action Details
+
+Retrieve the full manual for a specific action ID.
+
+```bash
+actionbook get "site/airbnb.com/page/home/element/search-button"
+```
+
 #### Browser Automation
 
 Every browser command is stateless — pass `--session` and `--tab` explicitly. The core workflow is: start a session, snapshot the page, then use element refs to interact.
@@ -69,8 +85,8 @@ This will download the skill definition to your `.skills` (or similar) directory
 ### Benefits of Skills
 
 1.  **Context Awareness**: The skill provides the agent with specific instructions on when and how to call Actionbook CLI commands.
-2.  **Workflow Optimization**: It teaches the agent the optimal workflow: `start` -> `snapshot` -> `automate with refs`.
-3.  **Reduced Hallucinations**: By following the skill's procedure, the agent uses snapshot refs instead of guessing DOM selectors.
+2.  **Workflow Optimization**: It teaches the agent the optimal workflow: `search` -> `get` -> `operate`.
+3.  **Reduced Hallucinations**: By following the skill's procedure, the agent relies on verified action manuals instead of guessing DOM selectors.
 
 ### Example Agent Workflow
 
@@ -80,9 +96,9 @@ Once the CLI is installed and the Skill is added, you can simply ask your agent:
 
 The agent will:
 1.  **Read Skill**: Understands it should use `actionbook` CLI.
-2.  **Start & Navigate**: Runs `actionbook browser start` and `goto` to open the page.
-3.  **Snapshot**: Runs `actionbook browser snapshot` to get element refs.
-4.  **Automate**: Uses refs (`@eN`) to fill, click, and interact confidently.
+2.  **Search**: Runs `actionbook search "airbnb search"`.
+3.  **Get**: Runs `actionbook get ...` to find the search input and button selectors.
+4.  **Operate**: Runs `actionbook browser start` + `goto` + snapshot refs to perform the search.
 
 ### Extracting Data
 
@@ -98,10 +114,10 @@ Ask naturally:
 > "Pull all job listings from this page — title, company, location."
 
 The agent will:
-1.  Start a browser session and navigate to the target page.
-2.  Snapshot the page to identify data elements and their refs.
+1.  Search Actionbook for verified selectors.
+2.  If `actionbook get` already covers required fields, start from those selectors and draft the script quickly.
 3.  Run lightweight mechanism probes when needed (hydration/scroll/pagination checks).
-4.  Use snapshot/screenshot/inspect to map the data structure.
+4.  Use snapshot/screenshot/inspect only when selectors are missing or fail in validation.
 5.  Generate a **standalone Playwright script** that handles detected page mechanisms.
 6.  Run the script and write the extracted data to disk.
 

--- a/docs/guides/cli-and-skills.mdx
+++ b/docs/guides/cli-and-skills.mdx
@@ -10,7 +10,7 @@ The Actionbook CLI and Skills/Workflows are the most powerful way to use Actionb
 
 ## Using the CLI
 
-The CLI allows you (and your agents) to search for actions, inspect them, and perform browser automation.
+The CLI allows you (and your agents) to automate any Chromium-based browser with stateless, session-addressed commands.
 
 ### Installation
 
@@ -28,35 +28,22 @@ This configures API key and browser preferences, then you can use the same `acti
 
 ### Core Commands
 
-#### Search Actions
-
-Find available action manuals for a specific task or website.
-
-```bash
-actionbook search "airbnb search"
-```
-
-#### Get Action Details
-
-Retrieve the full manual for a specific action ID.
-
-```bash
-actionbook get "site/airbnb.com/page/home/element/search-button"
-```
-
 #### Browser Automation
 
-The CLI includes a built-in browser automation tool that uses the action manuals.
+Every browser command is stateless — pass `--session` and `--tab` explicitly. The core workflow is: start a session, snapshot the page, then use element refs to interact.
 
 ```bash
-# Open a website
-actionbook browser open airbnb.com
+# Start a session and navigate
+actionbook browser start --set-session-id s1
+actionbook browser goto "https://airbnb.com" --session s1 --tab t1
 
-# Click an element using its verified selector
-actionbook browser click '[data-testid="search-button"]'
+# Snapshot to get element refs (@eN)
+actionbook browser snapshot --session s1 --tab t1
 
-# Fill a form field
-actionbook browser fill 'input[name="location"]' 'Tokyo'
+# Interact using refs from snapshot
+actionbook browser fill @e3 "Tokyo" --session s1 --tab t1
+actionbook browser click @e7 --session s1 --tab t1
+actionbook browser wait navigation --session s1 --tab t1
 ```
 
 <Tip>
@@ -82,8 +69,8 @@ This will download the skill definition to your `.skills` (or similar) directory
 ### Benefits of Skills
 
 1.  **Context Awareness**: The skill provides the agent with specific instructions on when and how to call Actionbook CLI commands.
-2.  **Workflow Optimization**: It teaches the agent the optimal workflow: `search` -> `get` -> `operate`.
-3.  **Reduced Hallucinations**: By following the skill's procedure, the agent relies on verified action manuals instead of guessing DOM selectors.
+2.  **Workflow Optimization**: It teaches the agent the optimal workflow: `start` -> `snapshot` -> `automate with refs`.
+3.  **Reduced Hallucinations**: By following the skill's procedure, the agent uses snapshot refs instead of guessing DOM selectors.
 
 ### Example Agent Workflow
 
@@ -93,9 +80,9 @@ Once the CLI is installed and the Skill is added, you can simply ask your agent:
 
 The agent will:
 1.  **Read Skill**: Understands it should use `actionbook` CLI.
-2.  **Search**: Runs `actionbook search "airbnb search"`.
-3.  **Get**: Runs `actionbook get ...` to find the search input and button selectors.
-4.  **Operate**: Runs `actionbook browser ...` commands to perform the search safely.
+2.  **Start & Navigate**: Runs `actionbook browser start` and `goto` to open the page.
+3.  **Snapshot**: Runs `actionbook browser snapshot` to get element refs.
+4.  **Automate**: Uses refs (`@eN`) to fill, click, and interact confidently.
 
 ### Extracting Data
 
@@ -111,10 +98,10 @@ Ask naturally:
 > "Pull all job listings from this page — title, company, location."
 
 The agent will:
-1.  Search Actionbook for verified selectors.
-2.  If `actionbook get` already covers required fields, start from those selectors and draft the script quickly.
+1.  Start a browser session and navigate to the target page.
+2.  Snapshot the page to identify data elements and their refs.
 3.  Run lightweight mechanism probes when needed (hydration/scroll/pagination checks).
-4.  Use snapshot/screenshot/inspect only when selectors are missing or fail in validation.
+4.  Use snapshot/screenshot/inspect to map the data structure.
 5.  Generate a **standalone Playwright script** that handles detected page mechanisms.
 6.  Run the script and write the extracted data to disk.
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -36,18 +36,17 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
 ## How It Works
 
 <Steps>
-  <Step title="Search for Actions" icon="magnifying-glass">
-    Find available actions for any website using the CLI (`actionbook search
-    "airbnb login"`).
+  <Step title="Start a Browser Session" icon="rocket">
+    Launch a browser session with a named ID (`actionbook browser start --set-session-id s1`).
   </Step>
-  <Step title="Get Action Details" icon="book">
-    Retrieve the full action manual with precise selectors and step-by-step
-    instructions (`actionbook get "google.com:/:default"`).
+  <Step title="Navigate & Snapshot" icon="magnifying-glass">
+    Go to any page and capture its structure with element refs
+    (`actionbook browser goto "https://airbnb.com" --session s1 --tab t1`,
+    then `actionbook browser snapshot --session s1 --tab t1`).
   </Step>
-  <Step title="Launch & Execute" icon="bullseye">
-    Open a browser session and let your agent execute actions with confidence —
-    no guessing, no hallucinations (`actionbook browser open
-    "https://www.google.com"`).
+  <Step title="Automate with Refs" icon="bullseye">
+    Use snapshot refs to interact with confidence — no guessing, no hallucinations
+    (`actionbook browser click @e7 --session s1 --tab t1`).
   </Step>
 </Steps>
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -36,17 +36,18 @@ Actionbook places up-to-date action manuals with the relevant DOM selectors dire
 ## How It Works
 
 <Steps>
-  <Step title="Start a Browser Session" icon="rocket">
-    Launch a browser session with a named ID (`actionbook browser start --set-session-id s1`).
+  <Step title="Search for Actions" icon="magnifying-glass">
+    Find available actions for any website using the CLI (`actionbook search
+    "airbnb login"`).
   </Step>
-  <Step title="Navigate & Snapshot" icon="magnifying-glass">
-    Go to any page and capture its structure with element refs
-    (`actionbook browser goto "https://airbnb.com" --session s1 --tab t1`,
-    then `actionbook browser snapshot --session s1 --tab t1`).
+  <Step title="Get Action Details" icon="book">
+    Retrieve the full action manual with precise selectors and step-by-step
+    instructions (`actionbook get "google.com:/:default"`).
   </Step>
-  <Step title="Automate with Refs" icon="bullseye">
-    Use snapshot refs to interact with confidence — no guessing, no hallucinations
-    (`actionbook browser click @e7 --session s1 --tab t1`).
+  <Step title="Launch & Execute" icon="bullseye">
+    Start a browser session and let your agent execute actions with confidence —
+    no guessing, no hallucinations (`actionbook browser start --set-session-id s1`,
+    then `actionbook browser goto "https://www.google.com" --session s1 --tab t1`).
   </Step>
 </Steps>
 

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -25,9 +25,10 @@ actionbook setup
 3. Run your first browser commands:
 
 ```bash
-actionbook browser open "https://example.com"
-actionbook browser snapshot
-actionbook browser close
+actionbook browser start --set-session-id s1
+actionbook browser goto "https://example.com" --session s1 --tab t1
+actionbook browser snapshot --session s1 --tab t1
+actionbook browser close --session s1
 ```
 
 If `snapshot` returns the page structure, your local setup is ready.

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -76,8 +76,8 @@ All commands support `--help` for full usage and examples.
 | Session | `start`, `close`, `restart`, `list-sessions`, `status` | `actionbook browser start --help` |
 | Tab | `new-tab`, `close-tab`, `list-tabs` | `actionbook browser new-tab --help` |
 | Navigation | `goto`, `back`, `forward`, `reload` | `actionbook browser goto --help` |
-| Observation | `snapshot`, `text`, `html`, `value`, `screenshot`, `title`, `url` | `actionbook browser snapshot --help` |
-| Interaction | `click`, `fill`, `type`, `press`, `select`, `hover`, `scroll` | `actionbook browser click --help` |
+| Observation | `snapshot`, `text`, `html`, `value`, `title`, `url`, `viewport`, `attr`, `attrs`, `box`, `styles`, `describe`, `state`, `inspect-point`, `screenshot`, `pdf` | `actionbook browser snapshot --help` |
+| Interaction | `click`, `fill`, `type`, `press`, `select`, `hover`, `focus`, `scroll`, `drag`, `upload`, `eval`, `mouse-move`, `cursor-position` | `actionbook browser click --help` |
 | Wait | `wait element`, `wait navigation`, `wait network-idle`, `wait condition` | `actionbook browser wait element --help` |
 | Cookies | `cookies list`, `cookies get`, `cookies set`, `cookies delete`, `cookies clear` | `actionbook browser cookies list --help` |
 | Storage | `local-storage list\|get\|set\|delete\|clear`, `session-storage ...` | `actionbook browser local-storage get --help` |
@@ -87,6 +87,19 @@ All commands support `--help` for full usage and examples.
 | Batch | `batch-new-tab`, `batch-snapshot`, `batch-click` | `actionbook browser batch-new-tab --help` |
 
 Full command reference: [command-reference.md](references/command-reference.md)
+
+### Cloud providers
+
+Use `-p` / `--provider` with `browser start` to run sessions on a remote browser instead of launching local Chrome. Supported providers: `driver`, `hyperbrowser`, `browseruse`. Each reads its own `<PROVIDER>_API_KEY` from the shell env.
+
+```bash
+export HYPERBROWSER_API_KEY="your-key"
+actionbook browser start -p hyperbrowser --session s1
+actionbook browser goto "https://example.com" --session s1 --tab t1
+actionbook browser snapshot --session s1 --tab t1
+```
+
+All browser commands work the same way regardless of mode. `browser restart --session <id>` mints a fresh remote session while preserving the session_id.
 
 ## Example: End-to-End
 

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -19,17 +19,22 @@ Selectors accept CSS, XPath, or snapshot refs (`@eN` from `snapshot` output).
 ```bash
 actionbook browser start                                   # Start a browser session
 actionbook browser start --set-session-id s1               # Start with a custom session ID
+actionbook browser start --session s1                      # Get-or-create: reuse if exists, create if not
 actionbook browser start --headless                        # Start headless
 actionbook browser start --mode cloud --cdp-endpoint <ws>  # Connect to cloud browser
+actionbook browser start -p hyperbrowser                   # Cloud provider (implies --mode cloud)
+actionbook browser start -p driver --header "X-Key:val"    # Provider with custom CDP headers
 actionbook browser start --open-url https://example.com    # Open URL on start
 actionbook browser start --profile myprofile               # Use named profile
-actionbook browser start --executable-path /path/to/chrome # Custom browser binary
+actionbook browser start --no-stealth                      # Disable anti-detection mode
 
 actionbook browser list-sessions                           # List all active sessions
 actionbook browser status --session s1                     # Show session status
 actionbook browser close --session s1                      # Close a session
 actionbook browser restart --session s1                    # Restart a session
 ```
+
+Supported cloud providers: `driver` (`DRIVER_API_KEY`), `hyperbrowser` (`HYPERBROWSER_API_KEY`), `browseruse` (`BROWSER_USE_API_KEY`). `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
 
 ## Tab
 
@@ -46,10 +51,14 @@ actionbook browser close-tab --session s1 --tab t1         # Close a tab
 
 ```bash
 actionbook browser goto <url> --session s1 --tab t1        # Navigate to URL
+actionbook browser goto <url> --wait-until load --session s1 --tab t1   # Wait for full page load
+actionbook browser goto <url> --wait-until none --session s1 --tab t1   # Return immediately
 actionbook browser back --session s1 --tab t1              # Go back
 actionbook browser forward --session s1 --tab t1           # Go forward
 actionbook browser reload --session s1 --tab t1            # Reload page
 ```
+
+`--wait-until` controls when `goto` returns: `domcontentloaded` (default), `load` (all resources), or `none` (immediate). A scheme (`https://`) is added automatically if omitted.
 
 ## Interaction
 
@@ -77,6 +86,7 @@ actionbook browser press Shift+Tab --session s1 --tab t1
 # Selection
 actionbook browser select "<selector>" "value" --session s1 --tab t1
 actionbook browser select "<selector>" "Display Text" --by-text --session s1 --tab t1
+actionbook browser select "<selector>" @e12 --by-ref --session s1 --tab t1
 
 # Mouse
 actionbook browser hover "<selector>" --session s1 --tab t1
@@ -100,7 +110,12 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
 # JavaScript
 actionbook browser eval "document.title" --session s1 --tab t1
 actionbook browser eval "document.querySelectorAll('a').length" --session s1 --tab t1
+actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isolate --session s1 --tab t1
 ```
+
+**eval scope isolation:** By default, `eval` wraps `let`/`const` declarations in an isolated scope so they don't leak across calls. Use `--no-isolate` to disable this — needed for multi-statement async expressions or when you want shared scope.
+
+**eval response fields:** Success includes `pre_url`, `pre_origin`, `pre_readyState` (page state before execution) and `post_url`, `post_title` (page state after). On failure, `details` contains `{stage, pre_url, pre_origin, pre_readyState, error_type}` for diagnostics.
 
 **fill vs type:** `fill` clears the field and sets the value directly (like pasting). `type` simulates individual keystrokes and appends to existing content.
 
@@ -173,6 +188,8 @@ actionbook browser screenshot output.png --session s1 --tab t1
 actionbook browser screenshot output.png --full --session s1 --tab t1          # Full page
 actionbook browser screenshot output.png --annotate --session s1 --tab t1      # Numbered labels
 actionbook browser screenshot output.jpg --screenshot-quality 80 --session s1 --tab t1
+actionbook browser screenshot output.jpg --screenshot-format jpeg --session s1 --tab t1
+actionbook browser screenshot output.png --selector "#main" --session s1 --tab t1  # Capture specific element
 actionbook browser pdf output.pdf --session s1 --tab t1
 ```
 
@@ -274,10 +291,11 @@ actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
 ```bash
 actionbook setup                                    # Interactive configuration wizard
 actionbook setup --non-interactive --api-key <KEY>  # Non-interactive setup
+actionbook setup --non-interactive --browser local   # Set browser mode non-interactively
 actionbook setup --reset                            # Reset configuration
 actionbook setup --target claude                    # Quick mode: install skills for an agent
 actionbook setup -t codex                           # Short flag
-# Targets: claude, codex, cursor, windsurf, antigravity, opencode, standalone, all
+# Targets: claude, codex, cursor, windsurf, antigravity, opencode, hermes, standalone, all
 ```
 
 ## Practical Examples

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -88,6 +88,8 @@ actionbook browser select "<selector>" "value" --session s1 --tab t1
 actionbook browser select "<selector>" "Display Text" --by-text --session s1 --tab t1
 actionbook browser select "<selector>" @e12 --by-ref --session s1 --tab t1
 
+When an option is not found, `select` returns structured diagnostics in the `details` field: available values, visible texts, current match mode (`by-value`/`by-text`), and total option count.
+
 # Mouse
 actionbook browser hover "<selector>" --session s1 --tab t1
 actionbook browser focus "<selector>" --session s1 --tab t1


### PR DESCRIPTION
## Summary

- **Fix broken examples** across 5 docs pages: add `--session`/`--tab` flags, replace `browser open` with `start` + `goto`, remove `search`/`get` references that are no longer part of the CLI
- **Add missing flags and commands** to `command-reference.md` and `SKILL.md`: cloud provider (`--provider/-p`), eval scope isolation (`--no-isolate`), goto `--wait-until`, select `--by-ref`, screenshot `--screenshot-format`/`--selector`, setup `--browser`/hermes target
- **Rewrite `api-reference/cli.mdx`** from scratch: removed stale search/get sections, added complete browser command reference covering all 50+ commands with correct `--session`/`--tab` usage

### Files changed (7)

| File | Change |
|------|--------|
| `docs/quickstart.mdx` | Add `--session`/`--tab`, use `start`+`goto` |
| `docs/index.mdx` | Replace search→get→operate with start→snapshot→automate |
| `docs/api-reference/cli.mdx` | Full rewrite: remove search/get, add all browser commands |
| `docs/guides/browser.mdx` | Add `--session`/`--tab` to Local Mode, replace recommended workflow |
| `docs/guides/cli-and-skills.mdx` | Add `--session`/`--tab`, update skill workflow |
| `skills/actionbook/SKILL.md` | Add missing commands to tables, add cloud provider section |
| `skills/actionbook/references/command-reference.md` | Add missing flags (provider, wait-until, by-ref, no-isolate, etc.) |

## Test plan

- [ ] Verify all CLI examples in docs pages use correct `--session`/`--tab` syntax
- [ ] Verify no remaining references to `actionbook search` or `actionbook get` in modified files
- [ ] Verify command-reference.md flags match actual CLI (`--help` output)
- [ ] Verify SKILL.md command table is complete against `BrowserCommands` enum in cli.rs

🤖 Generated with [Claude Code](https://claude.com/claude-code)