### PR TITLE
feat(extension): restore extension install/uninstall commands

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -34,8 +34,11 @@ toml = "0.8"
 # Error handling
 thiserror = "2"
 
-# HTTP (for Chrome CDP discovery endpoints)
+# HTTP (for Chrome CDP discovery endpoints and extension downloads)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
+# Zip extraction (for extension install)
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Base64 (screenshot/PDF decoding)
 base64 = "0.22"

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -34,11 +34,8 @@ toml = "0.8"
 # Error handling
 thiserror = "2"
 
-# HTTP (for Chrome CDP discovery endpoints and extension downloads)
+# HTTP (for Chrome CDP discovery endpoints)
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-
-# Zip extraction (for extension install)
-zip = { version = "2", default-features = false, features = ["deflate"] }
 
 # Base64 (screenshot/PDF decoding)
 base64 = "0.22"

--- a/packages/cli/src/action.rs
+++ b/packages/cli/src/action.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::browser::{cookies, interaction, navigation, observation, session, storage, tab, wait};
+use crate::extension;
 
 /// CLI → Daemon action protocol. Each variant wraps the command's Cmd type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,6 +70,9 @@ pub enum Action {
     WaitNetworkIdle(wait::network_idle::Cmd),
     WaitCondition(wait::condition::Cmd),
 
+    // ── Extension ──────────────────────────────────────────────
+    ExtensionStatus(extension::status::Cmd),
+
     // ── Interaction ────────────────────────────────────────────
     Eval(interaction::eval::Cmd),
     Click(interaction::click::Cmd),
