### PR TITLE
[skills/actionbook]fix: remove non-spec frontmatter fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ Actionbook ships with Agent Skills that teach your AI agent how to use the CLI.
 npx skills add actionbook/actionbook
 ```
 
-**Hermes** — one command (installs the CLI and registers the skill in `~/.hermes/skills/`):
+**Hermes** — one command (registers the skill in `~/.hermes/skills/`):
 
 ```bash
-npm install -g @actionbookdev/cli && hermes skills install actionbook -y
+hermes skills install actionbook -y
 ```
 
 Then start a chat and say things like *"use actionbook to open google.com and search for anthropic"*. Hermes auto-activates the skill and drives the CLI for you.

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -6,11 +6,8 @@ license: MIT
 platforms: [macos, linux, windows]
 metadata:
   hermes:
-    category: devops
     tags: [browser-automation, web-automation, scraping, e2e-testing]
     requires_toolsets: [terminal]
-prerequisites:
-  commands: [actionbook]
 ---
 
 ## When to Use This Skill


### PR DESCRIPTION
## Summary

Brings `skills/actionbook/SKILL.md` frontmatter in line with the [Hermes skill spec](https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills).

- **Remove `metadata.hermes.category: devops`** — `category` is not in the Hermes frontmatter whitelist. The documented keys under `metadata.hermes` are: `tags`, `related_skills`, `requires_toolsets`, `requires_tools`, `fallback_for_toolsets`, `fallback_for_tools`, `config`. Semantics are already captured by `tags`.
- **Remove `prerequisites.commands: [actionbook]`** — Hermes only recognizes the legacy alias `prerequisites.env_vars` (mapped to `required_environment_variables`). The `commands` subkey is undocumented and silently ignored by the Hermes parser, so it was dead metadata. Installation guidance is already provided in the README.

### Diff

```diff
 metadata:
   hermes:
-    category: devops
     tags: [browser-automation, web-automation, scraping, e2e-testing]
     requires_toolsets: [terminal]
-prerequisites:
-  commands: [actionbook]
 ---
```

No behavior change — the removed keys were never honored by Hermes.

## Test plan

- [ ] Load the skill in Hermes and confirm it still registers with the correct tags and `requires_toolsets`
- [ ] Confirm skill search/discovery surfaces the skill under browser-automation queries
- [ ] Verify no other SKILL.md in the repo references `category` or `prerequisites.commands`