### PR TITLE
docs: 1.4.3 release prep — extension, daemon, version bump

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -295,3 +295,32 @@ actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
 ```
 
 ---
+
+## `actionbook extension`
+
+Manage the Chrome extension used by extension mode. The extension bridge runs inside the actionbook daemon (auto-started by browser commands).
+
+```bash
+actionbook extension status                   # Bridge status + extension connection state
+actionbook extension ping                     # Measure bridge RTT
+actionbook extension install                  # Install extension to ~/.actionbook/extension/
+actionbook extension install --force          # Force reinstall
+actionbook extension uninstall                # Remove extension
+actionbook extension path                     # Print install path, status, and version
+```
+
+`extension status` returns the bridge state (`listening`, `not_listening`, or `failed`) and whether the extension is connected. `extension ping` connects to the bridge WebSocket at `ws://127.0.0.1:19222` and measures round-trip time.
+
+After `extension install`, load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, using the path from `extension path`.
+
+---
+
+## `actionbook daemon`
+
+The actionbook daemon runs in the background and manages browser sessions. It auto-starts on the first CLI call.
+
+```bash
+actionbook daemon restart                     # Stop the running daemon (next CLI call respawns)
+```
+
+---

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -127,11 +127,12 @@ If you've configured `mode = "extension"` in your config file, you only need to 
 
   <Step title="Verify with any browser command">
     ```bash
-    actionbook browser open "https://example.com"
-    actionbook browser snapshot
+    actionbook browser start --set-session-id s1
+    actionbook browser goto "https://example.com" --session s1 --tab t1
+    actionbook browser snapshot --session s1 --tab t1
     ```
 
-    The bridge auto-starts in the background and the extension auto-connects within a few seconds.
+    The extension bridge (part of the actionbook daemon) auto-starts in the background and the extension auto-connects within a few seconds.
   </Step>
 
   <Step title="Fallback: local debug install (only if Web Store install fails)">
@@ -152,6 +153,20 @@ If you've configured `mode = "extension"` in your config file, you only need to 
   </Step>
 </Steps>
 
+### Extension Commands
+
+The `actionbook extension` commands manage the Chrome extension and its connection to the actionbook daemon.
+
+```bash
+actionbook extension status                   # Bridge status + extension connection state
+actionbook extension ping                     # Measure bridge RTT
+actionbook extension install                  # Install extension to ~/.actionbook/extension/
+actionbook extension install --force          # Force reinstall
+actionbook extension uninstall                # Remove extension from disk
+actionbook extension path                     # Print install path, status, and version
+```
+
+The extension bridge runs inside the actionbook daemon (auto-started by browser commands). `extension status` shows whether the bridge is listening and the extension is connected. `extension ping` tests connectivity by connecting to the bridge WebSocket at `ws://127.0.0.1:19222`.
 
 ## Configuration
 

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -457,6 +457,7 @@ Usage: actionbook <command> [options]
 
 Commands:
   browser           Control browser sessions, tabs, and page interactions
+  extension         Manage the Chrome extension (status, ping, install, uninstall, path)
   daemon restart    Stop the running daemon (next CLI call auto-respawns one)
   setup             Configure actionbook (or --target <agent> for quick skills install)
   help       Show this help

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: actionbook
 description: Browser action engine. Provides up-to-date action manuals for the modern web — operate any website instantly, one tab or dozens, concurrently.
-version: 1.3.0
+version: 1.4.3
 license: MIT
 platforms: [macos, linux, windows]
 metadata:
@@ -82,6 +82,8 @@ All commands support `--help` for full usage and examples.
 | Network | `network requests`, `network request <id>` | `actionbook browser network requests --help` |
 | Query | `query one\|all\|nth\|count` | `actionbook browser query --help` |
 | Batch | `batch-new-tab`, `batch-snapshot`, `batch-click` | `actionbook browser batch-new-tab --help` |
+| Extension | `extension status`, `extension ping`, `extension install`, `extension uninstall`, `extension path` | `actionbook extension status --help` |
+| Daemon | `daemon restart` | `actionbook daemon restart --help` |
 
 Full command reference: [command-reference.md](references/command-reference.md)
 

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -293,6 +293,31 @@ actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
 
 `batch-new-tab` (alias `batch-open`) opens each URL as a new tab. If `--tabs` is provided, its length must match `--urls`. `batch-click` stops on first failure and reports progress. `batch-snapshot` returns per-tab results (ok or error).
 
+## Extension
+
+Manage the Chrome extension used by extension mode. The extension bridge runs inside the actionbook daemon (auto-started by browser commands).
+
+```bash
+actionbook extension status                          # Bridge status + extension connection state
+actionbook extension ping                            # Measure bridge RTT (connects to ws://127.0.0.1:19222)
+actionbook extension install                         # Install extension to ~/.actionbook/extension/
+actionbook extension install --force                 # Force reinstall even if up to date
+actionbook extension uninstall                       # Remove extension from ~/.actionbook/extension/
+actionbook extension path                            # Print install path, installed status, and version
+```
+
+`extension status` returns `bridge` state (`listening`, `not_listening`, or `failed`) and `extension_connected` (boolean). `extension ping` connects directly to the bridge WebSocket and measures round-trip time.
+
+After `extension install`, load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, pointing to the path from `extension path`.
+
+## Daemon
+
+The actionbook daemon runs in the background and manages browser sessions. It auto-starts on first CLI call.
+
+```bash
+actionbook daemon restart                            # Stop the running daemon (next CLI call respawns)
+```
+
 ## Setup
 
 ```bash


### PR DESCRIPTION
## Summary

- Add documentation for the 5 `actionbook extension` subcommands (`status`, `ping`, `install`, `uninstall`, `path`) across help text, SKILL.md, command reference, CLI reference, and browser guide
- Add `actionbook daemon restart` documentation to command reference and CLI reference
- Bump SKILL.md version from 1.3.0 to 1.4.3
- Clarify that the extension bridge runs inside the actionbook daemon service
- Fix extension mode verify step in browser guide to use `--session`/`--tab` flags

## Files changed

| File | Change |
|------|--------|
| `packages/cli/src/main.rs` | Added `extension` to `handle_help()` Commands list |
| `skills/actionbook/references/command-reference.md` | Added Extension (5 commands) and Daemon sections |
| `docs/api-reference/cli.mdx` | Added `actionbook extension` and `actionbook daemon` sections |
| `skills/actionbook/SKILL.md` | Version bump 1.3.0 → 1.4.3, added Extension/Daemon rows |
| `docs/guides/browser.mdx` | Fixed extension verify step, added Extension Commands subsection |

## Test plan

- [ ] Verify `actionbook extension status --help` matches documented behavior
- [ ] Verify `actionbook extension ping` connects to `ws://127.0.0.1:19222`
- [ ] Verify `actionbook extension install` installs to `~/.actionbook/extension/`
- [ ] Verify `actionbook daemon restart` stops the daemon
- [ ] Confirm SKILL.md version matches package version

🤖 Generated with [Claude Code](https://claude.com/claude-code)