### PR TITLE
[packages/cli]feat(extension): protocol 0.3.0 — concurrent multi-tab + explicit tabId

### DIFF
--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -530,7 +530,8 @@ async function handleExtensionCommand(id, method, params) {
 
     case "Extension.detachTab": {
       // Without explicit tabId, detach ALL attached tabs (used during
-      // session close). With tabId, detach just that one.
+      // session close). With tabId, detach just that one. Does NOT close
+      // the tab itself — see Extension.closeTabs for that.
       const targets = (typeof params.tabId === "number")
         ? [params.tabId]
         : Array.from(attachedTabs);
@@ -542,6 +543,37 @@ async function handleExtensionCommand(id, method, params) {
       }
       broadcastState();
       return { id, result: { detached: true, detachedTabIds: targets } };
+    }
+
+    case "Extension.closeTabs": {
+      // Detach + chrome.tabs.remove for the given tabIds (or all attached
+      // tabs if none specified). Used by `actionbook browser close` so a
+      // session that opened tabs cleans them up — symmetric with how
+      // local mode kills the chrome process at session close.
+      const targets = (Array.isArray(params.tabIds) && params.tabIds.length)
+        ? params.tabIds.filter((t) => typeof t === "number")
+        : Array.from(attachedTabs);
+      // Detach debugger first (chrome.tabs.remove on an attached tab works
+      // but the debugger detach event would arrive after, racing with our
+      // bookkeeping).
+      for (const t of targets) {
+        if (attachedTabs.has(t)) {
+          try { await chrome.debugger.detach({ tabId: t }); } catch (_) {}
+          attachedTabs.delete(t);
+        }
+      }
+      const closed = [];
+      const failed = [];
+      for (const t of targets) {
+        try {
+          await chrome.tabs.remove(t);
+          closed.push(t);
+        } catch (err) {
+          failed.push({ tabId: t, error: err && err.message ? err.message : String(err) });
+        }
+      }
+      broadcastState();
+      return { id, result: { closed, failed } };
     }
 
     case "Extension.status": {

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -14,22 +14,40 @@ const L3_CONFIRM_TIMEOUT_MS = 30000;
 const CDP_ALLOWLIST = {
   // L1 - Read only (auto-approved)
   'Page.captureScreenshot': 'L1',
+  'Page.getLayoutMetrics': 'L1',
+  'Page.getNavigationHistory': 'L1',
   'DOM.getDocument': 'L1',
   'DOM.querySelector': 'L1',
   'DOM.querySelectorAll': 'L1',
   'DOM.getOuterHTML': 'L1',
   'DOM.enable': 'L1',
+  'DOM.describeNode': 'L1',
+  'DOM.getBoxModel': 'L1',
+  'DOM.getFrameOwner': 'L1',
+  'DOM.getNodeForLocation': 'L1',
+  'DOM.requestNode': 'L1',
+  'DOM.resolveNode': 'L1',
   'Accessibility.enable': 'L1',
   'Accessibility.getFullAXTree': 'L1',
+  'Accessibility.getPartialAXTree': 'L1',
+  'Accessibility.queryAXTree': 'L1',
   'Network.getCookies': 'L1',
+  'Network.getAllCookies': 'L1',
+  'Network.getResponseBody': 'L1',
 
   // L2 - Page modification (auto-approved with logging)
   'Runtime.evaluate': 'L2',
+  'Runtime.callFunctionOn': 'L2',
+  'Page.enable': 'L2',
   'Page.navigate': 'L2',
+  'Page.navigateToHistoryEntry': 'L2',
   'Page.reload': 'L2',
   'Input.dispatchMouseEvent': 'L2',
   'Input.dispatchKeyEvent': 'L2',
+  'DOM.focus': 'L2',
+  'DOM.setFileInputFiles': 'L2',
   'Emulation.setDeviceMetricsOverride': 'L2',
+  'Emulation.clearDeviceMetricsOverride': 'L2',
   'Page.printToPDF': 'L2',
 
   // L3 - High risk (requires confirmation)
@@ -49,7 +67,12 @@ const SENSITIVE_DOMAIN_PATTERNS = [
 ];
 
 let ws = null;
-let attachedTabId = null;
+// Set<number> of Chrome tab IDs that the extension currently has
+// chrome.debugger attached to. Multiple tabs can be attached concurrently;
+// every CDP command from the CLI must carry its target `tabId` field.
+// The legacy single-attach variable and `Extension.attachActiveTab` have
+// been removed — the CLI always specifies tabId.
+const attachedTabs = new Set();
 let connectionState = "idle"; // idle | pairing_required | connecting | connected | disconnected | failed
 let reconnectDelay = RECONNECT_BASE_MS;
 let reconnectTimer = null;
@@ -142,11 +165,13 @@ async function connect() {
 
   ws.onopen = () => {
     wsOpened = true;
-    // Send hello handshake (tokenless - server validates via origin + extension ID)
+    // Send hello handshake (tokenless - server validates via origin + extension ID).
+    // Protocol 0.3.0 adds root-level `tabId` in every CDP request/event and
+    // supports concurrent multi-tab attach.
     wsSend({
       type: "hello",
       role: "extension",
-      version: "0.2.0",
+      version: "0.3.0",
     });
 
     // Start handshake timeout - if no hello_ack within this window, treat as auth failure
@@ -327,11 +352,14 @@ function scheduleReconnect() {
 // --- CDP Event Forwarding ---
 
 chrome.debugger.onEvent.addListener((source, method, params) => {
-  if (source.tabId === attachedTabId) {
-    // Forward CDP event to bridge (no id field = event, not response)
+  if (typeof source.tabId === "number" && attachedTabs.has(source.tabId)) {
+    // Forward CDP event to bridge (no id field = event, not response).
+    // Include `tabId` so CdpSession can route the event to the right tab
+    // subscriber in extension-mode multi-tab sessions.
     wsSend({
       method: method,
       params: params || {},
+      tabId: source.tabId,
     });
   }
 });
@@ -371,20 +399,31 @@ async function createOrReuseTab(targetUrl) {
 // --- Command Handler ---
 
 async function handleCommand(msg) {
-  const { id, method, params } = msg;
+  const { id, method, params, tabId } = msg;
 
   if (!method) {
     return { id, error: { code: -32600, message: "Missing method" } };
   }
 
   try {
-    // Extension-specific commands (non-CDP)
+    // Extension-specific commands (non-CDP) — tabId lives inside params for
+    // these (e.g. Extension.attachTab{tabId:N}), not at the message root.
     if (method.startsWith("Extension.")) {
       return await handleExtensionCommand(id, method, params || {});
     }
 
-    // CDP commands - forward to chrome.debugger
-    return await handleCdpCommand(id, method, params || {});
+    // CDP commands — every command must specify which tab it targets.
+    // Protocol 0.3.0: root-level `tabId` is required; no implicit "active".
+    if (typeof tabId !== "number") {
+      return {
+        id,
+        error: {
+          code: -32602,
+          message: `Missing required root-level "tabId" for CDP method ${method} (protocol 0.3.0+)`,
+        },
+      };
+    }
+    return await handleCdpCommand(id, method, params || {}, tabId);
   } catch (err) {
     return {
       id,
@@ -416,62 +455,51 @@ async function handleExtensionCommand(id, method, params) {
         return { id, error: { code: -32602, message: "Missing or invalid tabId" } };
       }
 
-      // Verify tab exists
+      // Verify tab exists, capture metadata for the response so callers
+      // (e.g. CLI session start) can surface url/title without an extra
+      // round-trip.
+      let tabInfo;
       try {
-        await chrome.tabs.get(tabId);
+        tabInfo = await chrome.tabs.get(tabId);
       } catch (_) {
         return { id, error: { code: -32000, message: `Tab ${tabId} not found` } };
       }
 
-      // Detach from current tab if any
-      if (attachedTabId !== null) {
+      // Accumulate — never auto-detach other tabs. Protocol 0.3.0 supports
+      // concurrent multi-tab attach; detach is explicit via Extension.detachTab.
+      if (!attachedTabs.has(tabId)) {
         try {
-          await chrome.debugger.detach({ tabId: attachedTabId });
-        } catch (_) {
-          // Ignore detach errors
+          await chrome.debugger.attach({ tabId }, "1.3");
+          attachedTabs.add(tabId);
+        } catch (err) {
+          return { id, error: { code: -32000, message: `attach failed: ${err.message}` } };
         }
       }
-
-      await chrome.debugger.attach({ tabId }, "1.3");
-      attachedTabId = tabId;
-      return { id, result: { attached: true, tabId } };
-    }
-
-    case "Extension.attachActiveTab": {
-      const [tab] = await chrome.tabs.query({
-        active: true,
-        currentWindow: true,
-      });
-      if (!tab) {
-        return { id, error: { code: -32000, message: "No active tab found" } };
-      }
-
-      if (attachedTabId !== null && attachedTabId !== tab.id) {
-        try {
-          await chrome.debugger.detach({ tabId: attachedTabId });
-        } catch (_) {
-          // Ignore
-        }
-      }
-
-      await chrome.debugger.attach({ tabId: tab.id }, "1.3");
-      attachedTabId = tab.id;
-      return { id, result: { attached: true, tabId: tab.id, title: tab.title, url: tab.url } };
+      broadcastState();
+      return {
+        id,
+        result: {
+          attached: true,
+          tabId,
+          url: tabInfo.url || "",
+          title: tabInfo.title || "",
+        },
+      };
     }
 
     case "Extension.createTab": {
       const url = params.url || "about:blank";
       const { tab, reused } = await createOrReuseTab(url);
 
-      // Auto-attach debugger to the target tab so subsequent CDP commands target it
+      // Auto-attach the newly-created tab so subsequent CDP commands on it
+      // work without a separate attachTab round-trip. Existing attached tabs
+      // are untouched (multi-attach).
       try {
-        if (attachedTabId !== null && attachedTabId !== tab.id) {
-          try { await chrome.debugger.detach({ tabId: attachedTabId }); } catch (_) {}
-        }
-        if (attachedTabId !== tab.id) {
+        if (!attachedTabs.has(tab.id)) {
           await chrome.debugger.attach({ tabId: tab.id }, "1.3");
-          attachedTabId = tab.id;
+          attachedTabs.add(tab.id);
         }
+        broadcastState();
         return { id, result: { tabId: tab.id, title: tab.title || "", url: tab.url || url, attached: true, reused } };
       } catch (err) {
         // Tab created but debugger attach failed — return tab info with attached: false
@@ -488,15 +516,12 @@ async function handleExtensionCommand(id, method, params) {
         await chrome.tabs.update(tabId, { active: true });
         const tab = await chrome.tabs.get(tabId);
 
-        // Auto-attach debugger to the activated tab so subsequent CDP commands target it
-        if (attachedTabId !== null && attachedTabId !== tabId) {
-          try { await chrome.debugger.detach({ tabId: attachedTabId }); } catch (_) {}
-        }
-        if (attachedTabId !== tabId) {
+        // Auto-attach (accumulating) so a follow-up CDP command can target it.
+        if (!attachedTabs.has(tabId)) {
           await chrome.debugger.attach({ tabId }, "1.3");
-          attachedTabId = tabId;
+          attachedTabs.add(tabId);
         }
-
+        broadcastState();
         return { id, result: { success: true, tabId, title: tab.title, url: tab.url, attached: true } };
       } catch (err) {
         return { id, error: { code: -32000, message: `Failed to activate tab ${tabId}: ${err.message}` } };
@@ -504,16 +529,19 @@ async function handleExtensionCommand(id, method, params) {
     }
 
     case "Extension.detachTab": {
-      if (attachedTabId === null) {
-        return { id, result: { detached: true } };
+      // Without explicit tabId, detach ALL attached tabs (used during
+      // session close). With tabId, detach just that one.
+      const targets = (typeof params.tabId === "number")
+        ? [params.tabId]
+        : Array.from(attachedTabs);
+      for (const t of targets) {
+        if (attachedTabs.has(t)) {
+          try { await chrome.debugger.detach({ tabId: t }); } catch (_) {}
+          attachedTabs.delete(t);
+        }
       }
-      try {
-        await chrome.debugger.detach({ tabId: attachedTabId });
-      } catch (_) {
-        // Ignore
-      }
-      attachedTabId = null;
-      return { id, result: { detached: true } };
+      broadcastState();
+      return { id, result: { detached: true, detachedTabIds: targets } };
     }
 
     case "Extension.status": {
@@ -521,8 +549,8 @@ async function handleExtensionCommand(id, method, params) {
         id,
         result: {
           connected: connectionState === "connected",
-          attachedTabId,
-          version: "0.2.0",
+          attachedTabIds: Array.from(attachedTabs),
+          version: "0.3.0",
         },
       };
     }
@@ -646,10 +674,10 @@ async function handleExtensionCommand(id, method, params) {
   }
 }
 
-async function getAttachedTabDomain() {
-  if (attachedTabId === null) return null;
+async function getTabDomain(tabId) {
+  if (typeof tabId !== "number") return null;
   try {
-    const tab = await chrome.tabs.get(attachedTabId);
+    const tab = await chrome.tabs.get(tabId);
     if (tab.url) {
       return new URL(tab.url).hostname;
     }
@@ -732,13 +760,13 @@ function broadcastL3Status(pending) {
     });
 }
 
-async function handleCdpCommand(id, method, params) {
-  if (attachedTabId === null) {
+async function handleCdpCommand(id, method, params, tabId) {
+  if (!attachedTabs.has(tabId)) {
     return {
       id,
       error: {
         code: -32000,
-        message: "No tab attached. Use Extension.attachTab first.",
+        message: `Tab ${tabId} not attached. Call Extension.attachTab first.`,
       },
     };
   }
@@ -751,24 +779,24 @@ async function handleCdpCommand(id, method, params) {
     };
   }
 
-  const domain = await getAttachedTabDomain();
+  const domain = await getTabDomain(tabId);
   const riskLevel = getEffectiveRiskLevel(method, domain);
 
   // L2: auto-approve with logging
   if (riskLevel === 'L2') {
-    debugLog(`[actionbook] L2 command: ${method} on ${domain || "unknown"}`);
+    debugLog(`[actionbook] L2 command: ${method} on ${domain || "unknown"} (tab ${tabId})`);
   }
 
   // L3: require user confirmation
   if (riskLevel === 'L3') {
-    debugLog(`[actionbook] L3 command requires confirmation: ${method} on ${domain || "unknown"}`);
+    debugLog(`[actionbook] L3 command requires confirmation: ${method} on ${domain || "unknown"} (tab ${tabId})`);
     const denial = await requestL3Confirmation(id, method, domain);
     if (denial) return denial;
   }
 
   try {
     const result = await chrome.debugger.sendCommand(
-      { tabId: attachedTabId },
+      { tabId },
       method,
       params
     );
@@ -783,14 +811,13 @@ async function handleCdpCommand(id, method, params) {
       errorMessage.includes("Cannot access") ||
       errorMessage.includes("Target closed")
     ) {
-      const previousTabId = attachedTabId;
-      attachedTabId = null;
+      attachedTabs.delete(tabId);
       broadcastState();
       return {
         id,
         error: {
           code: -32000,
-          message: `Debugger detached from tab ${previousTabId}: ${errorMessage}. Call Extension.attachTab to re-attach.`,
+          message: `Debugger detached from tab ${tabId}: ${errorMessage}. Call Extension.attachTab to re-attach.`,
         },
       };
     }
@@ -809,7 +836,7 @@ function broadcastState() {
     .sendMessage({
       type: "stateUpdate",
       connectionState,
-      attachedTabId,
+      attachedTabIds: Array.from(attachedTabs),
       retryCount,
       maxRetries: MAX_RETRIES,
     })
@@ -832,7 +859,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "getState") {
     sendResponse({
       connectionState,
-      attachedTabId,
+      attachedTabIds: Array.from(attachedTabs),
       retryCount,
       maxRetries: MAX_RETRIES,
     });
@@ -890,19 +917,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   return false;
 });
 
-// Clean up debugger on tab close
+// Clean up debugger state when a tab is closed.
 chrome.tabs.onRemoved.addListener((tabId) => {
-  if (tabId === attachedTabId) {
-    attachedTabId = null;
+  if (attachedTabs.delete(tabId)) {
     broadcastState();
   }
 });
 
-// Handle debugger detach events
+// Handle debugger detach events (user cancelled the debug banner, tab crashed,
+// etc.). Remove only the affected tab from the attached set.
 chrome.debugger.onDetach.addListener((source, reason) => {
-  if (source.tabId === attachedTabId) {
-    debugLog(`[actionbook] Debugger detached from tab ${attachedTabId}: ${reason}`);
-    attachedTabId = null;
+  const tabId = source.tabId;
+  if (typeof tabId === "number" && attachedTabs.has(tabId)) {
+    debugLog(`[actionbook] Debugger detached from tab ${tabId}: ${reason}`);
+    attachedTabs.delete(tabId);
     broadcastState();
   }
 });

--- a/packages/actionbook-extension/manifest.json
+++ b/packages/actionbook-extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Actionbook",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Bridge between Actionbook CLI and your browser for AI-powered automation",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5xhsOXoi029BKiQTCV7UTZd/f/nzgW6JerV8XfbJLOEr+gHAVNU6J+2Yq3DvTE7+Tnx9EW9jQNGtE4ZXXaGpkvpkcP2ch3ggQQFpjOvHdlVGljepRB2gJivGWR5ooQ1QPWAyxwDLeA09/w2oZ54W9RMXeuzfjv1KRceq9FHlmkIIGaaqYfLzrQbbE7GSV1DSeRG1kG0f7Km2wUsuNDCINI6XyBbhM+662Clurs1GdP7S+Gw/+N/97YEY8Ir2smotGTknHmHuUl5N2XXJjhxfaCT85DkaMV0Kn9D9pVczK4xgqGypplCna5I61YjNDMrymA25qLNKQv2nf/mv7Y7l9wIDAQAB",
   "permissions": [

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -101,7 +101,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     #[cfg(windows)]
     let chrome_job: Option<crate::daemon::chrome_reaper::ChromeJobObject>;
 
-    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode) = {
+    let (closed_tabs, cdp, chrome_process, profile_to_clean, mode, ext_native_tab_ids) = {
         let mut reg = registry.lock().await;
         let mut entry = match reg.remove(&cmd.session) {
             Some(e) => e,
@@ -130,6 +130,19 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 None
             };
 
+        // Extension mode: collect the native (Chrome numeric) tab IDs we
+        // attached so we can ask the extension to close them. native_id is
+        // a stringified i64 here.
+        let ext_ids: Vec<u64> = if entry_mode == Mode::Extension {
+            entry
+                .tabs
+                .iter()
+                .filter_map(|t| t.native_id.parse::<u64>().ok())
+                .collect()
+        } else {
+            Vec::new()
+        };
+
         #[cfg(windows)]
         {
             chrome_job = entry.job_object.take();
@@ -142,20 +155,28 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             entry.chrome_process.take(),
             profile_cleanup,
             entry_mode,
+            ext_ids,
         )
     };
     // Registry lock released here — slow I/O below won't block other sessions.
 
-    // Extension mode: detach debugger before tearing down the CDP connection.
-    // Extension mode doesn't own the browser — we only release the debugger,
-    // leaving tabs open for the user.
+    // Extension mode: detach the debugger AND close the chrome tabs the
+    // session opened. Symmetric with local mode killing its chrome process —
+    // the session "owns" the tabs it created via Extension.createTab and
+    // attached via --tab-id, so leaving them around on close would leak
+    // browser state across runs (and was responsible for tab-explosion in
+    // the e2e suite).
     if mode == Mode::Extension
         && let Some(ref cdp) = cdp
+        && !ext_native_tab_ids.is_empty()
         && let Err(e) = cdp
-            .execute_browser("Extension.detachTab", serde_json::json!({}))
+            .execute_browser(
+                "Extension.closeTabs",
+                serde_json::json!({ "tabIds": ext_native_tab_ids }),
+            )
             .await
     {
-        tracing::warn!("extension: failed to detach: {e}");
+        tracing::warn!("extension: failed to close tabs {ext_native_tab_ids:?}: {e}");
     }
 
     // Close CDP session AFTER extension cleanup is complete.

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -6,6 +6,7 @@ use crate::action_result::ActionResult;
 use crate::browser::session::provider::ProviderEnv;
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
+use crate::types::Mode;
 
 /// Restart a session
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -57,7 +58,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         headless,
         stealth,
         profile,
-        open_url,
+        mut open_url,
         cdp_endpoint,
         provider,
         headers,
@@ -104,6 +105,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 Some(t.url.clone())
             }
         });
+        // Extension mode requires either --open-url or --tab-id. If the
+        // previous session's URL was filtered out (about:blank, data:, etc.)
+        // and we have no native tab id to carry through, open a fresh tab so
+        // start::execute doesn't see MISSING_TAB_TARGET.
+        if mode == Mode::Extension && open_url.is_none() {
+            open_url = Some("about:blank".to_string());
+        }
         cdp_endpoint = entry.cdp_endpoint.clone();
         provider = entry.provider.clone();
         headers = entry

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -199,6 +199,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         profile: Some(profile),
         executable_path: None,
         open_url,
+        // Restart re-creates the session; if extension mode the original
+        // tab id is gone after debugger detach, so don't carry it through.
+        tab_id: None,
         cdp_endpoint: effective_cdp_endpoint,
         provider: effective_provider,
         header: effective_headers,

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -64,6 +64,13 @@ pub struct Cmd {
     /// Open this URL on start
     #[arg(long)]
     pub open_url: Option<String>,
+    /// Extension mode only: attach to a pre-existing Chrome tab by its native
+    /// numeric tab id (e.g. from `browser list-tabs --json`'s `native_tab_id`).
+    /// Mutually exclusive with --open-url. Required when `--mode extension`
+    /// is used without `--open-url`; the legacy "attach active tab" default
+    /// has been removed in protocol 0.3.0 — every tab must be explicit.
+    #[arg(long, conflicts_with = "open_url")]
+    pub tab_id: Option<u64>,
     /// Connect to existing CDP endpoint
     #[arg(long)]
     pub cdp_endpoint: Option<String>,
@@ -1489,29 +1496,29 @@ async fn execute_extension(
                 .await;
             }
         }
-    } else {
-        // No open_url — attach the current active tab.
+    } else if let Some(explicit_tab_id) = cmd.tab_id {
+        // Explicit attach to a pre-existing Chrome tab by its native id.
+        // No "active tab" default in protocol 0.3.0 — every attach is explicit.
         match cdp
-            .execute_browser("Extension.attachActiveTab", json!({}))
+            .execute_browser("Extension.attachTab", json!({ "tabId": explicit_tab_id }))
             .await
         {
             Ok(resp) => {
                 let result = &resp["result"];
-                let tab_id = result["tabId"].as_i64().unwrap_or(0).to_string();
+                let tab_id = result["tabId"]
+                    .as_i64()
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| explicit_tab_id.to_string());
                 let tab_url = result["url"].as_str().unwrap_or("about:blank").to_string();
                 let title = result["title"].as_str().unwrap_or("").to_string();
-                // The attach may succeed but return a URL that Chrome will later
-                // refuse CDP commands on (chrome://, devtools://, ...). Catch it
-                // here so the agent gets a clear remediation instead of a
-                // downstream -32000 error on the first real command.
                 if is_restricted_attach_scheme(&tab_url) {
                     cdp.close().await;
                     return fail_reserved_start_with_hint(
                         registry,
                         &session_id,
-                        "RESTRICTED_ACTIVE_TAB",
-                        format!("active tab is a restricted URL: {tab_url}"),
-                        "pass --open-url <url>",
+                        "RESTRICTED_TAB",
+                        format!("tab {explicit_tab_id} is a restricted URL: {tab_url}"),
+                        "pass --open-url <url> or pick a different --tab-id",
                     )
                     .await;
                 }
@@ -1524,9 +1531,9 @@ async fn execute_extension(
                     return fail_reserved_start_with_hint(
                         registry,
                         &session_id,
-                        "RESTRICTED_ACTIVE_TAB",
-                        "active tab is a restricted URL".to_string(),
-                        "pass --open-url <url>",
+                        "RESTRICTED_TAB",
+                        format!("tab {explicit_tab_id} cannot be debugged"),
+                        "pass --open-url <url> or pick a different --tab-id",
                     )
                     .await;
                 }
@@ -1534,11 +1541,22 @@ async fn execute_extension(
                     registry,
                     &session_id,
                     "CDP_ERROR",
-                    format!("failed to attach active tab via extension: {e}"),
+                    format!("failed to attach tab {explicit_tab_id} via extension: {e}"),
                 )
                 .await;
             }
         }
+    } else {
+        // Neither --open-url nor --tab-id: extension mode requires one.
+        cdp.close().await;
+        return fail_reserved_start_with_hint(
+            registry,
+            &session_id,
+            "MISSING_TAB_TARGET",
+            "extension mode requires either --open-url or --tab-id".to_string(),
+            "pass --open-url <url> to create a new tab, or --tab-id <N> (find ids via `actionbook browser list-tabs --json`)",
+        )
+        .await;
     };
 
     // Register extension tabs in CdpSession so execute_on_tab works.
@@ -2032,6 +2050,7 @@ mod provider_start_tests {
                 profile: None,
                 executable_path: None,
                 open_url: None,
+                tab_id: None,
                 cdp_endpoint: None,
                 provider: Some("hyperbrowser".to_string()),
                 header: vec![],
@@ -2093,6 +2112,7 @@ mod provider_start_tests {
                 profile: None,
                 executable_path: None,
                 open_url: None,
+                tab_id: None,
                 cdp_endpoint: None,
                 provider: Some("hyperbrowser".to_string()),
                 header: vec![],
@@ -2145,6 +2165,7 @@ mod provider_start_tests {
                 profile: None,
                 executable_path: None,
                 open_url: None,
+                tab_id: None,
                 cdp_endpoint: None,
                 provider: Some("browseruse".to_string()),
                 header: vec![],

--- a/packages/cli/src/browser/tab/batch_open.rs
+++ b/packages/cli/src/browser/tab/batch_open.rs
@@ -9,6 +9,7 @@ use crate::daemon::cdp::ensure_scheme_or_fatal;
 use crate::daemon::cdp_session::cdp_error_to_result;
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
+use crate::types::Mode;
 
 /// Open multiple tabs in one call (batch)
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -90,12 +91,12 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         }
     }
 
-    // Get CdpSession and stealth_ua from registry
-    let (cdp, stealth_ua) = {
+    // Get CdpSession, stealth_ua, and mode from registry
+    let (cdp, stealth_ua, mode) = {
         let reg = registry.lock().await;
         match reg.get(&cmd.session) {
             Some(e) => match e.cdp.clone() {
-                Some(c) => (c, e.stealth_ua.clone()),
+                Some(c) => (c, e.stealth_ua.clone(), e.mode),
                 None => {
                     return ActionResult::fatal_with_hint(
                         "INTERNAL_ERROR",
@@ -119,7 +120,97 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     for (i, final_url) in final_urls.iter().enumerate() {
         let custom_tab_id = cmd.tabs.get(i);
 
-        // Create tab via CDP
+        // Extension mode uses chrome.tabs.create (wrapped as Extension.createTab);
+        // bridge's CDP allowlist forbids raw Target.createTarget. Parallel to the
+        // branch in `tab/open.rs`.
+        if mode == Mode::Extension {
+            let resp = match cdp
+                .execute_browser("Extension.createTab", json!({ "url": final_url }))
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    return batch_error(
+                        i,
+                        final_url,
+                        cdp_error_to_result(e, "CDP_ERROR"),
+                        &results,
+                        cmd.urls.len(),
+                    );
+                }
+            };
+            let result = &resp["result"];
+            let native_id = match result["tabId"].as_i64() {
+                Some(n) => n.to_string(),
+                None => {
+                    return batch_error(
+                        i,
+                        final_url,
+                        ActionResult::fatal(
+                            "CDP_ERROR",
+                            format!("Extension.createTab did not return tabId: {}", resp),
+                        ),
+                        &results,
+                        cmd.urls.len(),
+                    );
+                }
+            };
+            let tab_url = result["url"].as_str().unwrap_or(final_url).to_string();
+            let title = result["title"].as_str().unwrap_or("").to_string();
+
+            let short_tab_id = {
+                let mut reg = registry.lock().await;
+                match reg.get_mut(&cmd.session) {
+                    Some(e) => {
+                        if let Some(custom_id) = custom_tab_id {
+                            match e.push_tab_with_id(
+                                custom_id.clone(),
+                                native_id.clone(),
+                                tab_url.clone(),
+                                title.clone(),
+                            ) {
+                                Ok(id) => id,
+                                Err(err_result) => {
+                                    return batch_error(
+                                        i,
+                                        final_url,
+                                        err_result,
+                                        &results,
+                                        cmd.urls.len(),
+                                    );
+                                }
+                            }
+                        } else {
+                            e.push_tab(native_id.clone(), tab_url.clone(), title.clone());
+                            e.tabs.last().map(|t| t.id.0.clone()).unwrap_or_default()
+                        }
+                    }
+                    None => {
+                        return ActionResult::fatal(
+                            "SESSION_NOT_FOUND",
+                            format!(
+                                "session '{}' was closed during batch tab creation",
+                                cmd.session
+                            ),
+                        );
+                    }
+                }
+            };
+
+            // Register in CdpSession so execute_on_tab finds this native_id.
+            // Same rationale as the single-tab path in tab/open.rs.
+            cdp.register_extension_tab(&native_id).await;
+
+            results.push(json!({
+                "tab_id": short_tab_id,
+                "native_tab_id": native_id,
+                "url": tab_url,
+                "title": title,
+            }));
+            continue;
+        }
+
+        // Local / cloud / CDP-direct: raw CDP Target.createTarget.
         let resp = match cdp
             .execute_browser("Target.createTarget", json!({ "url": final_url }))
             .await

--- a/packages/cli/src/browser/tab/close.rs
+++ b/packages/cli/src/browser/tab/close.rs
@@ -96,11 +96,15 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     }
 
     if mode == Mode::Extension {
-        // Extension mode: detach debugger. The extension doesn't own the
-        // browser so we can't force-close user tabs — only release the
-        // debugger attachment.
-        if let Err(e) = cdp.execute_browser("Extension.detachTab", json!({})).await {
-            tracing::warn!("extension: failed to detach tab: {e}");
+        // Extension mode: detach debugger from this specific tab only.
+        // Protocol 0.3.0: Extension.detachTab without tabId detaches ALL tabs;
+        // pass the native id so only this tab is released.
+        let native_tab_id: u64 = native_id.parse().unwrap_or(0);
+        if let Err(e) = cdp
+            .execute_browser("Extension.detachTab", json!({ "tabId": native_tab_id }))
+            .await
+        {
+            tracing::warn!("extension: failed to detach tab {native_tab_id}: {e}");
         }
     } else {
         // Local/Cloud mode: detach then close via CDP Target.closeTarget.

--- a/packages/cli/src/browser/tab/list.rs
+++ b/packages/cli/src/browser/tab/list.rs
@@ -133,7 +133,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     // - Matching native_id → keep short tab ID, update url/title
     // - Stale registry tabs (not in CDP) → remove
     // - New CDP tabs (not in registry) → assign new short ID
-    let (tabs, to_attach): (Vec<serde_json::Value>, Vec<String>) = {
+    let (tabs, to_attach_cdp, to_register_ext): (Vec<serde_json::Value>, Vec<String>, Vec<String>) = {
         let mut reg = registry.lock().await;
         let entry = match reg.get_mut(&cmd.session) {
             Some(e) => e,
@@ -152,8 +152,10 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             .retain(|t| live_pages.iter().any(|(nid, _, _)| *nid == t.native_id));
 
         let mut result = Vec::new();
-        let mut to_attach = Vec::new();
+        let mut to_attach_cdp = Vec::new();
+        let mut to_register_ext = Vec::new();
         for (native_id, url, title) in &live_pages {
+            let is_new;
             // Find existing short ID or assign a new one
             if let Some(existing) = entry.tabs.iter_mut().find(|t| t.native_id == *native_id) {
                 // Update url/title from live CDP data
@@ -165,29 +167,44 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                     "url": url,
                     "title": title,
                 }));
+                is_new = false;
             } else {
-                // New tab — assign next short ID and mark for CDP attach
+                // New tab — assign next short ID
                 entry.push_tab(native_id.to_string(), url.to_string(), title.to_string());
                 let new_tab = entry.tabs.last().unwrap();
-                to_attach.push(native_id.to_string());
                 result.push(json!({
                     "tab_id": new_tab.id.0,
                     "native_tab_id": native_id,
                     "url": url,
                     "title": title,
                 }));
+                is_new = true;
+            }
+            // Local/cloud: only NEW tabs need a CDP attach handshake — existing
+            // ones already have their session ID in CdpSession.tab_sessions.
+            //
+            // Extension: every live tab must be registered in CdpSession —
+            // register_extension_tab is an idempotent HashMap insert and it
+            // recovers the case where `entry.tabs` out-lives CdpSession (e.g.
+            // after a daemon restart, or when a tab was created by a pre-fix
+            // binary that skipped register_extension_tab). Without this
+            // `execute_on_tab` fails with INTERNAL_ERROR "no CDP session for
+            // target '<native_id>'".
+            if mode == Mode::Extension {
+                to_register_ext.push(native_id.to_string());
+            } else if is_new {
+                to_attach_cdp.push(native_id.to_string());
             }
         }
-        (result, to_attach)
+        (result, to_attach_cdp, to_register_ext)
     };
 
-    // Attach newly discovered tabs outside the registry lock.
-    // Extension mode uses register_extension_tab (no Target.attachToTarget);
-    // local/cloud mode uses the standard CDP attach.
-    for native_id in &to_attach {
-        if mode == Mode::Extension {
-            cdp.register_extension_tab(native_id).await;
-        } else if let Err(e) = cdp.attach(native_id, None).await {
+    // Outside the registry lock.
+    for native_id in &to_register_ext {
+        cdp.register_extension_tab(native_id).await;
+    }
+    for native_id in &to_attach_cdp {
+        if let Err(e) = cdp.attach(native_id, None).await {
             tracing::warn!("failed to attach discovered tab {native_id}: {e}");
         }
     }

--- a/packages/cli/src/browser/tab/open.rs
+++ b/packages/cli/src/browser/tab/open.rs
@@ -7,6 +7,7 @@ use crate::daemon::cdp::{ensure_scheme, ensure_scheme_or_fatal};
 use crate::daemon::cdp_session::{CdpSession, cdp_error_to_result};
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
+use crate::types::Mode;
 
 /// Open a new tab
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -86,7 +87,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         );
     }
 
-    let (cdp, stealth_ua) = match session_cdp(&cmd.session, registry).await {
+    let (cdp, stealth_ua, mode) = match session_cdp(&cmd.session, registry).await {
         Ok(parts) => parts,
         Err(err) => return err,
     };
@@ -111,6 +112,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             &cmd.session,
             &cdp,
             stealth_ua.as_deref(),
+            mode,
             registry,
             &final_url,
             cmd.set_tab_id.get(index).map(String::as_str),
@@ -173,7 +175,7 @@ async fn execute_single(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         Err(e) => return e,
     };
 
-    let (cdp, stealth_ua) = match session_cdp(&cmd.session, registry).await {
+    let (cdp, stealth_ua, mode) = match session_cdp(&cmd.session, registry).await {
         Ok(parts) => parts,
         Err(err) => return err,
     };
@@ -182,6 +184,7 @@ async fn execute_single(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         &cmd.session,
         &cdp,
         stealth_ua.as_deref(),
+        mode,
         registry,
         &final_url,
         cmd.set_tab_id.first().map(String::as_str),
@@ -200,11 +203,11 @@ async fn execute_single(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 async fn session_cdp(
     session_id: &str,
     registry: &SharedRegistry,
-) -> Result<(CdpSession, Option<String>), ActionResult> {
+) -> Result<(CdpSession, Option<String>, Mode), ActionResult> {
     let reg = registry.lock().await;
     match reg.get(session_id) {
         Some(entry) => match entry.cdp.clone() {
-            Some(cdp) => Ok((cdp, entry.stealth_ua.clone())),
+            Some(cdp) => Ok((cdp, entry.stealth_ua.clone(), entry.mode)),
             None => Err(ActionResult::fatal_with_hint(
                 "INTERNAL_ERROR",
                 format!("no CDP connection for session '{session_id}'"),
@@ -223,10 +226,85 @@ async fn open_one_tab(
     session_id: &str,
     cdp: &CdpSession,
     stealth_ua: Option<&str>,
+    mode: Mode,
     registry: &SharedRegistry,
     final_url: &str,
     custom_tab_id: Option<&str>,
 ) -> Result<serde_json::Value, ActionResult> {
+    // Extension mode: the bridge's CDP allowlist forbids `Target.createTarget`
+    // (an extension must not spawn debugger-controlled targets behind the
+    // user's back). Use the extension's custom `Extension.createTab` method,
+    // which calls `chrome.tabs.create` under the hood and auto-attaches the
+    // debugger — symmetric with the `--open-url` path in `session::start`.
+    if mode == Mode::Extension {
+        let resp = match cdp
+            .execute_browser("Extension.createTab", json!({ "url": final_url }))
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => return Err(cdp_error_to_result(e, "CDP_ERROR")),
+        };
+        let result = &resp["result"];
+        let tab_id = match result["tabId"].as_i64() {
+            Some(n) => n.to_string(),
+            None => {
+                return Err(ActionResult::fatal(
+                    "CDP_ERROR",
+                    format!("Extension.createTab did not return tabId: {}", resp),
+                ));
+            }
+        };
+        let tab_url = result["url"].as_str().unwrap_or(final_url).to_string();
+        let title = result["title"].as_str().unwrap_or("").to_string();
+        let native_id = tab_id; // extension uses Chrome tab ID as native identifier
+
+        let short_tab_id = {
+            let mut reg = registry.lock().await;
+            match reg.get_mut(session_id) {
+                Some(entry) => {
+                    if let Some(custom_id) = custom_tab_id {
+                        match entry.push_tab_with_id(
+                            custom_id.to_string(),
+                            native_id.clone(),
+                            tab_url.clone(),
+                            title.clone(),
+                        ) {
+                            Ok(id) => id,
+                            Err(err_result) => return Err(err_result),
+                        }
+                    } else {
+                        entry.push_tab(native_id.clone(), tab_url.clone(), title.clone());
+                        entry
+                            .tabs
+                            .last()
+                            .map(|t| t.id.0.clone())
+                            .unwrap_or_default()
+                    }
+                }
+                None => {
+                    return Err(ActionResult::fatal(
+                        "SESSION_NOT_FOUND",
+                        format!("session '{session_id}' was closed during tab creation"),
+                    ));
+                }
+            }
+        };
+
+        // Register the new tab in CdpSession so subsequent execute_on_tab
+        // finds it. Mirrors what tab::list does when it discovers a new tab
+        // via Extension.listTabs — without this, `goto --tab <new>` fails
+        // with INTERNAL_ERROR "no CDP session for target '<native_id>'".
+        cdp.register_extension_tab(&native_id).await;
+
+        return Ok(json!({
+            "tab_id": short_tab_id,
+            "native_tab_id": native_id,
+            "url": tab_url,
+            "title": title,
+        }));
+    }
+
+    // Local / cloud / CDP-direct modes: use the standard CDP `Target.createTarget`.
     let resp = match cdp
         .execute_browser("Target.createTarget", json!({ "url": final_url }))
         .await

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -379,6 +379,7 @@ mod tests {
             profile: None,
             executable_path: None,
             open_url: None,
+            tab_id: None,
             cdp_endpoint: None,
             provider: None,
             header: vec![],

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -40,7 +40,13 @@ pub const BRIDGE_PORT: u16 = 19222;
 const BIND_RETRY_DELAYS_MS: &[u64] = &[100, 500, 1_000, 2_000, 5_000];
 
 /// Protocol version for the hello handshake.
-const PROTOCOL_VERSION: &str = "0.2.0";
+///
+/// Bumped to `0.3.0` when multi-tab concurrent debug landed:
+/// - every CDP request now carries a root-level `tabId`
+/// - extension uses `attachedTabs: Set<number>` instead of a single attach
+/// - older extensions (0.2.x) are rejected and asked to reload — the
+///   single-attach protocol cannot be mixed with the multi-attach client.
+const PROTOCOL_VERSION: &str = "0.3.0";
 
 /// Known Actionbook Chrome extension IDs.
 const EXTENSION_ID_CWS: &str = "bebchpafpemheedhcdabookaifcijmfo";
@@ -671,14 +677,14 @@ fn is_origin_allowed(origin: Option<&str>) -> bool {
     false
 }
 
-/// Check protocol version >= 0.2.0 (simple major.minor comparison).
+/// Check protocol version >= 0.3.0 (simple major.minor comparison).
 fn is_version_ok(version: &str) -> bool {
     let parts: Vec<u32> = version.split('.').filter_map(|p| p.parse().ok()).collect();
     if parts.len() < 2 {
         return false;
     }
-    // 0.2.0 minimum: major > 0, or major == 0 && minor >= 2
-    parts[0] > 0 || (parts[0] == 0 && parts[1] >= 2)
+    // 0.3.0 minimum: major > 0, or major == 0 && minor >= 3
+    parts[0] > 0 || (parts[0] == 0 && parts[1] >= 3)
 }
 
 // ─── Unit Tests ─────────────────────────────────────────────────────────
@@ -702,9 +708,11 @@ mod tests {
 
     #[test]
     fn test_is_version_ok() {
-        assert!(is_version_ok("0.2.0"));
         assert!(is_version_ok("0.3.0"));
+        assert!(is_version_ok("0.3.5"));
         assert!(is_version_ok("1.0.0"));
+        assert!(!is_version_ok("0.2.0"));
+        assert!(!is_version_ok("0.2.9"));
         assert!(!is_version_ok("0.1.0"));
         assert!(!is_version_ok("0.0.1"));
         assert!(!is_version_ok("invalid"));

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -350,6 +350,7 @@ impl CdpSession {
         let tab_sessions: Arc<Mutex<HashMap<String, String>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let tab_net_requests: TabNetRequests = Arc::new(Mutex::new(HashMap::new()));
+        let is_extension_bridge = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
         let writer_handle = tokio::spawn(Self::writer_loop(ws_writer, writer_rx));
         tokio::spawn(Self::reader_loop(
@@ -362,6 +363,7 @@ impl CdpSession {
             tab_sessions.clone(),
             tab_net_requests.clone(),
             max_tracked_requests,
+            is_extension_bridge.clone(),
         ));
 
         Ok(CdpSession {
@@ -375,7 +377,7 @@ impl CdpSession {
             iframe_sessions,
             pending_iframe_enables,
             tab_net_requests,
-            is_extension_bridge: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            is_extension_bridge,
         })
     }
 
@@ -526,7 +528,7 @@ impl CdpSession {
     /// Idempotent: calling again for the same `native_id` is a no-op.
     pub async fn register_extension_tab(&self, native_id: &str) {
         self.is_extension_bridge
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+            .store(true, std::sync::atomic::Ordering::Release);
         let key = format!("tab:{native_id}");
         self.tab_sessions
             .lock()
@@ -589,7 +591,7 @@ impl CdpSession {
     ) -> Result<Value, CliError> {
         if self
             .is_extension_bridge
-            .load(std::sync::atomic::Ordering::SeqCst)
+            .load(std::sync::atomic::Ordering::Acquire)
         {
             let tab_id: u64 = target_id.parse().map_err(|e| {
                 CliError::CdpError(format!("non-numeric extension tab id '{target_id}': {e}"))
@@ -601,6 +603,9 @@ impl CdpSession {
             {
                 Ok(v) => Ok(v),
                 Err(CliError::CdpError(ref msg))
+                    // keep in sync with error messages in background.js
+                    // handleCdpCommand ("Tab N not attached") and the
+                    // chrome.debugger catch block ("Debugger detached from tab")
                     if msg.contains(&format!("Tab {tab_id} not attached"))
                         || msg.contains("Debugger detached from tab") =>
                 {
@@ -911,6 +916,7 @@ impl CdpSession {
         _tab_sessions: Arc<Mutex<HashMap<String, String>>>,
         tab_net_requests: TabNetRequests,
         max_tracked_requests: usize,
+        is_extension_bridge: Arc<std::sync::atomic::AtomicBool>,
     ) where
         S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
     {
@@ -939,11 +945,18 @@ impl CdpSession {
                 //   `tab:{tabId}` so per-tab subscribers stay separated.
                 // - local/cloud: CDP flat session — key by `sessionId`
                 //   (empty string for browser-level events).
-                let ext_tab_key = resp
-                    .get("tabId")
-                    .and_then(|v| v.as_u64())
-                    .map(|n| format!("tab:{n}"));
+                // Guard on is_extension_bridge so local/cloud events that happen
+                // to carry a numeric `tabId` field (e.g. Target.* params) are
+                // never mis-routed by the extension key path.
                 let session_id_str = resp.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+                let ext_tab_key: Option<String> =
+                    if is_extension_bridge.load(std::sync::atomic::Ordering::Acquire) {
+                        resp.get("tabId")
+                            .and_then(|v| v.as_u64())
+                            .map(|n| format!("tab:{n}"))
+                    } else {
+                        None
+                    };
                 let session_id = ext_tab_key.as_deref().unwrap_or(session_id_str);
 
                 // Track cross-origin iframe sessions from Target.setAutoAttach.

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -293,6 +293,12 @@ pub struct CdpSession {
     /// Per-tab ring buffer of tracked network requests, keyed by CDP session ID.
     /// Populated by reader_loop from Network events; capacity capped at MAX_TRACKED_REQUESTS.
     tab_net_requests: TabNetRequests,
+    /// `true` when this session speaks the extension-bridge protocol (0.3.0+).
+    /// Flipped by `register_extension_tab`. In extension mode every per-tab
+    /// command injects a root-level `tabId` instead of a CDP `sessionId`, and
+    /// the bridge/extension routes by that. Local/cloud sessions keep the
+    /// normal CDP flat-session protocol.
+    is_extension_bridge: Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl CdpSession {
@@ -369,6 +375,7 @@ impl CdpSession {
             iframe_sessions,
             pending_iframe_enables,
             tab_net_requests,
+            is_extension_bridge: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         })
     }
 
@@ -505,19 +512,26 @@ impl CdpSession {
         // (real users have 1366x768, 2560x1440, 3440x1440, etc.).
     }
 
-    /// Register a tab for extension mode (no CDP flat-session handshake needed).
+    /// Register a tab for extension mode (protocol 0.3.0+).
     ///
-    /// The extension bridge relays CDP commands to a single attached tab and
-    /// ignores the `sessionId` field entirely.  We insert an empty-string
-    /// session ID so that `execute_on_tab` can look it up and the resulting
-    /// WS message simply omits `sessionId` (because `execute()` only adds it
-    /// when `Some`).  Actually we store `""` but `execute_on_tab` passes
-    /// `Some("")` which adds `"sessionId":""` — the bridge ignores it.
+    /// Flips this session into "extension bridge" mode (one-way; local/cloud
+    /// sessions never call this), and derives a per-tab routing key
+    /// `tab:{native_id}` that is used uniformly by:
+    ///   - `execute_on_tab` to look up the tab (miss → `INTERNAL_ERROR`)
+    ///   - `get_cdp_session_id` to return a stable per-tab key for
+    ///     `subscribe_events`, `network_pending`, `network_requests`
+    ///   - `reader_loop` to bucket incoming events carrying the bridge's
+    ///     root-level `tabId` field
+    ///
+    /// Idempotent: calling again for the same `native_id` is a no-op.
     pub async fn register_extension_tab(&self, native_id: &str) {
+        self.is_extension_bridge
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let key = format!("tab:{native_id}");
         self.tab_sessions
             .lock()
             .await
-            .insert(native_id.to_string(), String::new());
+            .insert(native_id.to_string(), key);
     }
 
     /// Detach from a CDP target (tab).
@@ -559,24 +573,110 @@ impl CdpSession {
 
     /// Execute a CDP command on a specific tab (by target_id).
     ///
-    /// Looks up the CDP sessionId for the target and includes it in the message.
+    /// * **Local / cloud (CDP flat sessions)**: looks up the CDP `sessionId`
+    ///   for the target and includes it in the message.
+    /// * **Extension bridge (protocol 0.3.0+)**: parses `target_id` as the
+    ///   Chrome numeric tab id and injects a root-level `tabId`. The
+    ///   extension routes to `chrome.debugger.sendCommand({tabId}, …)`.
+    ///   On the extension's "Tab N not attached" error (can happen after
+    ///   extension reload or when the user cancels the debug banner),
+    ///   attempts exactly one lazy `Extension.attachTab` + retry.
     pub async fn execute_on_tab(
         &self,
         target_id: &str,
         method: &str,
         params: Value,
     ) -> Result<Value, CliError> {
-        let session_id = self
-            .tab_sessions
-            .lock()
-            .await
-            .get(target_id)
-            .cloned()
-            .ok_or_else(|| {
-                CliError::CdpError(format!("no CDP session for target '{target_id}'"))
+        if self
+            .is_extension_bridge
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            let tab_id: u64 = target_id.parse().map_err(|e| {
+                CliError::CdpError(format!("non-numeric extension tab id '{target_id}': {e}"))
             })?;
 
-        self.execute(method, params, Some(&session_id)).await
+            match self
+                .execute_extension_tab(tab_id, method, params.clone())
+                .await
+            {
+                Ok(v) => Ok(v),
+                Err(CliError::CdpError(ref msg))
+                    if msg.contains(&format!("Tab {tab_id} not attached"))
+                        || msg.contains("Debugger detached from tab") =>
+                {
+                    // Self-heal: extension reload / user-dismissed banner.
+                    // Re-attach, retry once. If that fails too, bubble up.
+                    self.execute("Extension.attachTab", json!({ "tabId": tab_id }), None)
+                        .await?;
+                    self.execute_extension_tab(tab_id, method, params).await
+                }
+                Err(e) => Err(e),
+            }
+        } else {
+            let session_id = self
+                .tab_sessions
+                .lock()
+                .await
+                .get(target_id)
+                .cloned()
+                .ok_or_else(|| {
+                    CliError::CdpError(format!("no CDP session for target '{target_id}'"))
+                })?;
+            self.execute(method, params, Some(&session_id)).await
+        }
+    }
+
+    /// Send a CDP command with a root-level `tabId` (extension bridge path).
+    async fn execute_extension_tab(
+        &self,
+        tab_id: u64,
+        method: &str,
+        params: Value,
+    ) -> Result<Value, CliError> {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let msg = json!({
+            "id": id,
+            "method": method,
+            "params": params,
+            "tabId": tab_id,
+        });
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        let writer = self.writer_tx.lock().await.clone();
+        let send_result = match writer {
+            Some(tx) => tx.send(msg.to_string()).await,
+            None => Err(mpsc::error::SendError(msg.to_string())),
+        };
+        if send_result.is_err() {
+            self.pending.lock().await.remove(&id);
+            return Err(CliError::SessionClosed(
+                "session was closed while command was pending".to_string(),
+            ));
+        }
+
+        let resp = tokio::time::timeout(std::time::Duration::from_secs(60), rx)
+            .await
+            .map_err(|_| {
+                let pending = self.pending.clone();
+                tokio::spawn(async move {
+                    pending.lock().await.remove(&id);
+                });
+                CliError::Timeout
+            })?
+            .map_err(|_| CliError::CdpError("response channel dropped".to_string()))??;
+
+        if let Some(err) = resp.get("error") {
+            let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
+            let message = err
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown CDP error");
+            return Err(CliError::CdpError(format!("CDP error {code}: {message}")));
+        }
+
+        Ok(resp)
     }
 
     /// Execute a browser-level CDP command (no sessionId).
@@ -833,8 +933,18 @@ impl CdpSession {
                     let _ = tx.send(Ok(resp));
                 }
             } else if let Some(method) = resp.get("method").and_then(|v| v.as_str()) {
-                // Event: extract sessionId (empty string for browser-level events).
-                let session_id = resp.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+                // Event routing key:
+                // - extension bridge (protocol 0.3.0): event frame carries a
+                //   root-level `tabId` that identifies the source tab; derive
+                //   `tab:{tabId}` so per-tab subscribers stay separated.
+                // - local/cloud: CDP flat session — key by `sessionId`
+                //   (empty string for browser-level events).
+                let ext_tab_key = resp
+                    .get("tabId")
+                    .and_then(|v| v.as_u64())
+                    .map(|n| format!("tab:{n}"));
+                let session_id_str = resp.get("sessionId").and_then(|v| v.as_str()).unwrap_or("");
+                let session_id = ext_tab_key.as_deref().unwrap_or(session_id_str);
 
                 // Track cross-origin iframe sessions from Target.setAutoAttach.
                 match method {

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -211,6 +211,7 @@ async fn handle_browser(
                         profile: None,
                         executable_path: None,
                         open_url: None,
+                        tab_id: None,
                         cdp_endpoint: None,
                         provider: None,
                         header: vec![],

--- a/packages/cli/tests/e2e/extension_new_tab.rs
+++ b/packages/cli/tests/e2e/extension_new_tab.rs
@@ -1,0 +1,266 @@
+//! E2E scenarios for extension-mode **new-tab** flows — the paths we just
+//! patched or know are still broken.
+//!
+//! Requires:
+//!   RUN_E2E_TESTS=true
+//!   RUN_E2E_EXTENSION=true
+//!   Chrome running locally with the Actionbook extension loaded and connected
+//!   to the bridge at 127.0.0.1:19222 (verify via the extension popup
+//!   before running).
+//!
+//! Not gated into CI — the extension connection and a real Chrome window are
+//! not available there.
+//!
+//! Unix-only because the surrounding harness lsof helper is unix-only.
+
+#![cfg(unix)]
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::harness::{SoloEnv, parse_json, stderr_str, stdout_str, url_a, url_b};
+
+/// Serialize against the global bridge port 19222.
+static BRIDGE_PORT_LOCK: Mutex<()> = Mutex::new(());
+
+/// Both env gates must be set, otherwise skip.
+fn skip() -> bool {
+    std::env::var("RUN_E2E_TESTS")
+        .map(|v| v != "true")
+        .unwrap_or(true)
+        || std::env::var("RUN_E2E_EXTENSION")
+            .map(|v| v != "true")
+            .unwrap_or(true)
+}
+
+fn start_extension(env: &SoloEnv, session_id: &str, open_url: &str) {
+    let out = env.headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "extension",
+            "--set-session-id",
+            session_id,
+            "--open-url",
+            open_url,
+        ],
+        30,
+    );
+    assert!(
+        out.status.success(),
+        "browser start --mode extension failed — verify Chrome + Actionbook extension are running and popup shows Connected. stderr={}",
+        stderr_str(&out)
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 1. Open a single new tab after start, then goto it.
+//
+// Exercises the fix in `tab/open.rs`:
+//   a) extension branch uses Extension.createTab (not Target.createTarget)
+//   b) the new tab is register_extension_tab-ed so execute_on_tab can find it
+//
+// Extension.createTab auto-attaches the new tab, so the very first goto
+// against it does not need bridge switching — this should pass today.
+// ─────────────────────────────────────────────────────────────────────────
+#[test]
+fn open_new_tab_then_goto_works() {
+    if skip() {
+        return;
+    }
+    let _g = BRIDGE_PORT_LOCK.lock().unwrap();
+    let env = SoloEnv::new();
+
+    let session = "ext-open";
+    start_extension(&env, session, &url_a());
+
+    let out = env.headless_json(&["browser", "open", &url_b(), "--session", session], 20);
+    assert!(
+        out.status.success(),
+        "browser open (extension) failed: stdout={} stderr={}",
+        stdout_str(&out),
+        stderr_str(&out)
+    );
+    let v = parse_json(&out);
+    assert_eq!(v["ok"], true);
+    let new_tab_id = v["data"]["tab"]["tab_id"]
+        .as_str()
+        .expect("tab_id should be a string")
+        .to_string();
+
+    // Goto on the just-opened tab: Extension.createTab auto-attached, so this
+    // is also the bridge's currently attached tab.
+    let out = env.headless_json(
+        &[
+            "browser",
+            "goto",
+            &url_a(),
+            "--session",
+            session,
+            "--tab",
+            &new_tab_id,
+        ],
+        20,
+    );
+    assert!(
+        out.status.success(),
+        "goto on the just-opened extension tab failed — register_extension_tab missing? stderr={}",
+        stderr_str(&out)
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 2. Multi-tab switching — open a second tab, then operate on the FIRST tab.
+//
+// Extension.createTab switches the bridge's attachedTabId to the new tab,
+// so operating on the original tab now requires the bridge to auto-switch
+// via Extension.attachTab before the command. Without that wrapper in
+// CdpSession::execute_on_tab, this fails with:
+//   "No tab attached. Use Extension.attachTab first."
+//
+// **Expected to fail until the auto-switch fix lands.**
+// ─────────────────────────────────────────────────────────────────────────
+#[test]
+fn alternate_goto_between_two_tabs_requires_bridge_auto_switch() {
+    if skip() {
+        return;
+    }
+    let _g = BRIDGE_PORT_LOCK.lock().unwrap();
+    let env = SoloEnv::new();
+
+    let session = "ext-multi";
+    start_extension(&env, session, &url_a());
+    // t1 is the session's starting tab — currently attached.
+
+    // Open t2 — Extension.createTab switches bridge.attachedTabId to t2.
+    let out = env.headless_json(&["browser", "open", &url_b(), "--session", session], 20);
+    assert!(out.status.success(), "open second tab failed");
+    let t2 = parse_json(&out)["data"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Goto back on t1 — bridge is attached to t2, NOT t1.
+    // This is the scenario that currently returns "No tab attached" with the
+    // extension-side CDP allowlist.
+    let out = env.headless_json(
+        &[
+            "browser",
+            "goto",
+            &url_a(),
+            "--session",
+            session,
+            "--tab",
+            "t1",
+        ],
+        20,
+    );
+    assert!(
+        out.status.success(),
+        "goto on t1 after bridge switched to t2 failed — execute_on_tab needs an Extension.attachTab wrapper in extension mode. stderr={}",
+        stderr_str(&out)
+    );
+
+    // And the reverse direction — goto on t2 again should also work, because
+    // auto-switch brings bridge back to t2.
+    let out = env.headless_json(
+        &[
+            "browser",
+            "goto",
+            &url_a(),
+            "--session",
+            session,
+            "--tab",
+            &t2,
+        ],
+        20,
+    );
+    assert!(
+        out.status.success(),
+        "goto on t2 after bridge was brought back to t1 failed — auto-switch missing. stderr={}",
+        stderr_str(&out)
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// 3. batch-new-tab: open multiple tabs at once, then exercise each.
+//
+// `batch-open` in extension mode loops `Extension.createTab` per URL. The
+// bridge's attachedTabId ends up pinned to the LAST created tab, so only
+// the last batch tab is directly usable without auto-switch — goto on the
+// earlier ones is gated by the same switching gap as test #2.
+//
+// **Expected to partially fail until auto-switch lands** (last tab OK,
+// earlier tabs fail).
+// ─────────────────────────────────────────────────────────────────────────
+#[test]
+fn batch_new_tab_each_tab_usable_after() {
+    if skip() {
+        return;
+    }
+    let _g = BRIDGE_PORT_LOCK.lock().unwrap();
+    let env = SoloEnv::new();
+
+    let session = "ext-batch";
+    start_extension(&env, session, &url_a());
+
+    let out = env.headless_json(
+        &[
+            "browser",
+            "batch-new-tab",
+            "--urls",
+            &url_a(),
+            &url_b(),
+            "--session",
+            session,
+        ],
+        30,
+    );
+    assert!(
+        out.status.success(),
+        "batch-new-tab (extension) failed: stderr={}",
+        stderr_str(&out)
+    );
+    let v = parse_json(&out);
+    let tabs = v["data"]["tabs"]
+        .as_array()
+        .cloned()
+        .expect("data.tabs should be an array");
+    assert_eq!(tabs.len(), 2, "expected 2 tabs opened, got {}", tabs.len());
+
+    let tab_ids: Vec<String> = tabs
+        .iter()
+        .map(|t| t["tab_id"].as_str().unwrap().to_string())
+        .collect();
+
+    // Try goto on each. Under the current (no auto-switch) implementation,
+    // only the last tab is bridge-attached, so the first goto will fail.
+    let mut failures = Vec::new();
+    for tid in &tab_ids {
+        let out = env.headless_json(
+            &[
+                "browser",
+                "goto",
+                &url_a(),
+                "--session",
+                session,
+                "--tab",
+                tid,
+            ],
+            20,
+        );
+        if !out.status.success() {
+            failures.push(format!("tab {tid}: {}", stderr_str(&out)));
+        }
+        // small delay so consecutive attachTab switches on the bridge settle
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    assert!(
+        failures.is_empty(),
+        "goto failed on {}/{} batch-opened extension tabs:\n  {}",
+        failures.len(),
+        tab_ids.len(),
+        failures.join("\n  ")
+    );
+}

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -13,6 +13,85 @@ use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
+/// If `ACTIONBOOK_E2E_MODE` is set, rewrite every `browser start` in `args`
+/// to target that mode instead of whatever the test hardcoded.
+///
+/// For `extension` target also:
+///   - strip `--headless` / `--executable-path` / `--cdp-endpoint` (local-only
+///     flags clap would reject on extension or that have no meaning)
+///   - if neither `--open-url` nor `--tab-id` is present, inject
+///     `--open-url http://127.0.0.1:<local_server_port>/` so the tests can
+///     actually land on a page (protocol 0.3.0 requires one or the other)
+///
+/// Everything else (non-`browser start` commands, arg order, etc.) is left
+/// untouched so tests see identical context before and after start.
+fn effective_override_mode() -> Option<String> {
+    env::var("ACTIONBOOK_E2E_MODE")
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+fn remove_flag_with_value(v: &mut Vec<String>, flag: &str) {
+    let mut i = 0;
+    while i < v.len() {
+        if v[i] == flag {
+            v.remove(i);
+            if i < v.len() {
+                v.remove(i);
+            }
+        } else {
+            i += 1;
+        }
+    }
+}
+
+fn rewrite_args_for_mode(args: &[&str]) -> Vec<String> {
+    let Some(target_mode) = effective_override_mode() else {
+        return args.iter().map(|s| s.to_string()).collect();
+    };
+
+    let Some(start_idx) = args
+        .windows(2)
+        .position(|w| w[0] == "browser" && w[1] == "start")
+    else {
+        return args.iter().map(|s| s.to_string()).collect();
+    };
+
+    let mut out: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    let mut replaced = false;
+    let mut i = start_idx + 2;
+    while i + 1 < out.len() {
+        if out[i] == "--mode" {
+            out[i + 1] = target_mode.clone();
+            replaced = true;
+            break;
+        }
+        i += 1;
+    }
+    if !replaced {
+        out.insert(start_idx + 2, "--mode".to_string());
+        out.insert(start_idx + 3, target_mode.clone());
+    }
+
+    if target_mode == "extension" {
+        out.retain(|s| s != "--headless");
+        remove_flag_with_value(&mut out, "--executable-path");
+        remove_flag_with_value(&mut out, "--cdp-endpoint");
+
+        let has_open_url = out.iter().any(|s| s == "--open-url");
+        let has_tab_id = out.iter().any(|s| s == "--tab-id");
+        if !has_open_url && !has_tab_id {
+            let default_url = format!("http://127.0.0.1:{}/", local_server().port);
+            out.insert(start_idx + 2, "--open-url".to_string());
+            out.insert(start_idx + 3, default_url);
+        }
+    }
+
+    out
+}
+
 /// Run a CLI command with a real timeout, avoiding pipe-inheritance hangs on Windows.
 ///
 /// On Windows, `assert_cmd::Command::output()` pipes stdout/stderr. When the CLI
@@ -26,6 +105,9 @@ fn run_cli_with_timeout(
     extra_env: &[(&str, &str)],
     timeout_secs: u64,
 ) -> Output {
+    let rewritten = rewrite_args_for_mode(args);
+    let args: Vec<&str> = rewritten.iter().map(String::as_str).collect();
+    let args = args.as_slice();
     #[cfg(windows)]
     {
         let stdout_file = tempfile::NamedTempFile::new().expect("create stdout temp file");
@@ -233,11 +315,61 @@ impl Drop for SoloEnv {
 
 // ── Gate ────────────────────────────────────────────────────────────
 
+/// Test-name substrings that are inherently incompatible with extension-mode
+/// rewrite (`ACTIONBOOK_E2E_MODE=extension`):
+///   - `cloud_mode::*` — talks to a mock cloud CDP endpoint, not the bridge
+///   - `concurrent_two_sessions` / `cross_session` — extension bridge is
+///     1 CDP client per daemon, multi-session in one daemon cannot race
+///   - `headless` tests — extension uses the host Chrome window, not headless
+///   - `windows_daemon::*` — Windows-specific daemon path, unrelated to
+///     extension
+const EXTENSION_INCOMPATIBLE_SUBSTRINGS: &[&str] = &[
+    "cloud_mode::",
+    "concurrent_two_sessions",
+    "cross_session",
+    "windows_daemon::",
+    "_headless",
+    "lifecycle_open_headless",
+];
+
 /// Returns `true` when E2E tests should be skipped.
+///
+/// Skip conditions:
+///   1. `RUN_E2E_TESTS != "true"` — e2e suite gate
+///   2. `ACTIONBOOK_E2E_MODE=extension` AND the current test's name matches
+///      any substring in `EXTENSION_INCOMPATIBLE_SUBSTRINGS` — these tests
+///      cannot pass under extension-bridge semantics and are skipped by
+///      design when running the extension-mode regression pass
 pub fn skip() -> bool {
-    env::var("RUN_E2E_TESTS")
+    if env::var("RUN_E2E_TESTS")
         .map(|v| v != "true")
         .unwrap_or(true)
+    {
+        return true;
+    }
+
+    if let Ok(m) = env::var("ACTIONBOOK_E2E_MODE")
+        && m == "extension"
+    {
+        let thread = std::thread::current();
+        let name = thread.name().unwrap_or("");
+        if EXTENSION_INCOMPATIBLE_SUBSTRINGS
+            .iter()
+            .any(|pat| name.contains(pat))
+        {
+            eprintln!(
+                "(skipping {name}: incompatible with extension mode — matches '{}')",
+                EXTENSION_INCOMPATIBLE_SUBSTRINGS
+                    .iter()
+                    .find(|p| name.contains(*p))
+                    .copied()
+                    .unwrap_or("?")
+            );
+            return true;
+        }
+    }
+
+    false
 }
 
 // ── Local HTTP server ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Silent bug fixed**: extension bridge was single-attach + no tab routing, so `snapshot --tab t1` could silently return t2's data with no error. Agents making decisions on wrong-tab data was the worst failure mode.
- Protocol 0.3.0: every CDP request/event carries a root-level `tabId`; bridge/extension route by it. Multi-tab concurrent debug is now first-class.
- Removed implicit "active tab" default. `browser start --mode extension` requires `--open-url` OR new `--tab-id <native>` flag; missing both → `MISSING_TAB_TARGET` with actionable hint.
- Allowlist expanded 14 methods (DOM.resolveNode, DOM.describeNode, Runtime.callFunctionOn, Accessibility.queryAXTree, etc.) that were silently rejected before, which broke every ref-based `click`/`inspect` on every page.

## Why

Real user-facing bugs surfaced during multi-tab testing:

| Scenario | Before | After |
|---|---|---|
| `snapshot --tab t1` then `--tab t2` then `--tab t1` | t1 returns t2 URL silently | each tab returns correct URL |
| `click @eN` | `REF_STALE` on every page | works |
| `browser open <url>` (extension) | `Method not allowed: Target.createTarget` | creates tab via Extension.createTab |
| `goto` on a tab created by `browser open` | `INTERNAL_ERROR no CDP session for target` | works |

Full failure analysis in `/Users/junliangfeng/.claude/plans/refactored-forging-hinton.md`.

**Breaking change**: older extension (0.2.x) is hard-rejected by new bridge; users MUST reload the extension in `chrome://extensions/` after upgrading CLI. Bridge's existing `hello_error` mechanism guides users to reload.

## What's in this PR

Commit `e65643e2` — tab open path fixes:
- `tab/open.rs`, `tab/batch_open.rs` branch on `Mode::Extension` and use `Extension.createTab` instead of `Target.createTarget`
- `tab/open.rs`, `tab/batch_open.rs`, `tab/list.rs` always call `register_extension_tab` so `execute_on_tab` can find every live tab (covers tabs created by pre-fix binary or carried across daemon restarts)

Commit `5743308d` — multi-tab protocol:
- Extension: `attachedTabs: Set<number>`, multi-attach, `handleCdpCommand(id, method, params, tabId)`, event forwarding includes source tabId, version 0.3.0, CDP allowlist expanded
- Bridge: `is_version_ok` ≥ 0.3.0
- CdpSession: `is_extension_bridge` flag; `execute_on_tab` injects root `tabId` + self-heals on "Tab N not attached"; `reader_loop` routes events via root `tabId`
- CLI start: `--tab-id <native>` parameter; `attachActiveTab` branch removed; `MISSING_TAB_TARGET` when neither `--open-url` nor `--tab-id` given

## Test plan

- [x] `cargo test -p actionbook-cli --lib` → 355/355 green
- [x] Build + reload extension, manual verify:
  - Multi-tab snapshot routing (t1/t2 interleaved, each returns correct URL)
  - `browser open` new tab + goto/click on it
  - `--tab-id <native>` attach to pre-existing Chrome tab
  - close-tab then operate → `TAB_NOT_FOUND` (CLI-layer early exit)
  - `daemon restart` → SESSION_NOT_FOUND (registry wiped, expected)
- [ ] E2E harness now supports `ACTIONBOOK_E2E_MODE=extension` to rewrite all existing `browser start --mode local` → `--mode extension` for full-suite extension regression — follow-up commit will add default `--open-url` injection

## Known follow-ups
- Extension popup.js/html still references old single-attach state; cosmetic (popup won't show attached tab list until updated)
- `cargo clippy` E2E harness run under `RUN_E2E_TESTS=true ACTIONBOOK_E2E_MODE=extension` — pending full-suite pass once harness injects `--open-url` default