### PR TITLE
chore: version packages — @actionbookdev/cli@1.4.3

### DIFF
--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-darwin-arm64",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for macOS ARM64",
   "os": [
     "darwin"

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-darwin-x64",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for macOS x64",
   "os": [
     "darwin"

--- a/packages/cli-linux-arm64-gnu/package.json
+++ b/packages/cli-linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-linux-arm64-gnu",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for Linux ARM64 (glibc)",
   "os": [
     "linux"

--- a/packages/cli-linux-x64-gnu/package.json
+++ b/packages/cli-linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-linux-x64-gnu",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for Linux x64 (glibc)",
   "os": [
     "linux"

--- a/packages/cli-win32-arm64/package.json
+++ b/packages/cli-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-win32-arm64",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for Windows ARM64",
   "os": [
     "win32"

--- a/packages/cli-win32-x64/package.json
+++ b/packages/cli-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-win32-x64",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Actionbook CLI native binary for Windows x64",
   "os": [
     "win32"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @actionbookdev/cli
 
+## 1.4.3
+
+### Patch Changes
+
+- Extension mode multi-tab support, eval improvements, and CLI enhancements.
+
+  - **Extension protocol 0.3.0**: concurrent multi-tab debugging with explicit `tabId` routing — fixes silent tab mis-routing where `snapshot --tab t1` could return data from the wrong tab. Breaking: extension must be reloaded after CLI upgrade.
+  - **Extension commands restored**: `extension install`, `uninstall`, `status`, `ping`, `path` — manage the Chrome extension lifecycle from the CLI. Extension files are now bundled in the binary.
+  - **Eval scope isolation** (default): repeated `let`/`const` declarations on the same tab no longer throw `SyntaxError`. Use `--no-isolate` for the old behavior. Eval responses now include `pre_url`, `pre_origin`, `pre_readyState` context and structured error details.
+  - **Select diagnostics**: `browser select` now shows available values, visible texts, and match mode when an option is not found.
+  - **Network enhancements**: `browser start --max-tracked-requests N` for configurable buffer size (default 500), `browser network requests --dump --out <dir>` to export requests with response bodies to disk.
+  - **Daemon restart**: new `actionbook daemon restart` command with lazy bridge start and port-holder diagnosis.
+  - **Extension bridge health check**: startup waits for bridge readiness to prevent connect/disconnect loops.
+  - Expanded CDP allowlist with 14 additional methods (DOM.resolveNode, Runtime.callFunctionOn, Accessibility.queryAXTree, etc.) that were previously silently rejected in extension mode.
+
 ## 1.4.2
 
 ### Patch Changes

--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "actionbook-cli"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "actionbook-cli"
-version = "1.4.2"
+version = "1.4.3"
 edition = "2024"
 description = "Actionbook CLI - Browser automation for AI agents"
 license = "MIT"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": false,
   "description": "Actionbook CLI - Browser automation for AI agents",
   "bin": {


### PR DESCRIPTION
## Summary
- Bump `@actionbookdev/cli` from 1.4.2 → 1.4.3 (patch)
- Sync all 6 platform packages, Cargo.toml, Cargo.lock
- Generated via `pnpm version-packages` (changeset version + sync-versions.js)

## Changelog highlights
- Extension protocol 0.3.0: concurrent multi-tab + explicit tabId
- Extension commands restored: install/uninstall/status/ping/path
- Eval scope isolation (default), pre-context, structured errors
- Select diagnostic details on option-not-found
- Network enhancements: --max-tracked-requests, --dump --out
- Daemon restart command + lazy bridge start
- 14 new CDP methods in extension allowlist

## Test plan
- [ ] CI green (version-only changes, no code diff)
- [ ] After merge, release.yml triggers build + publish