### PR TITLE
feat(cli): expose required extension version (>= 0.3.0) in extension commands

### DIFF
--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -47,7 +47,7 @@ const BIND_RETRY_DELAYS_MS: &[u64] = &[100, 500, 1_000, 2_000, 5_000];
 /// - extension uses `attachedTabs: Set<number>` instead of a single attach
 /// - older extensions (0.2.x) are rejected and asked to reload — the
 ///   single-attach protocol cannot be mixed with the multi-attach client.
-const PROTOCOL_VERSION: &str = "0.3.0";
+const PROTOCOL_VERSION: &str = crate::EXTENSION_PROTOCOL_MIN_VERSION;
 
 /// Known Actionbook Chrome extension IDs.
 const EXTENSION_ID_CWS: &str = "bebchpafpemheedhcdabookaifcijmfo";

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -151,6 +151,7 @@ pub fn execute_path() -> ActionResult {
         "path": dir.to_string_lossy(),
         "installed": installed,
         "version": version,
+        "required_version": crate::EXTENSION_PROTOCOL_MIN_VERSION,
     }))
 }
 
@@ -214,6 +215,7 @@ fn extract_bundled(dst: &Path) -> ActionResult {
     ActionResult::ok(json!({
         "path": dst.to_string_lossy(),
         "version": version,
+        "required_version": crate::EXTENSION_PROTOCOL_MIN_VERSION,
     }))
 }
 
@@ -237,6 +239,7 @@ fn copy_from_dir(src: &Path, dst: &Path) -> ActionResult {
     ActionResult::ok(json!({
         "path": dst.to_string_lossy(),
         "version": version,
+        "required_version": crate::EXTENSION_PROTOCOL_MIN_VERSION,
     }))
 }
 

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -1,5 +1,9 @@
 pub const BUILD_VERSION: &str = env!("BUILD_VERSION");
 
+/// Minimum extension protocol version required to connect to the daemon.
+/// Extensions reporting a lower version will be rejected with version_mismatch.
+pub const EXTENSION_PROTOCOL_MIN_VERSION: &str = "0.3.0";
+
 pub mod action;
 pub mod action_result;
 pub mod api;

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -361,6 +361,7 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                 "required_version: >= {}",
                 crate::EXTENSION_PROTOCOL_MIN_VERSION
             ));
+            lines.push("  (check version at chrome://extensions/)".to_string());
         }
         "extension ping" => {
             if let Some(bridge) = data.get("bridge").and_then(|v| v.as_str()) {
@@ -382,6 +383,7 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             }
             if let Some(required) = data.get("required_version").and_then(|v| v.as_str()) {
                 lines.push(format!("required_version: >= {required}"));
+                lines.push("  (check version at chrome://extensions/)".to_string());
             }
         }
         "extension install" => {
@@ -393,6 +395,7 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             }
             if let Some(required) = data.get("required_version").and_then(|v| v.as_str()) {
                 lines.push(format!("required_version: >= {required}"));
+                lines.push("  (check version at chrome://extensions/)".to_string());
             }
             lines.push(String::new());
             lines.push("To load the extension in Chrome:".to_string());
@@ -1204,7 +1207,7 @@ mod tests {
 
         assert_eq!(
             text,
-            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\nrequired_version: >= 0.3.0\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
+            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
         );
     }
 
@@ -1219,7 +1222,7 @@ mod tests {
 
         assert_eq!(
             text,
-            "bridge: listening\nextension_connected: true\nrequired_version: >= 0.3.0"
+            "bridge: listening\nextension_connected: true\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)"
         );
     }
 
@@ -1236,7 +1239,7 @@ mod tests {
 
         assert_eq!(
             text,
-            "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.3.0"
+            "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)"
         );
     }
 }

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -357,6 +357,10 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             {
                 lines.push(format!("extension_connected: {extension_connected}"));
             }
+            lines.push(format!(
+                "required_version: >= {}",
+                crate::EXTENSION_PROTOCOL_MIN_VERSION
+            ));
         }
         "extension ping" => {
             if let Some(bridge) = data.get("bridge").and_then(|v| v.as_str()) {
@@ -376,6 +380,9 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             if let Some(version) = data.get("version").and_then(|v| v.as_str()) {
                 lines.push(format!("version: {version}"));
             }
+            if let Some(required) = data.get("required_version").and_then(|v| v.as_str()) {
+                lines.push(format!("required_version: >= {required}"));
+            }
         }
         "extension install" => {
             if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
@@ -383,6 +390,9 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             }
             if let Some(version) = data.get("version").and_then(|v| v.as_str()) {
                 lines.push(format!("version: {version}"));
+            }
+            if let Some(required) = data.get("required_version").and_then(|v| v.as_str()) {
+                lines.push(format!("required_version: >= {required}"));
             }
             lines.push(String::new());
             lines.push("To load the extension in Chrome:".to_string());
@@ -1187,13 +1197,14 @@ mod tests {
         let result = ActionResult::ok(json!({
             "path": "/Users/test/.actionbook/extension",
             "version": "1.4.3-alpha",
+            "required_version": "0.3.0",
         }));
 
         let text = format_text("extension install", &None, &result);
 
         assert_eq!(
             text,
-            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
+            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\nrequired_version: >= 0.3.0\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
         );
     }
 
@@ -1206,7 +1217,10 @@ mod tests {
 
         let text = format_text("extension status", &None, &result);
 
-        assert_eq!(text, "bridge: listening\nextension_connected: true");
+        assert_eq!(
+            text,
+            "bridge: listening\nextension_connected: true\nrequired_version: >= 0.3.0"
+        );
     }
 
     #[test]
@@ -1215,13 +1229,14 @@ mod tests {
             "path": "/Users/test/.actionbook/extension",
             "installed": false,
             "version": null,
+            "required_version": "0.3.0",
         }));
 
         let text = format_text("extension path", &None, &result);
 
         assert_eq!(
             text,
-            "path: /Users/test/.actionbook/extension\ninstalled: false"
+            "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.3.0"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Added `EXTENSION_PROTOCOL_MIN_VERSION` constant to `lib.rs` as the single source of truth for the minimum required extension protocol version
- `bridge.rs` now references the shared constant instead of a local hardcoded string
- `extension path`, `extension status`, and `extension install` all output `required_version: >= 0.3.0` so users know what version is required before connecting

## Output after this change

**`actionbook extension path`**
```
path: ~/Actionbook/extension
installed: true
version: 0.3.1
required_version: >= 0.3.0
```

**`actionbook extension status`**
```
bridge: listening
extension_connected: false
required_version: >= 0.3.0
```

**`actionbook extension install`**
```
ok extension install
path: ~/Actionbook/extension
version: 0.3.1
required_version: >= 0.3.0

To load the extension in Chrome:
  1. Open chrome://extensions/
  2. Enable Developer mode
  3. If a previous version is loaded, click Remove first
  4. Click "Load unpacked" and select the path above
```

## Test plan

- [ ] `cargo test extension` passes (12 unit + 5 e2e tests)
- [ ] Run `actionbook extension path` and confirm `required_version` is shown
- [ ] Run `actionbook extension status` and confirm `required_version` is shown
- [ ] Run `actionbook extension install` and confirm `required_version` is shown