@@ -104,6 +108,9 @@ impl Action {
         }
 
         match self {
+            // Extension (no session/tab)
+            Action::ExtensionStatus(_) => "-".into(),
+
             // Session-level (no tab)
             Action::StartSession(_) | Action::ListSessions(_) => "-".into(),
             Action::SessionStatus(c) => s_only!(c),
@@ -187,6 +194,7 @@ impl Action {
     /// Normalized command name for the JSON envelope.
     pub fn command_name(&self) -> &str {
         match self {
+            Action::ExtensionStatus(_) => extension::status::COMMAND_NAME,
             Action::StartSession(_) => session::start::COMMAND_NAME,
             Action::ListSessions(_) => session::list::COMMAND_NAME,
             Action::SessionStatus(_) => session::status::COMMAND_NAME,

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -79,6 +79,11 @@ pub enum Commands {
         #[command(subcommand)]
         command: DaemonCommands,
     },
+    /// Manage the Actionbook browser extension
+    Extension {
+        #[command(subcommand)]
+        command: ExtensionCommands,
+    },
     /// Interactive configuration wizard
     Setup(setup::Cmd),
     /// Show help
@@ -98,6 +103,28 @@ pub enum DaemonCommands {
     /// after the holding process has been freed) without manually finding
     /// the daemon pid.
     Restart,
+}
+
+#[derive(Subcommand, Debug)]
+#[command(disable_help_subcommand = true)]
+pub enum ExtensionCommands {
+    /// Show extension status (bridge + connection)
+    Status,
+    /// Ping the extension bridge and measure RTT
+    Ping,
+    /// Show extension install path and installed status
+    Path,
+    /// Install the Actionbook extension
+    Install(ExtensionInstallArgs),
+    /// Uninstall the Actionbook extension
+    Uninstall,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct ExtensionInstallArgs {
+    /// Force overwrite of an existing installation
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Unimplemented tab-level command args.

--- a/packages/cli/src/daemon/router.rs
+++ b/packages/cli/src/daemon/router.rs
@@ -1,6 +1,7 @@
 use crate::action::Action;
 use crate::action_result::ActionResult;
 use crate::browser;
+use crate::extension;
 
 use super::registry::SharedRegistry;
 
@@ -82,5 +83,6 @@ pub async fn route(action: &Action, registry: &SharedRegistry) -> ActionResult {
             browser::interaction::cursor_position::execute(cmd, registry).await
         }
         Action::Scroll(cmd) => browser::interaction::scroll::execute(cmd, registry).await,
+        Action::ExtensionStatus(cmd) => extension::status::execute_daemon(cmd, registry).await,
     }
 }

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -1,0 +1,106 @@
+use std::path::{Path, PathBuf};
+
+use serde_json::json;
+
+use crate::action_result::ActionResult;
+use crate::config;
+
+pub const COMMAND_NAME_PATH: &str = "extension path";
+pub const COMMAND_NAME_INSTALL: &str = "extension install";
+pub const COMMAND_NAME_UNINSTALL: &str = "extension uninstall";
+
+fn extension_dir() -> PathBuf {
+    config::actionbook_home().join("extension")
+}
+
+fn read_version(dir: &Path) -> Option<String> {
+    let bytes = std::fs::read(dir.join("manifest.json")).ok()?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    v["version"].as_str().map(String::from)
+}
+
+pub fn execute_path() -> ActionResult {
+    let dir = extension_dir();
+    let installed = dir.join("manifest.json").exists();
+    let version = if installed { read_version(&dir) } else { None };
+    ActionResult::ok(json!({
+        "path": dir.to_string_lossy(),
+        "installed": installed,
+        "version": version,
+    }))
+}
+
+pub fn execute_install(force: bool) -> ActionResult {
+    let dir = extension_dir();
+
+    if dir.exists() && !force {
+        return ActionResult::fatal(
+            "ALREADY_INSTALLED",
+            format!(
+                "extension already installed at '{}'; use --force to overwrite",
+                dir.display()
+            ),
+        );
+    }
+
+    // Test seam: copy from local source directory
+    if let Ok(src) = std::env::var("ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR") {
+        return copy_from_dir(Path::new(&src), &dir);
+    }
+
+    ActionResult::fatal(
+        "NOT_IMPLEMENTED",
+        "GitHub Releases download is not yet implemented; use ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR for local install",
+    )
+}
+
+fn copy_from_dir(src: &Path, dst: &Path) -> ActionResult {
+    if let Err(e) = std::fs::remove_dir_all(dst)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to remove existing install: {e}"),
+        );
+    }
+    if let Err(e) = std::fs::create_dir_all(dst) {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to create install directory: {e}"),
+        );
+    }
+    if let Err(e) = copy_dir_all(src, dst) {
+        return ActionResult::fatal("IO_ERROR", format!("failed to copy extension files: {e}"));
+    }
+    let version = read_version(dst).unwrap_or_default();
+    ActionResult::ok(json!({
+        "path": dst.to_string_lossy(),
+        "version": version,
+    }))
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let dest = dst.join(entry.file_name());
+        if file_type.is_dir() {
+            std::fs::create_dir_all(&dest)?;
+            copy_dir_all(&entry.path(), &dest)?;
+        } else {
+            std::fs::copy(entry.path(), dest)?;
+        }
+    }
+    Ok(())
+}
+
+pub fn execute_uninstall() -> ActionResult {
+    let dir = extension_dir();
+    if !dir.exists() {
+        return ActionResult::fatal("NOT_INSTALLED", "extension is not installed");
+    }
+    if let Err(e) = std::fs::remove_dir_all(&dir) {
+        return ActionResult::fatal("IO_ERROR", format!("failed to remove extension: {e}"));
+    }
+    ActionResult::ok(json!({ "uninstalled": true }))
+}

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -1,3 +1,4 @@
+use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
@@ -8,6 +9,8 @@ use crate::config;
 pub const COMMAND_NAME_PATH: &str = "extension path";
 pub const COMMAND_NAME_INSTALL: &str = "extension install";
 pub const COMMAND_NAME_UNINSTALL: &str = "extension uninstall";
+
+const GITHUB_REPO: &str = "actionbook/actionbook";
 
 fn extension_dir() -> PathBuf {
     config::actionbook_home().join("extension")
@@ -30,7 +33,7 @@ pub fn execute_path() -> ActionResult {
     }))
 }
 
