### PR TITLE
docs: add Network Phase A flags

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -103,6 +103,7 @@ Start or attach a browser session. Entry point for all modes including cloud pro
 | `--headless` | Run in headless mode |
 | `--profile <name>` | Profile name |
 | `--stealth` / `--no-stealth` | Anti-detection mode (default: enabled) |
+| `--max-tracked-requests <N>` | Network request buffer size per tab (default: 500, range: 1–100000) |
 
 **Examples:**
 
@@ -262,6 +263,7 @@ actionbook browser logs errors --session s1 --tab t1
 # Network
 actionbook browser network requests --session s1 --tab t1
 actionbook browser network requests --filter /api/ --method POST --session s1 --tab t1
+actionbook browser network requests --dump --out /tmp/dump --session s1 --tab t1  # Export to requests.json
 actionbook browser network request <id> --session s1 --tab t1         # Full detail + response body
 ```
 

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -184,9 +184,10 @@ Most commands work in all modes. All per-tab commands require `--session` and `-
 
 ```bash
 actionbook browser start --session s1 --open-url https://google.com
-actionbook browser list-sessions                     # list all active sessions
+actionbook browser start --session s1 --max-tracked-requests 1000   # custom network buffer size
+actionbook browser list-sessions                     # list all active sessions (includes max_tracked_requests)
 actionbook browser status --session s1               # show session info
-actionbook browser restart --session s1              # restart, preserving session_id
+actionbook browser restart --session s1              # restart, preserving session_id and max_tracked_requests
 actionbook browser close --session s1                # close a session
 ```
 
@@ -263,6 +264,7 @@ actionbook browser state "#submit" --session s1 --tab t1           # element sta
 actionbook browser logs console --session s1 --tab t1              # console logs
 actionbook browser logs errors --session s1 --tab t1               # error logs
 actionbook browser network requests --session s1 --tab t1          # tracked network requests
+actionbook browser network requests --dump --out /tmp/dump --session s1 --tab t1  # export to file
 ```
 
 ### Cookie & Storage Operations

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -27,8 +27,9 @@ actionbook browser start -p driver --header "X-Key:val"    # Provider with custo
 actionbook browser start --open-url https://example.com    # Open URL on start
 actionbook browser start --profile myprofile               # Use named profile
 actionbook browser start --no-stealth                      # Disable anti-detection mode
+actionbook browser start --max-tracked-requests 1000       # Custom network buffer size (default 500, range 1-100000)
 
-actionbook browser list-sessions                           # List all active sessions
+actionbook browser list-sessions                           # List all active sessions (includes max_tracked_requests)
 actionbook browser status --session s1                     # Show session status
 actionbook browser close --session s1                      # Close a session
 actionbook browser restart --session s1                    # Restart a session
@@ -220,11 +221,15 @@ actionbook browser network requests --type xhr,fetch --session s1 --tab t1      
 actionbook browser network requests --method POST --session s1 --tab t1            # Filter by HTTP method
 actionbook browser network requests --status 2xx --session s1 --tab t1             # Filter by status (200, 2xx, 400-499)
 actionbook browser network requests --clear --session s1 --tab t1                  # Clear request buffer
+actionbook browser network requests --dump --out /tmp/dump --session s1 --tab t1  # Export matching requests to /tmp/dump/requests.json
+actionbook browser network requests --dump --out /tmp/dump --filter /api/ --session s1 --tab t1  # Export filtered requests
 
 actionbook browser network request 1234.1 --session s1 --tab t1                   # Get full request detail + response body
 ```
 
-Requests are captured automatically per tab (500 cap ring buffer). Use `network requests` to list IDs, then `network request <id>` for detail including response body.
+Requests are captured automatically per tab (default 500, configurable via `browser start --max-tracked-requests N`). Use `network requests` to list IDs, then `network request <id>` for detail including response body.
+
+`--dump --out <dir>` exports all matching requests (after filters) as a single `<dir>/requests.json` file with best-effort response bodies. Returns `dump: { path, count }` on success.
 
 ## Wait
 


### PR DESCRIPTION
## Summary

- Add `--max-tracked-requests N` to `browser start` docs (default 500, range 1–100000)
- Add `--dump --out <dir>` to `network requests` docs (exports filtered requests with best-effort response bodies to `requests.json`)
- Document that `list-sessions` now includes `max_tracked_requests` field
- Document that `restart` preserves `max_tracked_requests`

### Files changed (3)

| File | Change |
|------|--------|
| `skills/actionbook/references/command-reference.md` | Add `--max-tracked-requests` to start, `--dump --out` to network requests |
| `docs/api-reference/cli.mdx` | Add `--max-tracked-requests` to start options table, `--dump` to network section |
| `docs/guides/browser.mdx` | Add `--max-tracked-requests` to session lifecycle, `--dump` to observation section |

## Test plan

- [ ] Verify `--max-tracked-requests` documented in start command across all 3 files
- [ ] Verify `--dump --out` documented in network requests across all 3 files
- [ ] Verify flags match PR #524 implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)