### PR TITLE
[extension] group Actionbook tabs + fix HAR recording/output

### DIFF
--- a/packages/actionbook-extension/CHANGELOG.md
+++ b/packages/actionbook-extension/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @actionbookdev/extension
 
+## 0.4.0
+
+### Minor Changes
+
+- Group Actionbook-opened tabs into a dedicated Chrome tab group.
+
+  - Tabs opened via `Extension.createTab` (including the reuse-empty-tab path) are automatically moved into a per-window tab group titled "Actionbook" (blue). Makes it easy to tell agent-driven tabs apart from your own and bulk-collapse/close them.
+  - Adds the `tabGroups` permission to the extension manifest.
+  - New popup toggle "Group Actionbook tabs" (default on); preference persists in `chrome.storage.local` under `groupTabs`.
+  - User-attached existing tabs (`Extension.attachTab`) are **not** moved by default — controlled by the internal `ACTIONBOOK_GROUP_ATTACH` flag to preserve user intent.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -10,6 +10,21 @@ const BRIDGE_PROBE_TIMEOUT_MS = 750;
 const HANDSHAKE_TIMEOUT_MS = 2000;
 const L3_CONFIRM_TIMEOUT_MS = 30000;
 
+// --- Tab Group Config ---
+// All tabs opened by Actionbook (via Extension.createTab or the reuse-empty-tab
+// path) are moved into a per-window Chrome tab group titled "Actionbook" so
+// users can tell agent-driven tabs apart at a glance and collapse/close them
+// in bulk. The group is looked up by title in the tab's own window — we do
+// NOT persist groupId, since it's unstable across sessions and windows.
+const ACTIONBOOK_GROUP_TITLE = "Actionbook";
+const ACTIONBOOK_GROUP_COLOR = "grey";
+// When true, tabs that the user explicitly attaches via Extension.attachTab
+// are also moved into the group. Default false: don't yank a user's existing
+// tab into the Actionbook group without their knowledge.
+const ACTIONBOOK_GROUP_ATTACH = false;
+// User-facing toggle (chrome.storage.local key: "groupTabs"). Default on.
+let groupingEnabled = true;
+
 // --- CDP Method Allowlist ---
 
 const CDP_ALLOWLIST = {
@@ -401,6 +416,48 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
   }
 });
 
+// --- Tab Group Helper ---
+
+// Move a tab into the Actionbook group in its current window, creating the
+// group if none exists there. All failures are swallowed: grouping is a UX
+// nicety and must never break the CDP command that triggered it. Callers
+// should not await any particular outcome — treat this as fire-and-log.
+async function ensureTabInActionbookGroup(tabId) {
+  if (!groupingEnabled) return;
+  if (typeof tabId !== "number") return;
+  // tabGroups API availability guard — if user loaded an older build without
+  // the permission, skip silently instead of throwing.
+  if (!chrome.tabGroups || !chrome.tabs.group) return;
+
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (!tab || typeof tab.windowId !== "number") return;
+
+    // Look up an existing Actionbook group in THIS window. groupId must be
+    // scoped per-window: passing a cross-window groupId to chrome.tabs.group
+    // would move the tab to the group's window, which is not what we want.
+    const existing = await chrome.tabGroups.query({
+      title: ACTIONBOOK_GROUP_TITLE,
+      windowId: tab.windowId,
+    });
+
+    if (existing && existing.length > 0) {
+      await chrome.tabs.group({ groupId: existing[0].id, tabIds: [tabId] });
+    } else {
+      const groupId = await chrome.tabs.group({
+        tabIds: [tabId],
+        createProperties: { windowId: tab.windowId },
+      });
+      await chrome.tabGroups.update(groupId, {
+        title: ACTIONBOOK_GROUP_TITLE,
+        color: ACTIONBOOK_GROUP_COLOR,
+      });
+    }
+  } catch (err) {
+    debugLog("[actionbook] ensureTabInActionbookGroup failed:", err?.message || err);
+  }
+}
+
 const REUSABLE_EMPTY_TAB_URLS = new Set([
   "about:blank",
   "about:newtab",
@@ -426,10 +483,12 @@ async function createOrReuseTab(targetUrl) {
   ) {
     const reusableTab = tabsInCurrentWindow[0];
     const tab = await chrome.tabs.update(reusableTab.id, { url: targetUrl, active: true });
+    await ensureTabInActionbookGroup(tab.id);
     return { tab, reused: true };
   }
 
   const tab = await chrome.tabs.create({ url: targetUrl });
+  await ensureTabInActionbookGroup(tab.id);
   return { tab, reused: false };
 }
 
@@ -511,6 +570,11 @@ async function handleExtensionCommand(id, method, params) {
         } catch (err) {
           return { id, error: { code: -32000, message: `attach failed: ${err.message}` } };
         }
+      }
+      // Opt-in: only move user-attached existing tabs into the group when
+      // ACTIONBOOK_GROUP_ATTACH is true. Default false preserves user intent.
+      if (ACTIONBOOK_GROUP_ATTACH) {
+        await ensureTabInActionbookGroup(tabId);
       }
       broadcastState();
       return {
@@ -983,6 +1047,17 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // Offscreen document keep-alive ping - just acknowledge
     return false;
   }
+  if (message.type === "getGrouping") {
+    sendResponse({ enabled: groupingEnabled });
+    return true;
+  }
+  if (message.type === "setGrouping") {
+    // Only trust the popup — other senders cannot flip grouping
+    if (!isSenderPopup(sender)) return false;
+    groupingEnabled = message.enabled === true;
+    chrome.storage.local.set({ groupTabs: groupingEnabled });
+    return false;
+  }
   return false;
 });
 
@@ -1029,6 +1104,16 @@ function stopBridgePolling() {
 ensureOffscreenDocument();
 lastLoggedState = "idle";
 debugLog("[actionbook] Background service worker started");
+
+// Load the user's tab-grouping preference (default on). Kept fully async:
+// the few grouping calls that might race this load will just see the default
+// value, which is the safer fallback.
+chrome.storage.local.get("groupTabs", (result) => {
+  if (typeof result?.groupTabs === "boolean") {
+    groupingEnabled = result.groupTabs;
+  }
+});
+
 // Try immediate connect, then keep polling fixed ws://127.0.0.1:19222.
 connect();
 startBridgePolling();

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -1048,6 +1048,8 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return false;
   }
   if (message.type === "getGrouping") {
+    // Match the setter's sender check — only the popup reads this state.
+    if (!isSenderPopup(sender)) return false;
     sendResponse({ enabled: groupingEnabled });
     return true;
   }

