### PR TITLE
feat(network): phase-a implementation — configurable buffer size and request dump

### DIFF
--- a/packages/cli/src/browser/observation/network_requests.rs
+++ b/packages/cli/src/browser/observation/network_requests.rs
@@ -18,12 +18,14 @@ Examples:
   actionbook browser network requests --method POST --session s1 --tab t1
   actionbook browser network requests --status 2xx --session s1 --tab t1
   actionbook browser network requests --clear --session s1 --tab t1
+  actionbook browser network requests --dump --out /tmp/requests --session s1 --tab t1
 
 Lists all network requests captured since the tab was attached (or since last --clear).
 Requests are captured automatically — no setup required.
 Use --filter for URL substring, --type for resource type (comma-separated),
 --method for HTTP method, --status for status code (200, 2xx, 400-499).
-Use --clear to reset the request buffer and return {cleared: true}.")]
+Use --clear to reset the request buffer and return {cleared: true}.
+Use --dump --out <dir> to write all matched requests (with response bodies) to <dir>/requests.json.")]
 pub struct Cmd {
     /// Session ID
     #[arg(long)]
@@ -49,6 +51,13 @@ pub struct Cmd {
     /// Clear request buffer after retrieval (returns {cleared: true, count: N})
     #[arg(long)]
     pub clear: bool,
+    /// Dump matched requests (with response bodies) to <--out>/requests.json
+    #[arg(long)]
+    #[serde(default)]
+    pub dump: bool,
+    /// Output directory for --dump (required when --dump is set)
+    #[arg(long)]
+    pub out: Option<String>,
 }
 
 pub const COMMAND_NAME: &str = "browser network requests";
@@ -87,6 +96,10 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    if cmd.dump && cmd.out.is_none() {
+        return ActionResult::fatal("INVALID_ARGUMENT", "--out <dir> is required with --dump");
+    }
+
     let (cdp, target_id) = match get_cdp_and_target(registry, &cmd.session, &cmd.tab).await {
         Ok(v) => v,
         Err(e) => return e,
@@ -124,6 +137,82 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let total = cdp.network_requests_total(&cdp_session_id).await;
     let matched = cdp.network_requests(&cdp_session_id, &filter).await;
     let filtered = matched.len();
+
+    if cmd.dump {
+        let out_dir = cmd.out.as_deref().unwrap();
+        if let Err(e) = std::fs::create_dir_all(out_dir) {
+            return ActionResult::fatal(
+                "IO_ERROR",
+                format!("failed to create output directory '{out_dir}': {e}"),
+            );
+        }
+
+        let mut dump_requests: Vec<Value> = Vec::with_capacity(matched.len());
+        for req in &matched {
+            let (response_body, body_error): (Value, Value) =
+                match cdp
+                    .execute_on_tab(
+                        &target_id,
+                        "Network.getResponseBody",
+                        json!({ "requestId": req.request_id }),
+                    )
+                    .await
+                {
+                    Ok(resp) => {
+                        let body = resp
+                            .pointer("/result/body")
+                            .and_then(|v| v.as_str())
+                            .map(|s| Value::String(s.to_string()))
+                            .unwrap_or(Value::Null);
+                        (body, Value::Null)
+                    }
+                    Err(e) => (Value::Null, Value::String(e.to_string())),
+                };
+
+            dump_requests.push(json!({
+                "request_id": req.request_id,
+                "url": req.url,
+                "method": req.method,
+                "resource_type": req.resource_type,
+                "timestamp": req.timestamp_ms,
+                "status": req.status,
+                "mime_type": req.mime_type,
+                "request_headers": req.request_headers,
+                "response_headers": req.response_headers,
+                "response_body": response_body,
+                "body_error": body_error,
+            }));
+        }
+
+        let dump_path = std::path::Path::new(out_dir).join("requests.json");
+        let dump_json = json!({ "requests": dump_requests });
+        let dump_bytes = match serde_json::to_vec_pretty(&dump_json) {
+            Ok(b) => b,
+            Err(e) => {
+                return ActionResult::fatal(
+                    "INTERNAL_ERROR",
+                    format!("failed to serialize dump: {e}"),
+                );
+            }
+        };
+        if let Err(e) = std::fs::write(&dump_path, &dump_bytes) {
+            return ActionResult::fatal(
+                "IO_ERROR",
+                format!("failed to write '{}': {e}", dump_path.display()),
+            );
+        }
+
+        let url = navigation::get_tab_url(&cdp, &target_id).await;
+        let title = navigation::get_tab_title(&cdp, &target_id).await;
+        return ActionResult::ok(json!({
+            "dump": {
+                "path": dump_path.to_string_lossy(),
+                "count": filtered,
+            },
+            "__ctx_url": url,
+            "__ctx_title": title,
+        }));
+    }
 
     let requests: Vec<Value> = matched
         .into_iter()

--- a/packages/cli/src/browser/observation/network_requests.rs
+++ b/packages/cli/src/browser/observation/network_requests.rs
@@ -149,25 +149,24 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
         let mut dump_requests: Vec<Value> = Vec::with_capacity(matched.len());
         for req in &matched {
-            let (response_body, body_error): (Value, Value) =
-                match cdp
-                    .execute_on_tab(
-                        &target_id,
-                        "Network.getResponseBody",
-                        json!({ "requestId": req.request_id }),
-                    )
-                    .await
-                {
-                    Ok(resp) => {
-                        let body = resp
-                            .pointer("/result/body")
-                            .and_then(|v| v.as_str())
-                            .map(|s| Value::String(s.to_string()))
-                            .unwrap_or(Value::Null);
-                        (body, Value::Null)
-                    }
-                    Err(e) => (Value::Null, Value::String(e.to_string())),
-                };
+            let (response_body, body_error): (Value, Value) = match cdp
+                .execute_on_tab(
+                    &target_id,
+                    "Network.getResponseBody",
+                    json!({ "requestId": req.request_id }),
+                )
+                .await
+            {
+                Ok(resp) => {
+                    let body = resp
+                        .pointer("/result/body")
+                        .and_then(|v| v.as_str())
+                        .map(|s| Value::String(s.to_string()))
+                        .unwrap_or(Value::Null);
+                    (body, Value::Null)
+                }
+                Err(e) => (Value::Null, Value::String(e.to_string())),
+            };
 
             dump_requests.push(json!({
                 "request_id": req.request_id,

--- a/packages/cli/src/browser/session/list.rs
+++ b/packages/cli/src/browser/session/list.rs
@@ -34,6 +34,7 @@ pub async fn execute(_cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 "status": s.status.to_string(),
                 "headless": s.headless,
                 "tabs_count": s.tabs_count(),
+                "max_tracked_requests": s.max_tracked_requests,
             });
             // Include cdp_endpoint for cloud sessions (redacted), never expose headers
             if let Some(ref ep) = s.cdp_endpoint {

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -65,6 +65,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         saved_provider_env,
         cdp,
         chrome_process,
+        max_tracked_requests,
     );
     {
         let mut reg = registry.lock().await;
@@ -114,6 +115,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         saved_provider_env = provider_session.as_ref().map(|s| s.provider_env.clone());
         cdp = entry.cdp.take();
         chrome_process = entry.chrome_process.take();
+        max_tracked_requests = entry.max_tracked_requests;
 
         reg.clear_session_ref_caches(&cmd.session);
     }
@@ -203,6 +205,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         session: None,
         set_session_id: Some(cmd.session.clone()),
         stealth,
+        max_tracked_requests,
         provider_env: effective_provider_env,
     };
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1420,7 +1420,9 @@ async fn execute_extension(
     };
 
     // Connect CdpSession to bridge (transparent relay to extension).
-    let cdp = match CdpSession::connect_with_config(&bridge_ws_url, &[], cmd.max_tracked_requests).await {
+    let cdp = match CdpSession::connect_with_config(&bridge_ws_url, &[], cmd.max_tracked_requests)
+        .await
+    {
         Ok(c) => c,
         Err(e) => {
             return fail_reserved_start(

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -91,6 +91,11 @@ pub struct Cmd {
     #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
     #[serde(default = "default_stealth")]
     pub stealth: bool,
+    /// Maximum number of network requests to track per tab (ring buffer capacity).
+    /// Must be between 1 and 100000. Default: 500.
+    #[arg(long, default_value_t = 500)]
+    #[serde(default = "default_max_tracked_requests")]
+    pub max_tracked_requests: usize,
     /// Snapshot of provider env vars forwarded from the CLI client to the
     /// daemon (DRIVER_*, HYPERBROWSER_*, BROWSER_USE_*).
     /// The daemon must NOT read these from its own process env — its env was
@@ -100,6 +105,10 @@ pub struct Cmd {
     #[arg(skip)]
     #[serde(default)]
     pub provider_env: ProviderEnv,
+}
+
+fn default_max_tracked_requests() -> usize {
+    500
 }
 
 fn default_stealth() -> bool {
@@ -223,6 +232,16 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             "MISSING_CDP_ENDPOINT",
             "--mode cloud requires --cdp-endpoint",
             "provide a cloud browser endpoint, e.g. --cdp-endpoint wss://...",
+        );
+    }
+
+    if cmd.max_tracked_requests == 0 || cmd.max_tracked_requests > 100_000 {
+        return ActionResult::fatal(
+            "INVALID_ARGUMENT",
+            format!(
+                "--max-tracked-requests must be between 1 and 100000, got {}",
+                cmd.max_tracked_requests
+            ),
         );
     }
 
@@ -414,6 +433,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 headless,
                 Some(provider_connection.provider.as_str()),
                 provider_connection.session.clone(),
+                cmd.max_tracked_requests,
             )
             .await;
         }
@@ -427,6 +447,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             headless,
             None,
             None,
+            cmd.max_tracked_requests,
         )
         .await;
     }
@@ -749,7 +770,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     }
 
     // Create persistent CDP connection and attach all initial tabs
-    let cdp = match CdpSession::connect(&ws_url).await {
+    let cdp = match CdpSession::connect_with_config(&ws_url, &[], cmd.max_tracked_requests).await {
         Ok(c) => c,
         Err(e) => {
             return fail_reserved_start_with_chrome(
@@ -836,6 +857,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     entry.status = SessionState::Running;
     entry.cdp_port = port;
     entry.ws_url = ws_url.clone();
+    entry.max_tracked_requests = cmd.max_tracked_requests;
     for (native_id, url, title) in native_tabs {
         entry.push_tab(native_id, url, title);
     }
@@ -1089,6 +1111,7 @@ async fn execute_cloud(
     headless: bool,
     provider_name: Option<&str>,
     provider_session: Option<ProviderSession>,
+    max_tracked_requests: usize,
 ) -> ActionResult {
     let ws_url = match ensure_scheme_or_fatal(cdp_endpoint) {
         Ok(u) => u,
@@ -1159,8 +1182,8 @@ async fn execute_cloud(
         }
     };
 
-    // ── Connect with headers ──
-    let cdp = match CdpSession::connect_with_headers(&ws_url, headers).await {
+    // ── Connect with config ──
+    let cdp = match CdpSession::connect_with_config(&ws_url, headers, max_tracked_requests).await {
         Ok(c) => c,
         Err(e) => {
             return fail_reserved_cloud_start(
@@ -1270,6 +1293,7 @@ async fn execute_cloud(
     entry.status = SessionState::Running;
     entry.cdp_port = None;
     entry.ws_url = ws_url.clone();
+    entry.max_tracked_requests = max_tracked_requests;
     for (native_id, url, title) in tabs {
         entry.push_tab(native_id, url, title);
     }
@@ -1396,7 +1420,7 @@ async fn execute_extension(
     };
 
     // Connect CdpSession to bridge (transparent relay to extension).
-    let cdp = match CdpSession::connect(&bridge_ws_url).await {
+    let cdp = match CdpSession::connect_with_config(&bridge_ws_url, &[], cmd.max_tracked_requests).await {
         Ok(c) => c,
         Err(e) => {
             return fail_reserved_start(
@@ -1533,6 +1557,7 @@ async fn execute_extension(
     entry.status = SessionState::Running;
     entry.cdp_port = None;
     entry.ws_url = bridge_ws_url.clone();
+    entry.max_tracked_requests = cmd.max_tracked_requests;
     for (native_id, url, title) in tabs {
         entry.push_tab(native_id, url, title);
     }
@@ -1999,6 +2024,7 @@ mod provider_start_tests {
                 session: None,
                 set_session_id: Some("hyp3".to_string()),
                 stealth: true,
+                max_tracked_requests: 500,
                 provider_env: ProviderEnv::new(),
             },
             &registry,
@@ -2015,6 +2041,7 @@ mod provider_start_tests {
                     ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
                 ]),
             }),
+            500,
         )
         .await;
 
@@ -2058,6 +2085,7 @@ mod provider_start_tests {
                 session: None,
                 set_session_id: Some("hyp3".to_string()),
                 stealth: true,
+                max_tracked_requests: 500,
                 provider_env: ProviderEnv::from([
                     ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
                     (
@@ -2109,6 +2137,7 @@ mod provider_start_tests {
                 session: None,
                 set_session_id: Some("bs1".to_string()),
                 stealth: true,
+                max_tracked_requests: 500,
                 provider_env: ProviderEnv::new(),
             },
             &registry,
@@ -2118,6 +2147,7 @@ mod provider_start_tests {
             false,
             Some("browseruse"),
             None,
+            500,
         )
         .await;
 

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -385,6 +385,7 @@ mod tests {
             session: None,
             set_session_id: None,
             stealth: true,
+            max_tracked_requests: 500,
             provider_env: Default::default(),
         }
     }

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -72,7 +72,11 @@ fn normalize_headers(headers: Option<&Value>) -> HashMap<String, String> {
         .collect()
 }
 
-fn record_request_will_be_sent(requests: &mut VecDeque<TrackedRequest>, params: &Value) {
+fn record_request_will_be_sent(
+    requests: &mut VecDeque<TrackedRequest>,
+    params: &Value,
+    max_tracked_requests: usize,
+) {
     let request_id = params
         .get("requestId")
         .and_then(|v| v.as_str())
@@ -130,7 +134,7 @@ fn record_request_will_be_sent(requests: &mut VecDeque<TrackedRequest>, params: 
         return;
     }
 
-    if requests.len() >= MAX_TRACKED_REQUESTS {
+    if requests.len() >= max_tracked_requests {
         requests.pop_front();
     }
     requests.push_back(TrackedRequest {
@@ -294,13 +298,22 @@ pub struct CdpSession {
 impl CdpSession {
     /// Connect to a browser-level WebSocket endpoint and spawn background tasks.
     pub async fn connect(ws_url: &str) -> Result<Self, CliError> {
-        Self::connect_with_headers(ws_url, &[]).await
+        Self::connect_with_config(ws_url, &[], MAX_TRACKED_REQUESTS).await
     }
 
     /// Connect with custom headers (for cloud mode auth).
     pub async fn connect_with_headers(
         ws_url: &str,
         headers: &[(String, String)],
+    ) -> Result<Self, CliError> {
+        Self::connect_with_config(ws_url, headers, MAX_TRACKED_REQUESTS).await
+    }
+
+    /// Connect with custom headers and a configurable network request buffer size.
+    pub async fn connect_with_config(
+        ws_url: &str,
+        headers: &[(String, String)],
+        max_tracked_requests: usize,
     ) -> Result<Self, CliError> {
         let mut request = ws_url
             .into_client_request()
@@ -342,6 +355,7 @@ impl CdpSession {
             pending_iframe_enables.clone(),
             tab_sessions.clone(),
             tab_net_requests.clone(),
+            max_tracked_requests,
         ));
 
         Ok(CdpSession {
@@ -796,6 +810,7 @@ impl CdpSession {
         pending_iframe_enables: PendingIframeEnables,
         _tab_sessions: Arc<Mutex<HashMap<String, String>>>,
         tab_net_requests: TabNetRequests,
+        max_tracked_requests: usize,
     ) where
         S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
     {
@@ -898,7 +913,7 @@ impl CdpSession {
                             if let Some(params) = params {
                                 let mut tnr = tab_net_requests.lock().await;
                                 let requests = tnr.entry(session_id.to_string()).or_default();
-                                record_request_will_be_sent(requests, params);
+                                record_request_will_be_sent(requests, params, max_tracked_requests);
                             }
                         }
                         "Network.responseReceived" => {
@@ -2072,6 +2087,7 @@ mod tests {
                     "headers": { "accept": "application/json" }
                 }
             }),
+            MAX_TRACKED_REQUESTS,
         );
         record_response_received(
             &mut requests,
@@ -2119,6 +2135,7 @@ mod tests {
                         "headers": {}
                     }
                 }),
+                MAX_TRACKED_REQUESTS,
             );
         }
 

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -84,6 +84,8 @@ pub struct SessionEntry {
     pub provider_session: Option<ProviderSession>,
     /// Counter for assigning short tab IDs (t1, t2, ...).
     pub next_tab_id: u32,
+    /// Maximum number of network requests tracked per tab (ring buffer cap).
+    pub max_tracked_requests: usize,
 }
 
 impl Drop for SessionEntry {
@@ -124,6 +126,7 @@ impl SessionEntry {
             provider: None,
             provider_session: None,
             next_tab_id: 1,
+            max_tracked_requests: crate::daemon::cdp_session::MAX_TRACKED_REQUESTS,
         }
     }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -214,6 +214,7 @@ async fn handle_browser(
                         session: None,
                         set_session_id: None,
                         stealth: true,
+                        max_tracked_requests: 500,
                         provider_env: Default::default(),
                     });
                 let result = ActionResult::fatal(err.error_code(), err.to_string());

--- a/packages/cli/tests/e2e/network.rs
+++ b/packages/cli/tests/e2e/network.rs
@@ -398,8 +398,8 @@ fn start_with_custom_buffer_size() {
         .filter_map(|req| req["url"].as_str())
         .collect();
     assert!(
-        !urls.iter().any(|url| url.contains("buffer-0"))
-            && !urls.iter().any(|url| url.contains("buffer-1")),
+        !urls.iter().any(|url| url.ends_with("source=buffer-0"))
+            && !urls.iter().any(|url| url.ends_with("source=buffer-1")),
         "oldest requests should be evicted: {urls:?}"
     );
     assert!(

--- a/packages/cli/tests/e2e/network.rs
+++ b/packages/cli/tests/e2e/network.rs
@@ -96,7 +96,7 @@ fn issue_bulk_requests(session_id: &str, tab_id: &str, count: usize, prefix: &st
     let expression = format!(
         "await Promise.all(Array.from({{ length: {count} }}, (_, i) => fetch(`{api_prefix}{prefix}-${{i}}`).then(r => r.text())))"
     );
-    let argv = vec![
+    let argv = [
         "browser".to_string(),
         "eval".to_string(),
         expression,

--- a/packages/cli/tests/e2e/network.rs
+++ b/packages/cli/tests/e2e/network.rs
@@ -3,9 +3,12 @@
 //! Covers the planned `browser network requests` and
 //! `browser network request <id>` commands for ACT-882.
 
+use std::fs;
+
 use crate::harness::{
-    SessionGuard, assert_meta, assert_success, headless_json, parse_json, skip, start_session,
-    url_network_load, url_network_xhr,
+    SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success,
+    headless_json, parse_json, skip, start_session, unique_session, url_network_load,
+    url_network_xhr, wait_page_ready,
 };
 
 fn wait_requests_done(session_id: &str, tab_id: &str) {
@@ -27,11 +30,84 @@ fn wait_requests_done(session_id: &str, tab_id: &str) {
     assert_success(&out, "wait requests done");
 }
 
+fn clear_requests(session_id: &str, tab_id: &str) {
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+            "--clear",
+        ],
+        15,
+    );
+    assert_success(&out, "clear network requests");
+}
+
 fn request_items(value: &serde_json::Value) -> &[serde_json::Value] {
     value["data"]["requests"]
         .as_array()
         .map(Vec::as_slice)
         .unwrap_or(&[])
+}
+
+fn start_session_with_max_tracked_requests(
+    url: &str,
+    max_tracked_requests: usize,
+) -> (String, String) {
+    let (sid, profile) = unique_session("net");
+    let max = max_tracked_requests.to_string();
+    let argv = vec![
+        "browser".to_string(),
+        "start".to_string(),
+        "--mode".to_string(),
+        "local".to_string(),
+        "--headless".to_string(),
+        "--set-session-id".to_string(),
+        sid.clone(),
+        "--profile".to_string(),
+        profile,
+        "--open-url".to_string(),
+        url.to_string(),
+        "--max-tracked-requests".to_string(),
+        max,
+    ];
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = headless_json(&args, 30);
+    assert_success(
+        &out,
+        &format!("start session {sid} with custom max tracked requests"),
+    );
+    let v = parse_json(&out);
+    let actual_sid = v["data"]["session"]["session_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    let tid = v["data"]["tab"]["tab_id"].as_str().unwrap().to_string();
+    wait_page_ready(&actual_sid, &tid);
+    (actual_sid, tid)
+}
+
+fn issue_bulk_requests(session_id: &str, tab_id: &str, count: usize, prefix: &str) {
+    let api_prefix = url_network_xhr().replace("/network-xhr", "/api/data?source=");
+    let expression = format!(
+        "await Promise.all(Array.from({{ length: {count} }}, (_, i) => fetch(`{api_prefix}{prefix}-${{i}}`).then(r => r.text())))"
+    );
+    let argv = vec![
+        "browser".to_string(),
+        "eval".to_string(),
+        expression,
+        "--session".to_string(),
+        session_id.to_string(),
+        "--tab".to_string(),
+        tab_id.to_string(),
+    ];
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = headless_json(&args, 30);
+    assert_success(&out, "issue bulk requests");
 }
 
 #[test]
@@ -282,4 +358,262 @@ fn network_requests_empty_on_fresh_tab() {
     );
     assert!(v["data"]["total"].as_u64().unwrap_or(0) <= 1);
     assert_meta(&v);
+}
+
+#[test]
+fn start_with_custom_buffer_size() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session_with_max_tracked_requests(&url_network_xhr(), 10);
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+    clear_requests(&sid, &tid);
+    issue_bulk_requests(&sid, &tid, 12, "buffer");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        15,
+    );
+    assert_success(&out, "network requests custom buffer size");
+    let v = parse_json(&out);
+    let requests = request_items(&v);
+
+    assert_eq!(v["command"], "browser network requests");
+    assert!(
+        requests.len() <= 10,
+        "buffer should keep at most 10 newest requests"
+    );
+    let urls: Vec<&str> = requests
+        .iter()
+        .filter_map(|req| req["url"].as_str())
+        .collect();
+    assert!(
+        !urls.iter().any(|url| url.contains("buffer-0"))
+            && !urls.iter().any(|url| url.contains("buffer-1")),
+        "oldest requests should be evicted: {urls:?}"
+    );
+    assert!(
+        urls.iter().any(|url| url.contains("buffer-11")),
+        "newest request should be retained: {urls:?}"
+    );
+}
+
+#[test]
+fn start_default_buffer_size_shown() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(&["browser", "list-sessions"], 10);
+    assert_success(&out, "list-sessions with default buffer size");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser list-sessions");
+    let sessions = v["data"]["sessions"].as_array().expect("sessions array");
+    let session = sessions
+        .iter()
+        .find(|s| s["session_id"].as_str() == Some(sid.as_str()))
+        .expect("current session present in list-sessions");
+    assert_eq!(session["max_tracked_requests"], 500);
+}
+
+#[test]
+fn start_invalid_buffer_size_rejected() {
+    if skip() {
+        return;
+    }
+
+    let (sid, profile) = unique_session("net-invalid");
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--set-session-id",
+            &sid,
+            "--profile",
+            &profile,
+            "--open-url",
+            "about:blank",
+            "--max-tracked-requests",
+            "0",
+        ],
+        30,
+    );
+    assert_failure(&out, "start invalid max-tracked-requests");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "INVALID_ARGUMENT");
+}
+
+#[test]
+fn network_requests_dump_writes_file() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+    clear_requests(&sid, &tid);
+    issue_bulk_requests(&sid, &tid, 3, "dump");
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let dump_dir = temp.path().join("requests-dump");
+    let dump_dir_str = dump_dir.to_string_lossy().to_string();
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--dump",
+            "--out",
+            &dump_dir_str,
+        ],
+        30,
+    );
+    assert_success(&out, "network requests dump writes file");
+    let v = parse_json(&out);
+
+    let requests_path = dump_dir.join("requests.json");
+    assert!(requests_path.exists(), "requests.json should be created");
+    let dumped: serde_json::Value =
+        serde_json::from_slice(&fs::read(&requests_path).expect("read requests.json"))
+            .expect("requests.json must be valid JSON");
+
+    let requests = dumped["requests"].as_array().expect("requests array");
+    assert_eq!(requests.len(), 3);
+    assert!(
+        requests
+            .iter()
+            .all(|req| req["url"].is_string() && req["method"].is_string())
+    );
+    assert_eq!(
+        v["data"]["dump"]["path"],
+        requests_path.to_string_lossy().to_string()
+    );
+    assert_eq!(v["data"]["dump"]["count"], 3);
+}
+
+#[test]
+fn network_requests_dump_includes_body() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+    clear_requests(&sid, &tid);
+    issue_bulk_requests(&sid, &tid, 1, "dump-body");
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let dump_dir = temp.path().join("requests-dump-body");
+    let dump_dir_str = dump_dir.to_string_lossy().to_string();
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--dump",
+            "--out",
+            &dump_dir_str,
+        ],
+        30,
+    );
+    assert_success(&out, "network requests dump includes body");
+
+    let requests_path = dump_dir.join("requests.json");
+    let dumped: serde_json::Value =
+        serde_json::from_slice(&fs::read(&requests_path).expect("read requests.json"))
+            .expect("requests.json must be valid JSON");
+
+    let request = dumped["requests"]
+        .as_array()
+        .and_then(|requests| {
+            requests.iter().find(|req| {
+                req["url"]
+                    .as_str()
+                    .is_some_and(|url| url.contains("dump-body-0"))
+            })
+        })
+        .expect("matching dumped request");
+    assert!(
+        !request["response_body"].is_null() || !request["body_error"].is_null(),
+        "dumped request should include response_body or body_error"
+    );
+}
+
+#[test]
+fn network_requests_dump_with_filter() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session(&url_network_xhr());
+    let _guard = SessionGuard::new(&sid);
+    wait_requests_done(&sid, &tid);
+    clear_requests(&sid, &tid);
+    issue_bulk_requests(&sid, &tid, 2, "match");
+    issue_bulk_requests(&sid, &tid, 1, "skip");
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let dump_dir = temp.path().join("requests-dump-filter");
+    let dump_dir_str = dump_dir.to_string_lossy().to_string();
+
+    let out = headless_json(
+        &[
+            "browser",
+            "network",
+            "requests",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--filter",
+            "match",
+            "--dump",
+            "--out",
+            &dump_dir_str,
+        ],
+        30,
+    );
+    assert_success(&out, "network requests dump with filter");
+
+    let requests_path = dump_dir.join("requests.json");
+    let dumped: serde_json::Value =
+        serde_json::from_slice(&fs::read(&requests_path).expect("read requests.json"))
+            .expect("requests.json must be valid JSON");
+
+    let requests = dumped["requests"].as_array().expect("requests array");
+    assert_eq!(requests.len(), 2);
+    assert!(
+        requests
+            .iter()
+            .all(|req| req["url"].as_str().is_some_and(|url| url.contains("match")))
+    );
 }


### PR DESCRIPTION
## Summary

- **`browser start --max-tracked-requests N`** (1–100 000, default 500): configures the per-tab ring buffer capacity; validated on entry, stored in `SessionEntry`, reported in `list-sessions`. All three connection paths (local, cloud, extension) use `connect_with_config()` to thread the value down to the `reader_loop`.
- **`browser network requests --dump --out <dir>`**: filters requests, fetches best-effort response bodies via `Network.getResponseBody`, writes `<dir>/requests.json`, and returns `dump.{path,count}` in the response.
- `browser restart` preserves `max_tracked_requests` across restarts.
- Fix `clippy::useless_vec` in the network e2e test helper added in #60.

## Test plan

- [ ] All 350 unit tests pass (`cargo test --lib`)
- [ ] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [ ] E2E tests in `tests/e2e/network.rs` committed in #60 (commit `b3884e3`) cover all new behaviour: custom buffer size, default buffer shown in list-sessions, invalid size rejection, dump writes file, dump includes body, dump respects filters