### PR TITLE
fix(tests): allow clippy::too_many_arguments on select diagnostics helper

### DIFF
--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -272,6 +272,7 @@ fn assert_select_success_full(
     assert_meta(v);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn assert_select_not_found_diagnostics(
     v: &serde_json::Value,
     session_id: &str,


### PR DESCRIPTION
## Summary

- Adds `#[allow(clippy::too_many_arguments)]` to `assert_select_not_found_diagnostics` in `interaction.rs`
- This test helper has 8 params (clippy limit is 7); refactoring to a struct is unnecessary churn for a test-only function
- Fixes the remaining lint failure left by PR #521/#522

## Test plan
- [ ] Lint (fmt + clippy) passes
- [ ] No behavior change