### PR TITLE
[skills/actionbook]feat: declare ACTIONBOOK_API_KEY as optional env var

### DIFF
--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -8,6 +8,12 @@ metadata:
   hermes:
     tags: [browser-automation, web-automation, scraping, e2e-testing]
     requires_toolsets: [terminal]
+required_environment_variables:
+  - name: ACTIONBOOK_API_KEY
+    prompt: "Actionbook API key"
+    help: "Create one at https://actionbook.dev/dashboard — skill works without it, but requests are rate-limited"
+    required_for: "unlimited requests (without a key, public rate limits apply)"
+    optional: true
 ---
 
 ## When to Use This Skill


### PR DESCRIPTION
## Summary

Declares `ACTIONBOOK_API_KEY` in `skills/actionbook/SKILL.md` as an **optional** Hermes environment variable. Hermes prompts for the key on first load but users can skip — the skill still installs and runs (just rate-limited).

## Why

- Follows the Hermes `optional: true` pattern introduced in [NousResearch/hermes-agent#9355](https://github.com/NousResearch/hermes-agent/pull/9355) for skills with graceful rate-limit fallback. Direct precedent: fitness-nutrition's `USDA_API_KEY` ↔ DEMO_KEY pair.
- Code path verified at `tools/skills_tool.py:248` in `NousResearch/hermes-agent` — the `optional` field is parsed and honored.
- Without this declaration, Hermes users have no surfaced upgrade path from rate-limited to unlimited; they have to hunt through docs to learn that a key exists.

## Changes

- `skills/actionbook/SKILL.md` — add top-level `required_environment_variables` block with a single entry: `ACTIONBOOK_API_KEY`, `optional: true`, `required_for: "unlimited requests"`.
- No behavior change for non-Hermes users. The actionbook CLI's precedence (CLI flag > `ACTIONBOOK_API_KEY` env var > `~/.actionbook/config.toml`) is unchanged — Hermes simply supplies the env var when a user chooses to store the key there.

## Test plan

- [ ] Load the skill in a local Hermes install — confirm the setup prompt appears on first load with the help text from the new entry
- [ ] Skip the prompt — confirm the skill installs and `actionbook browser start` works (rate-limited)
- [ ] Provide the key — confirm the skill installs and the key is stored in `~/.hermes/.env`
- [ ] Ensure `actionbook setup`-configured key in `~/.actionbook/config.toml` is still used when `ACTIONBOOK_API_KEY` is unset
