### PR TITLE
fix(select): collapse nested if-let to fix clippy collapsible_if lint

### DIFF
--- a/packages/cli/src/browser/interaction/select.rs
+++ b/packages/cli/src/browser/interaction/select.rs
@@ -176,29 +176,29 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             );
         }
         other if other.starts_with('{') => {
-            if let Ok(diag) = serde_json::from_str::<serde_json::Value>(other) {
-                if diag["status"].as_str() == Some("option not found") {
-                    let mode = diag["mode"].as_str().unwrap_or("by-value").to_string();
-                    let total = diag["total"].as_u64().unwrap_or(0);
-                    let values = diag["values"].clone();
-                    let texts = diag["texts"].clone();
-                    let message = format!(
-                        "option not found: '{}'. Mode: {}. Total options: {}. Values: {}. Texts: {}",
-                        cmd.value, mode, total, values, texts,
-                    );
-                    return ActionResult::fatal_with_details(
-                        "INVALID_ARGUMENT",
-                        message,
-                        "check the available values and texts above, or use --by-text to match display text",
-                        json!({
-                            "status": "option not found",
-                            "mode": mode,
-                            "total": total,
-                            "values": values,
-                            "texts": texts,
-                        }),
-                    );
-                }
+            if let Ok(diag) = serde_json::from_str::<serde_json::Value>(other)
+                && diag["status"].as_str() == Some("option not found")
+            {
+                let mode = diag["mode"].as_str().unwrap_or("by-value").to_string();
+                let total = diag["total"].as_u64().unwrap_or(0);
+                let values = diag["values"].clone();
+                let texts = diag["texts"].clone();
+                let message = format!(
+                    "option not found: '{}'. Mode: {}. Total options: {}. Values: {}. Texts: {}",
+                    cmd.value, mode, total, values, texts,
+                );
+                return ActionResult::fatal_with_details(
+                    "INVALID_ARGUMENT",
+                    message,
+                    "check the available values and texts above, or use --by-text to match display text",
+                    json!({
+                        "status": "option not found",
+                        "mode": mode,
+                        "total": total,
+                        "values": values,
+                        "texts": texts,
+                    }),
+                );
             }
             return ActionResult::fatal("CDP_ERROR", format!("select failed: {other}"));
         }


### PR DESCRIPTION
## Summary

- Combines the nested `if let Ok(diag)` / `if diag["status"] == ...` into a single let-chain guard to satisfy `clippy::collapsible_if`
- PR #521 was merged with a lint failure on this; this follow-up cleans it up

## Test plan

- [ ] CI lint (clippy) passes
- [ ] No behavior change — purely cosmetic restructuring