### PR TITLE
[root]docs: fix hermes actionbook skill install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ npx skills add actionbook/actionbook
 **Hermes** — one command (registers the skill in `~/.hermes/skills/`):
 
 ```bash
-hermes skills install actionbook -y
+hermes skills install skills-sh/actionbook/actionbook/actionbook -y
 ```
 
 Then start a chat and say things like *"use actionbook to open google.com and search for anthropic"*. Hermes auto-activates the skill and drives the CLI for you.


### PR DESCRIPTION
## Summary
- Update README Hermes install command to use the full skill path `skills-sh/actionbook/actionbook/actionbook`.

## Test plan
- [ ] Verify README renders correctly on GitHub