### PR TITLE
[packages/actionbook-extension]feat: release 0.3.0

### DIFF
--- a/.changeset/extension-0-3-0.md
+++ b/.changeset/extension-0-3-0.md
@@ -1,0 +1,9 @@
+---
+"@actionbookdev/extension": minor
+---
+
+Release 0.3.0: align extension bridge with Actionbook CLI 1.0.0.
+
+- Support CLI 1.0.0 stateless architecture — every message is self-contained with explicit `--session`/`--tab` addressing, no implicit current-tab state.
+- Concurrent multi-tab operation: bridge protocol upgraded to handle parallel CDP traffic across multiple tabs in a single session.
+- Health check on startup to prevent connect/disconnect loops.

--- a/.changeset/extension-0-3-0.md
+++ b/.changeset/extension-0-3-0.md
@@ -2,8 +2,8 @@
 "@actionbookdev/extension": minor
 ---
 
-Release 0.3.0: align extension bridge with Actionbook CLI 1.0.0.
+Release 0.3.0: align extension bridge with Actionbook CLI 1.x.
 
-- Support CLI 1.0.0 stateless architecture — every message is self-contained with explicit `--session`/`--tab` addressing, no implicit current-tab state.
+- Support CLI 1.x stateless architecture — every message is self-contained with explicit `--session`/`--tab` addressing, no implicit current-tab state.
 - Concurrent multi-tab operation: bridge protocol upgraded to handle parallel CDP traffic across multiple tabs in a single session.
 - Health check on startup to prevent connect/disconnect loops.


### PR DESCRIPTION
## Summary
- Release `@actionbookdev/extension` 0.2.2 → 0.3.0 (minor)
- Aligns extension bridge with Actionbook CLI 1.0.0: stateless addressing, concurrent multi-tab support, startup health check
- Includes CLI output change showing Chrome load instructions after extension install (no changeset — not republishing CLI)

## Test plan
- [ ] Merge triggers Changesets "Version Packages" PR bumping extension to 0.3.0
- [ ] After Version PR merges, CI publishes extension ZIP to GitHub Release
- [ ] Verify no other packages are version-bumped