--- a/packages/actionbook-extension/manifest.json
+++ b/packages/actionbook-extension/manifest.json
@@ -1,12 +1,13 @@
 {
   "manifest_version": 3,
   "name": "Actionbook",
-  "version": "0.3.0",
+  "version": "0.4.0.3",
   "description": "Bridge between Actionbook CLI and your browser for AI-powered automation",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5xhsOXoi029BKiQTCV7UTZd/f/nzgW6JerV8XfbJLOEr+gHAVNU6J+2Yq3DvTE7+Tnx9EW9jQNGtE4ZXXaGpkvpkcP2ch3ggQQFpjOvHdlVGljepRB2gJivGWR5ooQ1QPWAyxwDLeA09/w2oZ54W9RMXeuzfjv1KRceq9FHlmkIIGaaqYfLzrQbbE7GSV1DSeRG1kG0f7Km2wUsuNDCINI6XyBbhM+662Clurs1GdP7S+Gw/+N/97YEY8Ir2smotGTknHmHuUl5N2XXJjhxfaCT85DkaMV0Kn9D9pVczK4xgqGypplCna5I61YjNDMrymA25qLNKQv2nf/mv7Y7l9wIDAQAB",
   "permissions": [
     "debugger",
     "tabs",
+    "tabGroups",
     "activeTab",
     "offscreen",
     "storage",

--- a/packages/actionbook-extension/package.json
+++ b/packages/actionbook-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/extension",
-  "version": "0.3.0",
+  "version": "0.4.0-alpha.3",
   "private": true,
   "description": "Actionbook Chrome Extension - Bridge for CLI-to-browser communication",
   "scripts": {

--- a/packages/actionbook-extension/popup.html
+++ b/packages/actionbook-extension/popup.html
@@ -167,6 +167,21 @@
       font-size: 11px;
       color: #999;
     }
+    .settings-row {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 0;
+      border-bottom: 1px solid #f0f0f0;
+    }
+    .settings-row label {
+      flex: 1;
+      color: #444;
+      cursor: pointer;
+    }
+    .settings-row input[type="checkbox"] {
+      cursor: pointer;
+    }
   </style>
 </head>
 <body>
@@ -185,6 +200,11 @@
     <span class="dot" id="tabDot"></span>
     <span class="label">Tab</span>
     <span class="value" id="tabStatus">--</span>
+  </div>
+
+  <div class="settings-row">
+    <label for="groupTabsToggle">Group Actionbook tabs</label>
+    <input type="checkbox" id="groupTabsToggle" checked>
   </div>
 
   <div class="token-section hidden" id="tokenSection">

--- a/packages/actionbook-extension/popup.js
+++ b/packages/actionbook-extension/popup.js
@@ -144,6 +144,21 @@ chrome.storage.local.get("bridgeToken", (result) => {
   }
 });
 
+// Tab-grouping toggle — reflects and writes background's in-memory
+// groupingEnabled flag; background persists to chrome.storage.local.
+const groupTabsToggle = document.getElementById("groupTabsToggle");
+chrome.runtime.sendMessage({ type: "getGrouping" }, (response) => {
+  if (response && typeof response.enabled === "boolean") {
+    groupTabsToggle.checked = response.enabled;
+  }
+});
+groupTabsToggle.addEventListener("change", () => {
+  chrome.runtime.sendMessage({
+    type: "setGrouping",
+    enabled: groupTabsToggle.checked,
+  });
+});
+
 // Set version from manifest
 document.getElementById("versionLabel").textContent =
   "v" + chrome.runtime.getManifest().version;

--- a/packages/cli-darwin-arm64/package.json
+++ b/packages/cli-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-darwin-arm64",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "description": "Actionbook CLI native binary for macOS ARM64",
   "os": [
     "darwin"

--- a/packages/cli-darwin-x64/package.json
+++ b/packages/cli-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli-darwin-x64",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.2",
   "description": "Actionbook CLI native binary for macOS x64",
   "os": [
     "darwin"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/cli",
-  "version": "1.5.0-alpha.1",
+  "version": "1.5.0-alpha.3",
   "private": false,
   "description": "Actionbook CLI - Browser automation for AI agents",
   "bin": {

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -66,14 +66,15 @@ pub struct StartCmd {
 }
 
 /// Parse a comma-separated resource-type list into the canonical CDP casing.
-/// Returns empty set for "all" (= no filter).
-/// Unknown tokens are silently ignored (log + continue would need tracing
-/// plumbing at the caller; keep parsing infallible here).
-fn parse_resource_types(s: &str) -> HashSet<String> {
+/// Returns empty set for "all" / "*" (= no filter). Any unknown token is a
+/// hard error — silently dropping typos would turn "xrh" into "record
+/// everything" from the caller's perspective.
+fn parse_resource_types(s: &str) -> Result<HashSet<String>, Vec<String>> {
     let mut out = HashSet::new();
+    let mut invalid = Vec::new();
     for tok in s.split(',').map(|t| t.trim()).filter(|t| !t.is_empty()) {
         let canonical = match tok.to_ascii_lowercase().as_str() {
-            "all" | "*" => return HashSet::new(),
+            "all" | "*" => return Ok(HashSet::new()),
             "document" => "Document",
             "stylesheet" => "Stylesheet",
             "image" => "Image",
@@ -92,11 +93,17 @@ fn parse_resource_types(s: &str) -> HashSet<String> {
             "cspviolationreport" => "CSPViolationReport",
             "preflight" => "Preflight",
             "other" => "Other",
-            _ => continue,
+            _ => {
+                invalid.push(tok.to_string());
+                continue;
+            }
         };
         out.insert(canonical.to_string());
     }
-    out
+    if !invalid.is_empty() {
+        return Err(invalid);
+    }
+    Ok(out)
 }
 
 pub const START_COMMAND_NAME: &str = "browser network har start";
@@ -142,7 +149,18 @@ pub async fn execute_start(cmd: &StartCmd, registry: &SharedRegistry) -> ActionR
         }
     };
 
-    let resource_types = parse_resource_types(&cmd.resource_types);
+    let resource_types = match parse_resource_types(&cmd.resource_types) {
+        Ok(set) => set,
+        Err(invalid) => {
+            return ActionResult::fatal(
+                "INVALID_RESOURCE_TYPES",
+                format!(
+                    "unknown resource type(s): {}. Valid values: all, document, stylesheet, image, media, font, script, texttrack, xhr, fetch, prefetch, eventsource, websocket, manifest, signedexchange, ping, cspviolationreport, preflight, other",
+                    invalid.join(", ")
+                ),
+            );
+        }
+    };
     // Echo the canonical filter list back to the agent so it can tell at a
     // glance whether the alias ("all", "xhr,fetch") was expanded correctly.
     let resource_types_echo = if resource_types.is_empty() {
@@ -616,4 +634,35 @@ fn default_har_path() -> PathBuf {
         .unwrap_or_default()
         .as_millis();
     dir.join(format!("har-{ts}.har"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_resource_types_known_tokens_canonicalize() {
+        let set = parse_resource_types("xhr,fetch").unwrap();
+        assert!(set.contains("XHR"));
+        assert!(set.contains("Fetch"));
+    }
+
+    #[test]
+    fn parse_resource_types_all_returns_empty_set() {
+        assert!(parse_resource_types("all").unwrap().is_empty());
+        assert!(parse_resource_types("*").unwrap().is_empty());
+    }
+
+    #[test]
+    fn parse_resource_types_unknown_token_is_error() {
+        // Regression: typo-only input used to silently become "record all".
+        let err = parse_resource_types("xrh").unwrap_err();
+        assert_eq!(err, vec!["xrh".to_string()]);
+    }
+
+    #[test]
+    fn parse_resource_types_mixed_valid_invalid_is_error() {
+        let err = parse_resource_types("xhr,bogus").unwrap_err();
+        assert_eq!(err, vec!["bogus".to_string()]);
+    }
 }

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -3,6 +3,7 @@
 //! Records all network requests for a tab in HAR 1.2 format. Recording is
 //! per-tab: multiple tabs can record independently at the same time.
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 
 use clap::Args;
@@ -14,6 +15,13 @@ use crate::daemon::cdp_session::{HarEntry, get_cdp_and_target};
 use crate::daemon::registry::SharedRegistry;
 use crate::output::ResponseContext;
 
+/// Default cap on per-response body size (bytes). Bodies larger than this are
+/// dropped; metadata is still recorded. Keeps HAR output bounded even on long
+/// recordings.
+const DEFAULT_MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
+/// Default ring-buffer cap on number of entries. Oldest evicted when full.
+const DEFAULT_MAX_ENTRIES: usize = 2000;
+
 // ── Start ─────────────────────────────────────────────────────────────────────
 
 /// Start HAR recording for a tab.
@@ -21,9 +29,14 @@ use crate::output::ResponseContext;
 #[command(after_help = "\
 Examples:
   actionbook browser network har start --session s1 --tab t1
+  actionbook browser network har start --session s1 --tab t1 \\
+      --resource-types xhr,fetch,document --max-body-size 10485760
 
-Starts capturing all HTTP requests/responses for the tab. Stop with
-`browser network har stop` to export a HAR 1.2 file.")]
+Captures HTTP requests/responses for the tab into a ring buffer. By default
+only XHR and fetch requests are recorded, with response bodies fetched via
+Network.getResponseBody (text bodies stored as-is, binary as base64).
+
+Stop with `browser network har stop` to export a HAR 1.2 file.")]
 pub struct StartCmd {
     /// Session ID
     #[arg(long)]
@@ -33,6 +46,57 @@ pub struct StartCmd {
     #[arg(long)]
     #[serde(rename = "tab_id")]
     pub tab: String,
+    /// Comma-separated CDP resource types to record. Case-insensitive.
+    /// Valid values: document, stylesheet, image, media, font, script, texttrack,
+    /// xhr, fetch, prefetch, eventsource, websocket, manifest, signedexchange,
+    /// ping, cspviolationreport, preflight, other. Use "all" to record everything.
+    #[arg(long, default_value = "xhr,fetch")]
+    pub resource_types: String,
+    /// Maximum number of entries to keep. Oldest are dropped when full.
+    /// Set to 0 to disable the cap (unbounded memory use).
+    #[arg(long, default_value_t = DEFAULT_MAX_ENTRIES)]
+    pub max_entries: usize,
+    /// Maximum bytes per response body; larger bodies drop the body text
+    /// (metadata still recorded).
+    #[arg(long, default_value_t = DEFAULT_MAX_BODY_SIZE)]
+    pub max_body_size: usize,
+    /// Skip fetching response bodies; only record request/response metadata.
+    #[arg(long)]
+    pub no_bodies: bool,
+}
+
+/// Parse a comma-separated resource-type list into the canonical CDP casing.
+/// Returns empty set for "all" (= no filter).
+/// Unknown tokens are silently ignored (log + continue would need tracing
+/// plumbing at the caller; keep parsing infallible here).
+fn parse_resource_types(s: &str) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for tok in s.split(',').map(|t| t.trim()).filter(|t| !t.is_empty()) {
+        let canonical = match tok.to_ascii_lowercase().as_str() {
+            "all" | "*" => return HashSet::new(),
+            "document" => "Document",
+            "stylesheet" => "Stylesheet",
+            "image" => "Image",
+            "media" => "Media",
+            "font" => "Font",
+            "script" => "Script",
+            "texttrack" => "TextTrack",
+            "xhr" => "XHR",
+            "fetch" => "Fetch",
+            "prefetch" => "Prefetch",
+            "eventsource" => "EventSource",
+            "websocket" => "WebSocket",
+            "manifest" => "Manifest",
+            "signedexchange" => "SignedExchange",
+            "ping" => "Ping",
+            "cspviolationreport" => "CSPViolationReport",
+            "preflight" => "Preflight",
+            "other" => "Other",
+            _ => continue,
+        };
+        out.insert(canonical.to_string());
+    }
+    out
 }
 
 pub const START_COMMAND_NAME: &str = "browser network har start";
@@ -78,7 +142,19 @@ pub async fn execute_start(cmd: &StartCmd, registry: &SharedRegistry) -> ActionR
         }
     };
 
-    match cdp.har_start(&cdp_session_id).await {
+    let resource_types = parse_resource_types(&cmd.resource_types);
+
+    match cdp
+        .har_start(
+            &cdp_session_id,
+            &target_id,
+            resource_types,
+            cmd.max_entries,
+            cmd.no_bodies,
+            cmd.max_body_size,
+        )
+        .await
+    {
         Ok(()) => ActionResult::ok(json!({ "recording": true })),
         Err("HAR_ALREADY_RECORDING") => ActionResult::fatal(
             "HAR_ALREADY_RECORDING",
@@ -159,8 +235,8 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
     // Peek at entries without removing the recorder yet.  The recorder is
     // only committed (removed) after the file has been written successfully,
     // so an I/O failure leaves the data intact and the user can retry.
-    let entries = match cdp.har_stop(&cdp_session_id).await {
-        Ok(entries) => entries,
+    let (entries, dropped_count) = match cdp.har_stop(&cdp_session_id).await {
+        Ok(v) => v,
         Err("HAR_NOT_RECORDING") => {
             return ActionResult::fatal(
                 "HAR_NOT_RECORDING",
@@ -185,7 +261,7 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
         );
     }
 
-    let har = serialize_har(entries);
+    let har = serialize_har(entries, dropped_count);
     let har_str = match serde_json::to_string_pretty(&har) {
         Ok(s) => s,
         Err(e) => return ActionResult::fatal("IO_ERROR", format!("HAR serialization failed: {e}")),
@@ -201,23 +277,30 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
     ActionResult::ok(json!({
         "path": out_path.to_string_lossy().as_ref(),
         "count": count,
+        "dropped": dropped_count,
     }))
 }
 
 // ── HAR 1.2 serialization ─────────────────────────────────────────────────────
 
-fn serialize_har(entries: Vec<HarEntry>) -> serde_json::Value {
+fn serialize_har(entries: Vec<HarEntry>, dropped_count: usize) -> serde_json::Value {
     let entries_json: Vec<serde_json::Value> = entries.into_iter().map(har_entry_to_json).collect();
-    json!({
-        "log": {
-            "version": "1.2",
-            "creator": {
-                "name": "actionbook",
-                "version": env!("CARGO_PKG_VERSION"),
-            },
-            "entries": entries_json,
-        }
-    })
+    let mut log = json!({
+        "version": "1.2",
+        "creator": {
+            "name": "actionbook",
+            "version": env!("CARGO_PKG_VERSION"),
+        },
+        "entries": entries_json,
+    });
+    if dropped_count > 0 {
+        // HAR 1.2 permits `_`-prefixed custom fields on any object.
+        log["_droppedEntries"] = json!(dropped_count);
+        log["_comment"] = json!(format!(
+            "{dropped_count} earlier entries were dropped due to max_entries ring-buffer cap"
+        ));
+    }
+    json!({ "log": log })
 }
 
 fn har_entry_to_json(e: HarEntry) -> serde_json::Value {
@@ -283,6 +366,24 @@ fn har_entry_to_json(e: HarEntry) -> serde_json::Value {
         e.mime_type
     };
 
+    let mut content = json!({
+        "size": e.response_body_size,
+        "mimeType": mime_type,
+    });
+    if let Some(body) = e.response_body {
+        content["text"] = json!(body);
+        if e.response_body_base64 {
+            content["encoding"] = json!("base64");
+        }
+    }
+    if let Some(dropped) = e.body_dropped_size_bytes {
+        // `_`-prefixed fields are HAR 1.2-permitted extensions.
+        content["_bodyDroppedSizeBytes"] = json!(dropped);
+    }
+    if let Some(err) = e.body_error {
+        content["_bodyError"] = json!(err);
+    }
+
     json!({
         "startedDateTime": started_date_time,
         "time": total_time,
@@ -293,10 +394,7 @@ fn har_entry_to_json(e: HarEntry) -> serde_json::Value {
             "httpVersion": e.http_version,
             "cookies": resp_cookies,
             "headers": resp_headers,
-            "content": {
-                "size": e.response_body_size,
-                "mimeType": mime_type,
-            },
+            "content": content,
             "redirectURL": e.redirect_url,
             "headersSize": -1,
             "bodySize": e.response_body_size,

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -143,6 +143,15 @@ pub async fn execute_start(cmd: &StartCmd, registry: &SharedRegistry) -> ActionR
     };
 
     let resource_types = parse_resource_types(&cmd.resource_types);
+    // Echo the canonical filter list back to the agent so it can tell at a
+    // glance whether the alias ("all", "xhr,fetch") was expanded correctly.
+    let resource_types_echo = if resource_types.is_empty() {
+        "all".to_string()
+    } else {
+        let mut v: Vec<&str> = resource_types.iter().map(String::as_str).collect();
+        v.sort_unstable();
+        v.join(",")
+    };
 
     match cdp
         .har_start(
@@ -155,7 +164,17 @@ pub async fn execute_start(cmd: &StartCmd, registry: &SharedRegistry) -> ActionR
         )
         .await
     {
-        Ok(()) => ActionResult::ok(json!({ "recording": true })),
+        Ok(()) => ActionResult::ok(json!({
+            "recording": true,
+            "resource_types": resource_types_echo,
+            "max_entries": cmd.max_entries,
+            "max_body_size": cmd.max_body_size,
+            "capture_bodies": !cmd.no_bodies,
+            // Agents need to know where stop will write by default. The actual
+            // filename is only decided at stop time (timestamped), so we
+            // surface the directory — the stop response returns the full path.
+            "output_dir": default_har_dir().to_string_lossy().as_ref(),
+        })),
         Err("HAR_ALREADY_RECORDING") => ActionResult::fatal(
             "HAR_ALREADY_RECORDING",
             format!("HAR recording is already active for tab '{}'", cmd.tab),
@@ -582,11 +601,15 @@ fn parse_query_string(url_str: &str) -> Vec<serde_json::Value> {
         .collect()
 }
 
-fn default_har_path() -> PathBuf {
-    let dir = dirs::home_dir()
+fn default_har_dir() -> PathBuf {
+    dirs::home_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join(".actionbook")
-        .join("har");
+        .join("har")
+}
+
+fn default_har_path() -> PathBuf {
+    let dir = default_har_dir();
     let _ = std::fs::create_dir_all(&dir);
     let ts = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -4,9 +4,9 @@
 //! tabs via CDP flat sessions (Target.attachToTarget + sessionId). Concurrent
 //! requests are multiplexed using incrementing message IDs.
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use futures_util::{SinkExt, StreamExt};
 use serde_json::{Value, json};
@@ -78,19 +78,73 @@ pub struct HarEntry {
     pub response_body_size: i64,
     pub cdp_timing: Option<Value>,
     pub loading_finished_timestamp: Option<f64>,
+    /// Response body text. For binary resources this is base64-encoded and
+    /// `response_body_base64` is true. Only populated after `loadingFinished`
+    /// + an async `Network.getResponseBody` call succeeds.
+    pub response_body: Option<String>,
+    /// True when `response_body` is base64 (CDP's `base64Encoded` flag).
+    pub response_body_base64: bool,
+    /// If the body was larger than the configured max_body_size, this holds
+    /// the original byte count and `response_body` is left None.
+    pub body_dropped_size_bytes: Option<i64>,
+    /// Non-fatal error encountered while fetching the body
+    /// (e.g. "No data found for resource with given identifier" for 3xx).
+    pub body_error: Option<String>,
 }
 
 /// Per-tab HAR recording state, keyed by CDP flat-session ID.
 /// Present in the map only while recording is active.
 pub struct HarRecorder {
-    pub entries: Vec<HarEntry>,
+    /// Ring buffer of captured entries. Oldest are evicted when `max_entries`
+    /// is reached.
+    pub entries: VecDeque<HarEntry>,
+    /// CDP `targetId` for the tab being recorded. Needed so background body
+    /// fetches can call `Network.getResponseBody` via `execute_on_tab`.
+    pub target_id: String,
+    /// Allowed CDP resource types (canonical casing: "XHR", "Fetch", …).
+    /// Empty set = record everything.
+    pub resource_types: HashSet<String>,
+    /// Hard cap on entry count. Once reached, oldest entries are dropped.
+    pub max_entries: usize,
+    /// Skip `Network.getResponseBody` calls entirely.
+    pub no_bodies: bool,
+    /// Max bytes per response body. Larger bodies are dropped (metadata kept).
+    pub max_body_size: usize,
+    /// Number of entries evicted due to `max_entries` cap. Surfaced in HAR
+    /// output as `log._droppedEntries` so the caller knows data was missed.
+    pub dropped_count: usize,
+    /// Counter for in-flight `Network.getResponseBody` spawn tasks.
+    /// Incremented when a fetch is dispatched from reader_loop, decremented
+    /// when the task finishes (success or error). `har_stop` polls this to
+    /// drain outstanding fetches before reading entries, so users who call
+    /// `har stop` right after `wait network-idle` still get populated bodies.
+    pub pending_body_fetches: Arc<AtomicUsize>,
 }
 
 impl HarRecorder {
-    fn new() -> Self {
+    pub fn new(
+        target_id: String,
+        resource_types: HashSet<String>,
+        max_entries: usize,
+        no_bodies: bool,
+        max_body_size: usize,
+    ) -> Self {
         Self {
-            entries: Vec::new(),
+            entries: VecDeque::new(),
+            target_id,
+            resource_types,
+            max_entries,
+            no_bodies,
+            max_body_size,
+            dropped_count: 0,
+            pending_body_fetches: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    /// Returns true if this resource type should be recorded.
+    /// Empty filter set = record everything.
+    fn allows(&self, resource_type: &str) -> bool {
+        self.resource_types.is_empty() || self.resource_types.contains(resource_type)
     }
 
     fn on_request_will_be_sent(&mut self, params: &Value) {
@@ -102,6 +156,8 @@ impl HarRecorder {
         // Handle redirect: the redirectResponse field carries the HTTP response
         // for the *previous* request that issued the redirect (e.g. status 302).
         // Finalize the existing entry for this requestId with the redirect data.
+        // (If the original request was filtered out, there's no entry to find —
+        //  find() returns None and this is a no-op.)
         if let Some(rr) = params.get("redirectResponse")
             && let Some(entry) = self
                 .entries
@@ -132,6 +188,14 @@ impl HarRecorder {
             .and_then(|v| v.as_str())
             .unwrap_or("Other")
             .to_string();
+
+        // Resource-type filter: drop non-matching requests before building the
+        // entry. Subsequent events (responseReceived, loadingFinished) will
+        // find nothing and skip naturally.
+        if !self.allows(&resource_type) {
+            return;
+        }
+
         let request_headers = har_extract_headers(req.and_then(|r| r.get("headers")));
         let post_data = req
             .and_then(|r| r.get("postData"))
@@ -139,7 +203,13 @@ impl HarRecorder {
             .map(|s| s.to_string());
         let request_body_size = post_data.as_ref().map(|s| s.len() as i64).unwrap_or(0);
 
-        self.entries.push(HarEntry {
+        // Enforce ring-buffer cap.
+        if self.max_entries > 0 && self.entries.len() >= self.max_entries {
+            self.entries.pop_front();
+            self.dropped_count += 1;
+        }
+
+        self.entries.push_back(HarEntry {
             request_id: request_id.to_string(),
             wall_time,
             method,
@@ -157,6 +227,10 @@ impl HarRecorder {
             response_body_size: -1,
             cdp_timing: None,
             loading_finished_timestamp: None,
+            response_body: None,
+            response_body_base64: false,
+            body_dropped_size_bytes: None,
+            body_error: None,
         });
     }
 
@@ -269,6 +343,79 @@ fn har_extract_headers(headers_val: Option<&Value>) -> Vec<(String, String)> {
 }
 
 type TabHarRecorders = Arc<Mutex<HashMap<String, HarRecorder>>>;
+
+/// CDP routing discriminant for HAR body fetches spawned from reader_loop.
+#[derive(Clone)]
+enum HarFetchRoute {
+    /// Local/cloud flat session — routes via `sessionId` in the CDP frame.
+    FlatSession(String),
+    /// Extension bridge (protocol 0.3.0+) — routes via root-level `tabId`.
+    ExtensionTab(u64),
+}
+
+/// Send a raw CDP command on an already-open connection and await its response.
+/// This is a minimal analogue of `CdpSession::execute` that can be invoked from
+/// `reader_loop` without requiring a `CdpSession` handle. It is only used for
+/// background HAR body fetches; everything else goes through `execute`.
+///
+/// Never hold any recorder/event lock across this await.
+async fn send_cdp_raw(
+    pending: &PendingRequests,
+    writer_tx: &mpsc::Sender<String>,
+    next_id: &AtomicU64,
+    method: &str,
+    params: Value,
+    route: &HarFetchRoute,
+) -> Result<Value, CliError> {
+    let id = next_id.fetch_add(1, Ordering::Relaxed);
+    let mut msg = json!({
+        "id": id,
+        "method": method,
+        "params": params,
+    });
+    match route {
+        HarFetchRoute::FlatSession(sid) if !sid.is_empty() => {
+            msg["sessionId"] = json!(sid);
+        }
+        HarFetchRoute::ExtensionTab(tid) => {
+            msg["tabId"] = json!(*tid);
+        }
+        _ => {}
+    }
+
+    let (tx, rx) = oneshot::channel();
+    pending.lock().await.insert(id, tx);
+    if writer_tx.send(msg.to_string()).await.is_err() {
+        pending.lock().await.remove(&id);
+        return Err(CliError::SessionClosed(
+            "session was closed while HAR body fetch was pending".to_string(),
+        ));
+    }
+
+    // 15s is plenty for getResponseBody; use a tighter bound than execute()'s 60s
+    // so a stuck body fetch doesn't linger in memory forever.
+    let resp = tokio::time::timeout(std::time::Duration::from_secs(15), rx)
+        .await
+        .map_err(|_| {
+            let pending = pending.clone();
+            tokio::spawn(async move {
+                pending.lock().await.remove(&id);
+            });
+            CliError::Timeout
+        })?
+        .map_err(|_| CliError::CdpError("response channel dropped".to_string()))??;
+
+    if let Some(err) = resp.get("error") {
+        let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
+        let message = err
+            .get("message")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown CDP error");
+        return Err(CliError::CdpError(format!("CDP error {code}: {message}")));
+    }
+
+    Ok(resp)
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct NetworkRequestsFilter {
@@ -561,6 +708,9 @@ impl CdpSession {
         let pending: PendingRequests = Arc::new(Mutex::new(HashMap::new()));
         let next_id = Arc::new(AtomicU64::new(1));
         let (writer_tx, writer_rx) = mpsc::channel::<String>(64);
+        // Clone for reader_loop — it needs to dispatch async HAR body fetches
+        // (Network.getResponseBody) without blocking itself.
+        let writer_tx_for_reader = writer_tx.clone();
         let event_subs: EventSubs = Arc::new(Mutex::new(HashMap::new()));
         let tab_net_pending: TabNetPending = Arc::new(Mutex::new(HashMap::new()));
         let iframe_sessions: IframeSessions = Arc::new(Mutex::new(HashMap::new()));
@@ -584,6 +734,8 @@ impl CdpSession {
             max_tracked_requests,
             is_extension_bridge.clone(),
             tab_har_recorders.clone(),
+            writer_tx_for_reader,
+            next_id.clone(),
         ));
 
         Ok(CdpSession {
@@ -1133,27 +1285,89 @@ impl CdpSession {
     /// Returns `Err("HAR_ALREADY_RECORDING")` if recording is already active
     /// for this session. The caller is responsible for enabling `Network.*`
     /// events on the target before calling this.
-    pub async fn har_start(&self, cdp_session_id: &str) -> Result<(), &'static str> {
+    ///
+    /// Config:
+    /// - `target_id`: CDP targetId for the tab; needed so background body
+    ///   fetches can route the CDP command back to the correct tab.
+    /// - `resource_types`: canonical CDP resource-type names to record.
+    ///   Empty set = record everything.
+    /// - `max_entries`: ring-buffer cap; 0 disables the cap.
+    /// - `no_bodies`: skip `Network.getResponseBody` calls when true.
+    /// - `max_body_size`: bytes; bodies larger than this are dropped
+    ///   (metadata is still recorded).
+    #[allow(clippy::too_many_arguments)]
+    pub async fn har_start(
+        &self,
+        cdp_session_id: &str,
+        target_id: &str,
+        resource_types: HashSet<String>,
+        max_entries: usize,
+        no_bodies: bool,
+        max_body_size: usize,
+    ) -> Result<(), &'static str> {
         let mut recorders = self.tab_har_recorders.lock().await;
         if recorders.contains_key(cdp_session_id) {
             return Err("HAR_ALREADY_RECORDING");
         }
-        recorders.insert(cdp_session_id.to_string(), HarRecorder::new());
+        recorders.insert(
+            cdp_session_id.to_string(),
+            HarRecorder::new(
+                target_id.to_string(),
+                resource_types,
+                max_entries,
+                no_bodies,
+                max_body_size,
+            ),
+        );
         Ok(())
     }
 
-    /// Stop HAR recording and return all captured entries.
+    /// Stop HAR recording and return captured entries plus dropped count.
     ///
     /// The recorder is **not** removed yet — call `har_commit` after successfully
     /// writing the file to release it.  This ensures that an I/O failure in the
     /// caller does not silently destroy the captured data.
     ///
+    /// Before reading entries, waits up to 3 seconds for any in-flight
+    /// `Network.getResponseBody` fetches to complete, so users calling `har_stop`
+    /// immediately after `wait network-idle` still get populated response bodies.
+    ///
+    /// `dropped_count` is the number of entries evicted due to the `max_entries`
+    /// ring-buffer cap; surface this so callers can warn the user.
+    ///
     /// Returns `Err("HAR_NOT_RECORDING")` if no recording was active.
-    pub async fn har_stop(&self, cdp_session_id: &str) -> Result<Vec<HarEntry>, &'static str> {
+    pub async fn har_stop(
+        &self,
+        cdp_session_id: &str,
+    ) -> Result<(Vec<HarEntry>, usize), &'static str> {
+        // Snapshot the pending-fetch counter handle, then release the lock
+        // while polling so body-fetch spawn tasks can acquire it to write back.
+        let pending_counter = {
+            let recorders = self.tab_har_recorders.lock().await;
+            match recorders.get(cdp_session_id) {
+                None => return Err("HAR_NOT_RECORDING"),
+                Some(recorder) => recorder.pending_body_fetches.clone(),
+            }
+        };
+
+        // Drain outstanding body fetches. 3s is generous: individual fetches
+        // have a 15s ceiling in send_cdp_raw but typically resolve in
+        // milliseconds. Exiting after the deadline is safe — entries simply
+        // ship without bodies and keep their `body_error`/None state.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+        while pending_counter.load(Ordering::Acquire) > 0
+            && std::time::Instant::now() < deadline
+        {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
         let recorders = self.tab_har_recorders.lock().await;
         match recorders.get(cdp_session_id) {
             None => Err("HAR_NOT_RECORDING"),
-            Some(recorder) => Ok(recorder.entries.clone()),
+            Some(recorder) => Ok((
+                recorder.entries.iter().cloned().collect(),
+                recorder.dropped_count,
+            )),
         }
     }
 
@@ -1177,6 +1391,8 @@ impl CdpSession {
         max_tracked_requests: usize,
         is_extension_bridge: Arc<std::sync::atomic::AtomicBool>,
         tab_har_recorders: TabHarRecorders,
+        writer_tx: mpsc::Sender<String>,
+        next_id: Arc<AtomicU64>,
     ) where
         S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
     {
@@ -1324,6 +1540,20 @@ impl CdpSession {
 
                     // HAR recording: feed network events into any active recorder
                     // for this CDP session. Independent of the ring-buffer path above.
+                    //
+                    // For `Network.loadingFinished`, also trigger an async body
+                    // fetch via `Network.getResponseBody`. We MUST NOT await that
+                    // from inside reader_loop (it would deadlock on itself), so
+                    // we collect the info we need, drop the recorder lock, and
+                    // spawn a detached task.
+                    type BodyFetchDispatch = (
+                        String,
+                        String,
+                        HarFetchRoute,
+                        usize,
+                        Arc<AtomicUsize>,
+                    );
+                    let mut body_fetch: Option<BodyFetchDispatch> = None;
                     if let Some(params) = resp.get("params") {
                         let mut recorders = tab_har_recorders.lock().await;
                         if let Some(recorder) = recorders.get_mut(session_id) {
@@ -1336,6 +1566,47 @@ impl CdpSession {
                                 }
                                 "Network.loadingFinished" => {
                                     recorder.on_loading_finished(params);
+                                    if !recorder.no_bodies {
+                                        let req_id = params
+                                            .get("requestId")
+                                            .and_then(|v| v.as_str())
+                                            .unwrap_or("");
+                                        if !req_id.is_empty()
+                                            && recorder
+                                                .entries
+                                                .iter()
+                                                .any(|e| e.request_id == req_id)
+                                        {
+                                            let route = if is_extension_bridge
+                                                .load(std::sync::atomic::Ordering::Acquire)
+                                            {
+                                                // session_id is "tab:{N}" here; parse the numeric tail.
+                                                ext_tab_key
+                                                    .as_deref()
+                                                    .and_then(|k| k.strip_prefix("tab:"))
+                                                    .and_then(|n| n.parse::<u64>().ok())
+                                                    .map(HarFetchRoute::ExtensionTab)
+                                            } else {
+                                                Some(HarFetchRoute::FlatSession(
+                                                    session_id.to_string(),
+                                                ))
+                                            };
+                                            if let Some(route) = route {
+                                                // Reserve a pending slot BEFORE we drop the lock
+                                                // so har_stop's drain can see the in-flight fetch.
+                                                recorder
+                                                    .pending_body_fetches
+                                                    .fetch_add(1, Ordering::Release);
+                                                body_fetch = Some((
+                                                    session_id.to_string(),
+                                                    req_id.to_string(),
+                                                    route,
+                                                    recorder.max_body_size,
+                                                    recorder.pending_body_fetches.clone(),
+                                                ));
+                                            }
+                                        }
+                                    }
                                 }
                                 "Network.loadingFailed" => {
                                     recorder.on_loading_failed(params);
@@ -1343,6 +1614,75 @@ impl CdpSession {
                                 _ => {}
                             }
                         }
+                    }
+
+                    if let Some((sess_key, req_id, route, max_body_size, pending_counter)) =
+                        body_fetch
+                    {
+                        let pending_clone = pending.clone();
+                        let writer_tx_clone = writer_tx.clone();
+                        let next_id_clone = next_id.clone();
+                        let recorders_clone = tab_har_recorders.clone();
+                        tokio::spawn(async move {
+                            let result = send_cdp_raw(
+                                &pending_clone,
+                                &writer_tx_clone,
+                                &next_id_clone,
+                                "Network.getResponseBody",
+                                json!({ "requestId": req_id }),
+                                &route,
+                            )
+                            .await;
+                            {
+                                let mut recorders = recorders_clone.lock().await;
+                                if let Some(recorder) = recorders.get_mut(&sess_key)
+                                    && let Some(entry) = recorder
+                                        .entries
+                                        .iter_mut()
+                                        .find(|e| e.request_id == req_id)
+                                {
+                                    match result {
+                                        Ok(resp) => {
+                                            let body = resp
+                                                .pointer("/result/body")
+                                                .and_then(|v| v.as_str())
+                                                .map(|s| s.to_string());
+                                            let base64 = resp
+                                                .pointer("/result/base64Encoded")
+                                                .and_then(|v| v.as_bool())
+                                                .unwrap_or(false);
+                                            match body {
+                                                Some(b) if b.len() > max_body_size => {
+                                                    entry.body_dropped_size_bytes =
+                                                        Some(b.len() as i64);
+                                                    entry.body_error = Some(
+                                                        "body_exceeds_max_body_size"
+                                                            .to_string(),
+                                                    );
+                                                }
+                                                Some(b) => {
+                                                    entry.response_body = Some(b);
+                                                    entry.response_body_base64 = base64;
+                                                }
+                                                None => {
+                                                    entry.body_error = Some(
+                                                        "empty_body_field_in_response"
+                                                            .to_string(),
+                                                    );
+                                                }
+                                            }
+                                        }
+                                        Err(e) => {
+                                            entry.body_error = Some(e.to_string());
+                                        }
+                                    }
+                                }
+                            }
+                            // Always decrement, even if the recorder was already
+                            // removed (har_commit raced us) or the entry was
+                            // evicted by the ring buffer.
+                            pending_counter.fetch_sub(1, Ordering::Release);
+                        });
                     }
                 }
 

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -634,6 +634,10 @@ pub struct CdpSession {
     /// it, the peer (e.g. bridge) still sees the old client as connected and
     /// rejects the new CDP client.
     writer_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
+    /// Reader task handle. Aborted by `close()` so the `writer_tx_for_reader`
+    /// clone is released, allowing writer_loop to see channel close and send
+    /// a graceful WS Close frame to the peer (e.g. extension bridge).
+    reader_handle: Arc<Mutex<Option<JoinHandle<()>>>>,
     /// In-flight requests keyed by message ID.
     pending: PendingRequests,
     /// Atomic counter for generating unique message IDs.
@@ -722,7 +726,7 @@ impl CdpSession {
         let tab_har_recorders: TabHarRecorders = Arc::new(Mutex::new(HashMap::new()));
 
         let writer_handle = tokio::spawn(Self::writer_loop(ws_writer, writer_rx));
-        tokio::spawn(Self::reader_loop(
+        let reader_handle = tokio::spawn(Self::reader_loop(
             ws_reader,
             pending.clone(),
             event_subs.clone(),
@@ -741,6 +745,7 @@ impl CdpSession {
         Ok(CdpSession {
             writer_tx: Arc::new(Mutex::new(Some(writer_tx))),
             writer_handle: Arc::new(Mutex::new(Some(writer_handle))),
+            reader_handle: Arc::new(Mutex::new(Some(reader_handle))),
             pending,
             next_id,
             tab_sessions,
@@ -1193,6 +1198,14 @@ impl CdpSession {
         // Take and drop the writer sender — closes the channel.
         self.writer_tx.lock().await.take();
 
+        // Abort reader_loop so it releases writer_tx_for_reader. Without this
+        // the reader holds the only remaining sender clone, keeping the mpsc
+        // channel open, so writer_loop never sees channel close and blocks
+        // forever instead of sending a graceful WS Close frame.
+        if let Some(handle) = self.reader_handle.lock().await.take() {
+            handle.abort();
+        }
+
         // Fail all pending requests immediately instead of waiting for
         // the reader loop to notice the connection drop.
         {
@@ -1355,9 +1368,7 @@ impl CdpSession {
         // milliseconds. Exiting after the deadline is safe — entries simply
         // ship without bodies and keep their `body_error`/None state.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-        while pending_counter.load(Ordering::Acquire) > 0
-            && std::time::Instant::now() < deadline
-        {
+        while pending_counter.load(Ordering::Acquire) > 0 && std::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
 
@@ -1546,13 +1557,8 @@ impl CdpSession {
                     // from inside reader_loop (it would deadlock on itself), so
                     // we collect the info we need, drop the recorder lock, and
                     // spawn a detached task.
-                    type BodyFetchDispatch = (
-                        String,
-                        String,
-                        HarFetchRoute,
-                        usize,
-                        Arc<AtomicUsize>,
-                    );
+                    type BodyFetchDispatch =
+                        (String, String, HarFetchRoute, usize, Arc<AtomicUsize>);
                     let mut body_fetch: Option<BodyFetchDispatch> = None;
                     if let Some(params) = resp.get("params") {
                         let mut recorders = tab_har_recorders.lock().await;
@@ -1635,10 +1641,17 @@ impl CdpSession {
                             .await;
                             {
                                 let mut recorders = recorders_clone.lock().await;
+                                // `.rev()`: on redirect chains CDP reuses the same
+                                // requestId, so `on_request_will_be_sent` appends
+                                // one HAR entry per hop. The body we just fetched
+                                // belongs to the final response (the newest entry),
+                                // not the first hop — mirror the reverse-search
+                                // used by `on_response_received`/`on_loading_*`.
                                 if let Some(recorder) = recorders.get_mut(&sess_key)
                                     && let Some(entry) = recorder
                                         .entries
                                         .iter_mut()
+                                        .rev()
                                         .find(|e| e.request_id == req_id)
                                 {
                                     match result {
@@ -1652,22 +1665,36 @@ impl CdpSession {
                                                 .and_then(|v| v.as_bool())
                                                 .unwrap_or(false);
                                             match body {
-                                                Some(b) if b.len() > max_body_size => {
-                                                    entry.body_dropped_size_bytes =
-                                                        Some(b.len() as i64);
-                                                    entry.body_error = Some(
-                                                        "body_exceeds_max_body_size"
-                                                            .to_string(),
-                                                    );
-                                                }
                                                 Some(b) => {
-                                                    entry.response_body = Some(b);
-                                                    entry.response_body_base64 = base64;
+                                                    // For base64 payloads the wire
+                                                    // string is ~4/3 larger than the
+                                                    // decoded bytes; compare against
+                                                    // decoded length so the byte cap
+                                                    // means what it says.
+                                                    let decoded_len = if base64 {
+                                                        use base64::Engine as _;
+                                                        base64::engine::general_purpose::STANDARD
+                                                            .decode(&b)
+                                                            .map(|v| v.len())
+                                                            .unwrap_or(b.len())
+                                                    } else {
+                                                        b.len()
+                                                    };
+                                                    if decoded_len > max_body_size {
+                                                        entry.body_dropped_size_bytes =
+                                                            Some(decoded_len as i64);
+                                                        entry.body_error = Some(
+                                                            "body_exceeds_max_body_size"
+                                                                .to_string(),
+                                                        );
+                                                    } else {
+                                                        entry.response_body = Some(b);
+                                                        entry.response_body_base64 = base64;
+                                                    }
                                                 }
                                                 None => {
                                                     entry.body_error = Some(
-                                                        "empty_body_field_in_response"
-                                                            .to_string(),
+                                                        "empty_body_field_in_response".to_string(),
                                                     );
                                                 }
                                             }

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -874,7 +874,9 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                 lines.push(format!("capture_bodies: {b}"));
             }
             if let Some(dir) = data.get("output_dir").and_then(|v| v.as_str()) {
-                lines.push(format!("output_dir: {dir} (default; override at stop with --out <path>)"));
+                lines.push(format!(
+                    "output_dir: {dir} (default; override at stop with --out <path>)"
+                ));
             }
         }
         "browser network har stop" => {

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -229,6 +229,8 @@ pub fn format_text(
                     | "browser session-storage clear"
                     | "browser network requests"
                     | "browser network request"
+                    | "browser network har start"
+                    | "browser network har stop"
                     | "extension install"
                     | "extension uninstall"
             );
@@ -856,6 +858,36 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
                     };
                     lines.push(format!("body: {preview}"));
                 }
+            }
+        }
+        "browser network har start" => {
+            if let Some(rt) = data.get("resource_types").and_then(|v| v.as_str()) {
+                lines.push(format!("resource_types: {rt}"));
+            }
+            if let Some(n) = data.get("max_entries").and_then(|v| v.as_u64()) {
+                lines.push(format!("max_entries: {n}"));
+            }
+            if let Some(n) = data.get("max_body_size").and_then(|v| v.as_u64()) {
+                lines.push(format!("max_body_size: {n}"));
+            }
+            if let Some(b) = data.get("capture_bodies").and_then(|v| v.as_bool()) {
+                lines.push(format!("capture_bodies: {b}"));
+            }
+            if let Some(dir) = data.get("output_dir").and_then(|v| v.as_str()) {
+                lines.push(format!("output_dir: {dir} (default; override at stop with --out <path>)"));
+            }
+        }
+        "browser network har stop" => {
+            if let Some(path) = data.get("path").and_then(|v| v.as_str()) {
+                lines.push(format!("path: {path}"));
+            }
+            if let Some(n) = data.get("count").and_then(|v| v.as_u64()) {
+                lines.push(format!("count: {n}"));
+            }
+            if let Some(n) = data.get("dropped").and_then(|v| v.as_u64())
+                && n > 0
+            {
+                lines.push(format!("dropped: {n}"));
             }
         }
         "browser logs console" | "browser logs errors" => {

--- a/packages/cli/tests/e2e/network_har.rs
+++ b/packages/cli/tests/e2e/network_har.rs
@@ -27,6 +27,27 @@ fn har_start(session_id: &str, tab_id: &str) -> std::process::Output {
     )
 }
 
+/// Start HAR recording capturing **all** resource types, not just the default
+/// xhr,fetch. Used by tests that navigate to static fixtures (network-load,
+/// redirect) where Document/Script/Stylesheet entries are the whole point.
+fn har_start_all(session_id: &str, tab_id: &str) -> std::process::Output {
+    headless_json(
+        &[
+            "browser",
+            "network",
+            "har",
+            "start",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+            "--resource-types",
+            "all",
+        ],
+        15,
+    )
+}
+
 fn har_stop(session_id: &str, tab_id: &str) -> std::process::Output {
     headless_json(
         &[
@@ -119,7 +140,9 @@ fn har_start_stop_creates_file() {
     let (sid, tid) = start_session("about:blank");
     let _guard = SessionGuard::new(&sid);
 
-    let start_out = har_start(&sid, &tid);
+    // network-load is a static page (no XHR), so we need `--resource-types all`
+    // to end up with non-empty entries.
+    let start_out = har_start_all(&sid, &tid);
     assert_success(&start_out, "har start");
 
     let goto_out = headless_json(
@@ -259,6 +282,111 @@ fn har_valid_json_structure() {
 }
 
 #[test]
+fn har_entry_captures_response_body() {
+    // Core new behavior: response.content.text is populated for XHR/fetch.
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    assert_success(&har_start(&sid, &tid), "har start");
+    assert_success(
+        &headless_json(
+            &[
+                "browser",
+                "goto",
+                &url_network_xhr(),
+                "--session",
+                &sid,
+                "--tab",
+                &tid,
+            ],
+            20,
+        ),
+        "goto network xhr",
+    );
+    wait_requests_done(&sid, &tid);
+
+    let stop_v = parse_json(&har_stop(&sid, &tid));
+    let path = PathBuf::from(stop_v["data"]["path"].as_str().expect("har path"));
+    let har = har_json_from_file(&path);
+
+    // At least one XHR/fetch entry should have response.content.text set to a
+    // non-empty string. If this fails, the body-capture spawn is broken.
+    let populated = har_entries(&har)
+        .iter()
+        .filter(|e| {
+            e["response"]["content"]["text"]
+                .as_str()
+                .is_some_and(|t| !t.is_empty())
+        })
+        .count();
+    assert!(
+        populated > 0,
+        "expected at least one XHR/fetch entry with response.content.text populated, got 0"
+    );
+}
+
+#[test]
+fn har_no_bodies_flag_skips_body_capture() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let start_out = headless_json(
+        &[
+            "browser",
+            "network",
+            "har",
+            "start",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--no-bodies",
+        ],
+        15,
+    );
+    assert_success(&start_out, "har start --no-bodies");
+
+    assert_success(
+        &headless_json(
+            &[
+                "browser",
+                "goto",
+                &url_network_xhr(),
+                "--session",
+                &sid,
+                "--tab",
+                &tid,
+            ],
+            20,
+        ),
+        "goto network xhr",
+    );
+    wait_requests_done(&sid, &tid);
+
+    let stop_v = parse_json(&har_stop(&sid, &tid));
+    let path = PathBuf::from(stop_v["data"]["path"].as_str().expect("har path"));
+    let har = har_json_from_file(&path);
+
+    // With --no-bodies, no entry should have response.content.text.
+    let populated = har_entries(&har)
+        .iter()
+        .filter(|e| e["response"]["content"].get("text").is_some())
+        .count();
+    assert_eq!(
+        populated, 0,
+        "--no-bodies should prevent any text field from being written"
+    );
+}
+
+#[test]
 fn har_entry_has_request_response() {
     if skip() {
         return;
@@ -315,7 +443,8 @@ fn har_entry_has_timings() {
     let (sid, tid) = start_session(&url_network_load());
     let _guard = SessionGuard::new(&sid);
 
-    assert_success(&har_start(&sid, &tid), "har start");
+    // Document / static assets aren't in the default xhr,fetch filter.
+    assert_success(&har_start_all(&sid, &tid), "har start");
     let goto_out = headless_json(
         &[
             "browser",
@@ -354,7 +483,8 @@ fn har_redirect_chain_multiple_entries() {
     let (sid, tid) = start_session("about:blank");
     let _guard = SessionGuard::new(&sid);
 
-    assert_success(&har_start(&sid, &tid), "har start");
+    // Top-level redirects are Document-typed, not XHR/Fetch.
+    assert_success(&har_start_all(&sid, &tid), "har start");
     let goto_out = headless_json(
         &[
             "browser",
@@ -560,7 +690,9 @@ fn har_cross_session_independent_recording() {
     let (sid2, tid2) = start_session("about:blank");
     let _guard2 = SessionGuard::new(&sid2);
 
-    assert_success(&har_start(&sid1, &tid1), "har start session 1");
+    // Session 1 loads a static page (Document/CSS/JS), so needs all types.
+    // Session 2 issues XHR/fetch, which is the default.
+    assert_success(&har_start_all(&sid1, &tid1), "har start session 1");
     assert_success(&har_start(&sid2, &tid2), "har start session 2");
 
     // Session 1: navigate to the network-load fixture (static assets, no XHR).


### PR DESCRIPTION
## Summary
- Extension: auto-group tabs opened via `Extension.createTab` into a per-window "Actionbook" Chrome tab group (toggle in popup, persisted in `chrome.storage.local`). Adds `tabGroups` permission.
- CLI: fix HAR recording and output bugs (commits 209911e3, 5e2aa77f).
- Version bumps: extension `0.4.0-alpha.3`, CLI `1.5.0-alpha.3`.

## Test plan
- [ ] Load unpacked extension; open tab via CLI — confirm it lands in a blue "Actionbook" group.
- [ ] Toggle "Group Actionbook tabs" off in popup — new tabs stay ungrouped; preference survives reload.
- [ ] Manually-attached tabs (`Extension.attachTab`) are NOT auto-grouped.
- [ ] CLI `browser network har start/stop` produces expected HAR output.