-pub fn execute_install(force: bool) -> ActionResult {
+pub async fn execute_install(force: bool) -> ActionResult {
     let dir = extension_dir();
 
     if dir.exists() && !force {
@@ -48,10 +51,8 @@ pub fn execute_install(force: bool) -> ActionResult {
         return copy_from_dir(Path::new(&src), &dir);
     }
 
-    ActionResult::fatal(
-        "NOT_IMPLEMENTED",
-        "GitHub Releases download is not yet implemented; use ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR for local install",
-    )
+    // Production: download from GitHub Releases
+    download_from_github(&dir).await
 }
 
 fn copy_from_dir(src: &Path, dst: &Path) -> ActionResult {
@@ -92,6 +93,177 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+async fn download_from_github(dst: &Path) -> ActionResult {
+    let client = match reqwest::Client::builder()
+        .user_agent(format!("actionbook-cli/{}", crate::BUILD_VERSION))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return ActionResult::fatal(
+                "INTERNAL_ERROR",
+                format!("failed to build HTTP client: {e}"),
+            );
+        }
+    };
+
+    // Query the latest release for the extension asset
+    let api_url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
+    let release: serde_json::Value = match client
+        .get(&api_url)
+        .header("Accept", "application/vnd.github+json")
+        .send()
+        .await
+    {
+        Ok(r) => match r.json().await {
+            Ok(v) => v,
+            Err(e) => {
+                return ActionResult::fatal(
+                    "DOWNLOAD_ERROR",
+                    format!("failed to parse GitHub release response: {e}"),
+                );
+            }
+        },
+        Err(e) => {
+            return ActionResult::fatal(
+                "DOWNLOAD_ERROR",
+                format!("failed to fetch latest release from GitHub: {e}"),
+            );
+        }
+    };
+
+    // Find the extension zip asset
+    let download_url = match release["assets"].as_array().and_then(|assets| {
+        assets.iter().find(|a| {
+            a["name"]
+                .as_str()
+                .map(|n| n.starts_with("actionbook-extension-") && n.ends_with(".zip"))
+                .unwrap_or(false)
+        })
+    }) {
+        Some(asset) => match asset["browser_download_url"].as_str() {
+            Some(u) => u.to_string(),
+            None => {
+                return ActionResult::fatal(
+                    "DOWNLOAD_ERROR",
+                    "extension asset has no download URL",
+                );
+            }
+        },
+        None => {
+            return ActionResult::fatal(
+                "NOT_AVAILABLE",
+                "extension zip not found in the latest GitHub release; \
+                 install manually by extracting to ~/.actionbook/extension/",
+            );
+        }
+    };
+
+    // Download the zip bytes
+    let zip_bytes = match client.get(&download_url).send().await {
+        Ok(r) => match r.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                return ActionResult::fatal(
+                    "DOWNLOAD_ERROR",
+                    format!("failed to read extension zip: {e}"),
+                );
+            }
+        },
+        Err(e) => {
+            return ActionResult::fatal(
+                "DOWNLOAD_ERROR",
+                format!("failed to download extension: {e}"),
+            );
+        }
+    };
+
+    // Remove existing install and recreate directory
+    if let Err(e) = std::fs::remove_dir_all(dst)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to remove existing install: {e}"),
+        );
+    }
+    if let Err(e) = std::fs::create_dir_all(dst) {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to create install directory: {e}"),
+        );
+    }
+
+    // Extract zip
+    let cursor = Cursor::new(zip_bytes);
+    let mut archive = match zip::ZipArchive::new(cursor) {
+        Ok(a) => a,
+        Err(e) => {
+            return ActionResult::fatal(
+                "EXTRACT_ERROR",
+                format!("failed to open extension zip: {e}"),
+            );
+        }
+    };
+
+    for i in 0..archive.len() {
+        let mut file = match archive.by_index(i) {
+            Ok(f) => f,
+            Err(e) => {
+                return ActionResult::fatal(
+                    "EXTRACT_ERROR",
+                    format!("failed to read zip entry {i}: {e}"),
+                );
+            }
+        };
+
+        // Sanitize path: skip entries with absolute or traversal paths
+        let out_path = match file.enclosed_name() {
+            Some(p) => dst.join(p),
+            None => continue,
+        };
+
+        if file.is_dir() {
+            if let Err(e) = std::fs::create_dir_all(&out_path) {
+                return ActionResult::fatal(
+                    "EXTRACT_ERROR",
+                    format!("failed to create directory '{}': {e}", out_path.display()),
+                );
+            }
+        } else {
+            if let Some(parent) = out_path.parent() {
+                if let Err(e) = std::fs::create_dir_all(parent) {
+                    return ActionResult::fatal(
+                        "EXTRACT_ERROR",
+                        format!("failed to create parent directory: {e}"),
+                    );
+                }
+            }
+            let mut out_file = match std::fs::File::create(&out_path) {
+                Ok(f) => f,
+                Err(e) => {
+                    return ActionResult::fatal(
+                        "EXTRACT_ERROR",
+                        format!("failed to create '{}': {e}", out_path.display()),
+                    );
+                }
+            };
+            if let Err(e) = std::io::copy(&mut file, &mut out_file) {
+                return ActionResult::fatal(
+                    "EXTRACT_ERROR",
+                    format!("failed to extract '{}': {e}", out_path.display()),
+                );
+            }
+        }
+    }
+
+    let version = read_version(dst).unwrap_or_default();
+    ActionResult::ok(json!({
+        "path": dst.to_string_lossy(),
+        "version": version,
+    }))
 }
 
 pub fn execute_uninstall() -> ActionResult {

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -1,4 +1,3 @@
-use std::io::Cursor;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
@@ -10,7 +9,75 @@ pub const COMMAND_NAME_PATH: &str = "extension path";
 pub const COMMAND_NAME_INSTALL: &str = "extension install";
 pub const COMMAND_NAME_UNINSTALL: &str = "extension uninstall";
 
-const GITHUB_REPO: &str = "actionbook/actionbook";
+/// Extension files bundled at compile time from packages/actionbook-extension/.
+///
+/// Using include_bytes! ties the installed extension to the CLI version it was
+/// built from — no network dependency, always consistent.
+static BUNDLED_EXTENSION: &[(&str, &[u8])] = &[
+    (
+        "manifest.json",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/manifest.json"
+        )),
+    ),
+    (
+        "background.js",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/background.js"
+        )),
+    ),
+    (
+        "popup.html",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/popup.html"
+        )),
+    ),
+    (
+        "popup.js",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/popup.js"
+        )),
+    ),
+    (
+        "offscreen.html",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/offscreen.html"
+        )),
+    ),
+    (
+        "offscreen.js",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/offscreen.js"
+        )),
+    ),
+    (
+        "icons/icon-16.png",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/icons/icon-16.png"
+        )),
+    ),
+    (
+        "icons/icon-48.png",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/icons/icon-48.png"
+        )),
+    ),
+    (
+        "icons/icon-128.png",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/icons/icon-128.png"
+        )),
+    ),
+];
 
 fn extension_dir() -> PathBuf {
     config::actionbook_home().join("extension")
@@ -33,7 +100,7 @@ pub fn execute_path() -> ActionResult {
     }))
 }
 
-pub async fn execute_install(force: bool) -> ActionResult {
+pub fn execute_install(force: bool) -> ActionResult {
     let dir = extension_dir();
 
     if dir.exists() && !force {
@@ -46,13 +113,54 @@ pub async fn execute_install(force: bool) -> ActionResult {
         );
     }
 
-    // Test seam: copy from local source directory
+    // Test seam: copy from local source directory (used in e2e tests)
     if let Ok(src) = std::env::var("ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR") {
         return copy_from_dir(Path::new(&src), &dir);
     }
 
-    // Production: download from GitHub Releases
-    download_from_github(&dir).await
+    // Production: extract bundled extension files
+    extract_bundled(&dir)
+}
+
+fn extract_bundled(dst: &Path) -> ActionResult {
+    if let Err(e) = std::fs::remove_dir_all(dst)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to remove existing install: {e}"),
+        );
+    }
+    if let Err(e) = std::fs::create_dir_all(dst) {
+        return ActionResult::fatal(
+            "IO_ERROR",
+            format!("failed to create install directory: {e}"),
+        );
+    }
+
+    for (relative_path, bytes) in BUNDLED_EXTENSION {
+        let out = dst.join(relative_path);
+        if let Some(parent) = out.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                return ActionResult::fatal(
+                    "IO_ERROR",
+                    format!("failed to create directory '{}': {e}", parent.display()),
+                );
+            }
+        }
+        if let Err(e) = std::fs::write(&out, bytes) {
+            return ActionResult::fatal(
+                "IO_ERROR",
+                format!("failed to write '{}': {e}", out.display()),
+            );
+        }
+    }
+
+    let version = read_version(dst).unwrap_or_default();
+    ActionResult::ok(json!({
+        "path": dst.to_string_lossy(),
+        "version": version,
+    }))
 }
 
 fn copy_from_dir(src: &Path, dst: &Path) -> ActionResult {
@@ -93,177 +201,6 @@ fn copy_dir_all(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
-}
-
-async fn download_from_github(dst: &Path) -> ActionResult {
-    let client = match reqwest::Client::builder()
-        .user_agent(format!("actionbook-cli/{}", crate::BUILD_VERSION))
-        .build()
-    {
-        Ok(c) => c,
-        Err(e) => {
-            return ActionResult::fatal(
-                "INTERNAL_ERROR",
-                format!("failed to build HTTP client: {e}"),
-            );
-        }
-    };
-
-    // Query the latest release for the extension asset
-    let api_url = format!("https://api.github.com/repos/{GITHUB_REPO}/releases/latest");
-    let release: serde_json::Value = match client
-        .get(&api_url)
-        .header("Accept", "application/vnd.github+json")
-        .send()
-        .await
-    {
-        Ok(r) => match r.json().await {
-            Ok(v) => v,
-            Err(e) => {
-                return ActionResult::fatal(
-                    "DOWNLOAD_ERROR",
-                    format!("failed to parse GitHub release response: {e}"),
-                );
-            }
-        },
-        Err(e) => {
-            return ActionResult::fatal(
-                "DOWNLOAD_ERROR",
-                format!("failed to fetch latest release from GitHub: {e}"),
-            );
-        }
-    };
-
-    // Find the extension zip asset
-    let download_url = match release["assets"].as_array().and_then(|assets| {
-        assets.iter().find(|a| {
-            a["name"]
-                .as_str()
-                .map(|n| n.starts_with("actionbook-extension-") && n.ends_with(".zip"))
-                .unwrap_or(false)
-        })
-    }) {
-        Some(asset) => match asset["browser_download_url"].as_str() {
-            Some(u) => u.to_string(),
-            None => {
-                return ActionResult::fatal(
-                    "DOWNLOAD_ERROR",
-                    "extension asset has no download URL",
-                );
-            }
-        },
-        None => {
-            return ActionResult::fatal(
-                "NOT_AVAILABLE",
-                "extension zip not found in the latest GitHub release; \
-                 install manually by extracting to ~/.actionbook/extension/",
-            );
-        }
-    };
-
-    // Download the zip bytes
-    let zip_bytes = match client.get(&download_url).send().await {
-        Ok(r) => match r.bytes().await {
-            Ok(b) => b,
-            Err(e) => {
-                return ActionResult::fatal(
-                    "DOWNLOAD_ERROR",
-                    format!("failed to read extension zip: {e}"),
-                );
-            }
-        },
-        Err(e) => {
-            return ActionResult::fatal(
-                "DOWNLOAD_ERROR",
-                format!("failed to download extension: {e}"),
-            );
-        }
-    };
-
-    // Remove existing install and recreate directory
-    if let Err(e) = std::fs::remove_dir_all(dst)
-        && e.kind() != std::io::ErrorKind::NotFound
-    {
-        return ActionResult::fatal(
-            "IO_ERROR",
-            format!("failed to remove existing install: {e}"),
-        );
-    }
-    if let Err(e) = std::fs::create_dir_all(dst) {
-        return ActionResult::fatal(
-            "IO_ERROR",
-            format!("failed to create install directory: {e}"),
-        );
-    }
-
-    // Extract zip
-    let cursor = Cursor::new(zip_bytes);
-    let mut archive = match zip::ZipArchive::new(cursor) {
-        Ok(a) => a,
-        Err(e) => {
-            return ActionResult::fatal(
-                "EXTRACT_ERROR",
-                format!("failed to open extension zip: {e}"),
-            );
-        }
-    };
-
-    for i in 0..archive.len() {
-        let mut file = match archive.by_index(i) {
-            Ok(f) => f,
-            Err(e) => {
-                return ActionResult::fatal(
-                    "EXTRACT_ERROR",
-                    format!("failed to read zip entry {i}: {e}"),
-                );
-            }
-        };
-
-        // Sanitize path: skip entries with absolute or traversal paths
-        let out_path = match file.enclosed_name() {
-            Some(p) => dst.join(p),
-            None => continue,
-        };
-
-        if file.is_dir() {
-            if let Err(e) = std::fs::create_dir_all(&out_path) {
-                return ActionResult::fatal(
-                    "EXTRACT_ERROR",
-                    format!("failed to create directory '{}': {e}", out_path.display()),
-                );
-            }
-        } else {
-            if let Some(parent) = out_path.parent() {
-                if let Err(e) = std::fs::create_dir_all(parent) {
-                    return ActionResult::fatal(
-                        "EXTRACT_ERROR",
-                        format!("failed to create parent directory: {e}"),
-                    );
-                }
-            }
-            let mut out_file = match std::fs::File::create(&out_path) {
-                Ok(f) => f,
-                Err(e) => {
-                    return ActionResult::fatal(
-                        "EXTRACT_ERROR",
-                        format!("failed to create '{}': {e}", out_path.display()),
-                    );
-                }
-            };
-            if let Err(e) = std::io::copy(&mut file, &mut out_file) {
-                return ActionResult::fatal(
-                    "EXTRACT_ERROR",
-                    format!("failed to extract '{}': {e}", out_path.display()),
-                );
-            }
-        }
-    }
-
-    let version = read_version(dst).unwrap_or_default();
-    ActionResult::ok(json!({
-        "path": dst.to_string_lossy(),
-        "version": version,
-    }))
 }
 
 pub fn execute_uninstall() -> ActionResult {

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -140,13 +140,13 @@ fn extract_bundled(dst: &Path) -> ActionResult {
 
     for (relative_path, bytes) in BUNDLED_EXTENSION {
         let out = dst.join(relative_path);
-        if let Some(parent) = out.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                return ActionResult::fatal(
-                    "IO_ERROR",
-                    format!("failed to create directory '{}': {e}", parent.display()),
-                );
-            }
+        if let Some(parent) = out.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            return ActionResult::fatal(
+                "IO_ERROR",
+                format!("failed to create directory '{}': {e}", parent.display()),
+            );
         }
         if let Err(e) = std::fs::write(&out, bytes) {
             return ActionResult::fatal(

--- a/packages/cli/src/extension/mod.rs
+++ b/packages/cli/src/extension/mod.rs
@@ -1,0 +1,3 @@
+pub mod installer;
+pub mod ping;
+pub mod status;

--- a/packages/cli/src/extension/ping.rs
+++ b/packages/cli/src/extension/ping.rs
@@ -1,0 +1,30 @@
+use std::time::Instant;
+
+use serde_json::json;
+
+use crate::action_result::ActionResult;
+use crate::daemon::bridge::BRIDGE_PORT;
+
+pub const COMMAND_NAME: &str = "extension ping";
+
+pub async fn execute() -> ActionResult {
+    let port: u16 = std::env::var("ACTIONBOOK_EXTENSION_BRIDGE_PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(BRIDGE_PORT);
+
+    let start = Instant::now();
+    match tokio::net::TcpStream::connect(("127.0.0.1", port)).await {
+        Ok(_) => {
+            let rtt_ms = start.elapsed().as_millis() as u64;
+            ActionResult::ok(json!({
+                "bridge": "listening",
+                "rtt_ms": rtt_ms,
+            }))
+        }
+        Err(_) => ActionResult::ok(json!({
+            "bridge": "not_listening",
+            "rtt_ms": serde_json::Value::Null,
+        })),
+    }
+}

--- a/packages/cli/src/extension/status.rs
+++ b/packages/cli/src/extension/status.rs
@@ -1,0 +1,38 @@
+use clap::Args;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::action_result::ActionResult;
+use crate::daemon::bridge::BridgeListenerStatus;
+use crate::daemon::registry::SharedRegistry;
+
+/// Query extension bridge status.
+#[derive(Args, Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Cmd {}
+
+pub const COMMAND_NAME: &str = "extension status";
+
+pub async fn execute_daemon(_cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    let bridge_arc = {
+        let reg = registry.lock().await;
+        reg.bridge_state().cloned()
+    };
+
+    let (bridge, extension_connected) = match bridge_arc {
+        Some(state) => {
+            let state = state.lock().await;
+            let bridge_str = match state.listener_status() {
+                BridgeListenerStatus::Listening => "listening",
+                BridgeListenerStatus::Failed => "failed",
+                BridgeListenerStatus::Binding => "not_listening",
+            };
+            (bridge_str, state.is_extension_connected())
+        }
+        None => ("not_listening", false),
+    };
+
+    ActionResult::ok(json!({
+        "bridge": bridge,
+        "extension_connected": extension_connected,
+    }))
+}

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -9,6 +9,7 @@ pub mod commands;
 pub mod config;
 pub mod daemon;
 pub mod error;
+pub mod extension;
 pub mod output;
 pub mod setup;
 pub mod types;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -4,8 +4,9 @@ use std::time::{Duration, Instant};
 use clap::Parser;
 use serde_json::json;
 
+use actionbook_cli::action::Action;
 use actionbook_cli::action_result::ActionResult;
-use actionbook_cli::cli::{BrowserCommands, Cli, Commands, DaemonCommands};
+use actionbook_cli::cli::{BrowserCommands, Cli, Commands, DaemonCommands, ExtensionCommands};
 use actionbook_cli::config;
 use actionbook_cli::output::{self, JsonEnvelope};
 use actionbook_cli::utils::client::DaemonClient;
@@ -168,6 +169,9 @@ async fn run(mut cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         Commands::Daemon { command } => {
             handle_daemon(command, json_mode, timeout_ms).await?;
+        }
+        Commands::Extension { command } => {
+            handle_extension(command, json_mode).await?;
         }
         Commands::Setup(cmd) => {
             actionbook_cli::setup::execute(&cmd, json_mode).await?;
@@ -370,6 +374,63 @@ async fn handle_daemon(
             }
         }
     }
+    Ok(())
+}
+
+async fn handle_extension(
+    command: ExtensionCommands,
+    json_mode: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = Instant::now();
+
+    let (command_name, result) = match command {
+        ExtensionCommands::Status => {
+            let action = Action::ExtensionStatus(actionbook_cli::extension::status::Cmd::default());
+            let mut client = DaemonClient::connect().await?;
+            let result = client.send_action(&action).await?;
+            (actionbook_cli::extension::status::COMMAND_NAME, result)
+        }
+        ExtensionCommands::Ping => {
+            let result = actionbook_cli::extension::ping::execute().await;
+            (actionbook_cli::extension::ping::COMMAND_NAME, result)
+        }
+        ExtensionCommands::Path => {
+            let result = actionbook_cli::extension::installer::execute_path();
+            (
+                actionbook_cli::extension::installer::COMMAND_NAME_PATH,
+                result,
+            )
+        }
+        ExtensionCommands::Install(args) => {
+            let result = actionbook_cli::extension::installer::execute_install(args.force);
+            (
+                actionbook_cli::extension::installer::COMMAND_NAME_INSTALL,
+                result,
+            )
+        }
+        ExtensionCommands::Uninstall => {
+            let result = actionbook_cli::extension::installer::execute_uninstall();
+            (
+                actionbook_cli::extension::installer::COMMAND_NAME_UNINSTALL,
+                result,
+            )
+        }
+    };
+
+    let duration = start.elapsed();
+
+    if json_mode {
+        let envelope = JsonEnvelope::from_result(command_name, None, &result, duration);
+        println!("{}", serde_json::to_string(&envelope)?);
+    } else {
+        let text = output::format_text(command_name, &None, &result);
+        println!("{text}");
+    }
+
+    if !result.is_ok() {
+        flush_and_exit(1);
+    }
+
     Ok(())
 }
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -402,7 +402,7 @@ async fn handle_extension(
             )
         }
         ExtensionCommands::Install(args) => {
-            let result = actionbook_cli::extension::installer::execute_install(args.force);
+            let result = actionbook_cli::extension::installer::execute_install(args.force).await;
             (
                 actionbook_cli::extension::installer::COMMAND_NAME_INSTALL,
                 result,

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -402,7 +402,7 @@ async fn handle_extension(
             )
         }
         ExtensionCommands::Install(args) => {
-            let result = actionbook_cli::extension::installer::execute_install(args.force).await;
+            let result = actionbook_cli::extension::installer::execute_install(args.force);
             (
                 actionbook_cli::extension::installer::COMMAND_NAME_INSTALL,
                 result,

--- a/packages/cli/tests/e2e/extension.rs
+++ b/packages/cli/tests/e2e/extension.rs
@@ -1,0 +1,166 @@
+//! E2E tests for `actionbook extension` commands.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::harness::{SoloEnv, assert_success, parse_json, skip};
+
+fn extension_dir(env: &SoloEnv) -> PathBuf {
+    Path::new(&env.actionbook_home).join("extension")
+}
+
+fn extension_fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../actionbook-extension")
+        .canonicalize()
+        .expect("extension fixture dir")
+}
+
+fn extension_fixture_version() -> String {
+    let manifest_path = extension_fixture_dir().join("manifest.json");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&fs::read(&manifest_path).expect("read extension fixture manifest"))
+            .expect("parse extension fixture manifest");
+    manifest["version"]
+        .as_str()
+        .expect("extension fixture manifest version")
+        .to_string()
+}
+
+fn reserve_unused_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .expect("bind ephemeral port")
+        .local_addr()
+        .expect("local addr")
+        .port()
+}
+
+#[test]
+fn extension_path_outputs_path_field() {
+    if skip() {
+        return;
+    }
+
+    let env = SoloEnv::new();
+    let out = env.headless_json(&["extension", "path"], 10);
+    assert_success(&out, "extension path");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "extension path");
+    assert_eq!(
+        v["data"]["path"],
+        extension_dir(&env).to_string_lossy().to_string()
+    );
+    assert_eq!(v["data"]["installed"], false);
+    assert!(v["data"]["version"].is_null());
+}
+
+#[test]
+fn extension_install_force_and_uninstall_round_trip() {
+    if skip() {
+        return;
+    }
+
+    let env = SoloEnv::new();
+    let expected_path = extension_dir(&env);
+    let expected_path_str = expected_path.to_string_lossy().to_string();
+    let expected_version = extension_fixture_version();
+    let fixture_dir = extension_fixture_dir();
+    let fixture_dir_str = fixture_dir.to_string_lossy().to_string();
+
+    let install = env.headless_json_with_env(
+        &["extension", "install", "--force"],
+        &[(
+            "ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR",
+            fixture_dir_str.as_str(),
+        )],
+        30,
+    );
+    assert_success(&install, "extension install --force");
+    let install_v = parse_json(&install);
+    assert_eq!(install_v["command"], "extension install");
+    assert_eq!(install_v["data"]["path"], expected_path_str);
+    assert_eq!(install_v["data"]["version"], expected_version);
+    assert!(
+        expected_path.join("manifest.json").exists(),
+        "installed extension should include manifest.json"
+    );
+
+    let path = env.headless_json(&["extension", "path"], 10);
+    assert_success(&path, "extension path after install");
+    let path_v = parse_json(&path);
+    assert_eq!(path_v["data"]["path"], expected_path_str);
+    assert_eq!(path_v["data"]["installed"], true);
+    assert_eq!(path_v["data"]["version"], expected_version);
+
+    let uninstall = env.headless_json(&["extension", "uninstall"], 10);
+    assert_success(&uninstall, "extension uninstall");
+    let uninstall_v = parse_json(&uninstall);
+    assert_eq!(uninstall_v["command"], "extension uninstall");
+    assert_eq!(uninstall_v["data"]["uninstalled"], true);
+    assert!(
+        !expected_path.exists(),
+        "extension directory should be removed after uninstall"
+    );
+}
+
+#[test]
+fn extension_status_with_running_daemon_does_not_crash() {
+    if skip() {
+        return;
+    }
+
+    let env = SoloEnv::new();
+    let start = env.headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--open-url",
+            "about:blank",
+        ],
+        30,
+    );
+    assert_success(&start, "warm daemon for extension status");
+
+    let out = env.headless_json(&["extension", "status"], 10);
+    assert_success(&out, "extension status with daemon running");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "extension status");
+    let bridge = v["data"]["bridge"].as_str().expect("bridge state string");
+    assert!(
+        matches!(bridge, "listening" | "not_listening" | "failed"),
+        "unexpected bridge state: {bridge}"
+    );
+    assert!(
+        v["data"]["extension_connected"].is_boolean(),
+        "extension_connected must be boolean"
+    );
+}
+
+#[test]
+fn extension_ping_returns_bridge_not_listening() {
+    if skip() {
+        return;
+    }
+
+    let env = SoloEnv::new();
+    let port = reserve_unused_port().to_string();
+    let out = env.headless_json_with_env(
+        &["extension", "ping"],
+        &[("ACTIONBOOK_EXTENSION_BRIDGE_PORT", port.as_str())],
+        10,
+    );
+    assert_success(&out, "extension ping on unused bridge port");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "extension ping");
+    assert_eq!(v["data"]["bridge"], "not_listening");
+    assert!(
+        v["data"]["rtt_ms"].is_null() || v["data"]["rtt_ms"].is_number(),
+        "rtt_ms must be null or number when bridge is not listening"
+    );
+}

--- a/packages/cli/tests/e2e/main.rs
+++ b/packages/cli/tests/e2e/main.rs
@@ -17,6 +17,7 @@ mod cookies;
 mod describe_state;
 mod element_details;
 mod element_read;
+mod extension;
 mod harness;
 mod iframe;
 mod inspect_point;


### PR DESCRIPTION
## Summary

- Restores `actionbook extension install` and `actionbook extension uninstall` commands
- Install path: `~/.actionbook/extension/` (no legacy migration)
- Test seam: `ACTIONBOOK_EXTENSION_TEST_SOURCE_DIR` env var bypasses GitHub Releases download for deterministic e2e testing
- Includes supporting utilities: `extension path`, `extension status` (daemon IPC), `extension ping` (direct TCP)

## Test plan

- [x] `extension path` returns path / installed=false when not installed
- [x] `extension install --force` + `extension uninstall` round-trip (copies from local fixture dir)
- [x] `extension status` returns bridge state without crashing when daemon is running
- [x] `extension ping` returns `bridge=not_listening` on unused port
- [x] All 4 e2e tests pass: `cargo test --test e2e extension_`
- [x] clippy clean, cargo fmt clean, 350+ unit tests pass