### PR TITLE
[cli] fix CdpSession::close event-sub hang + HAR base64 size OOM

### DIFF
--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -427,15 +427,30 @@ pub struct NetworkRequestsFilter {
 
 /// Compute how many bytes a standard-base64 string would decode to, without
 /// allocating the decoded buffer. CDP's `Network.getResponseBody` returns
-/// unpadded-free standard base64 whose text length is always a multiple of 4;
-/// if we encounter malformed input (not a multiple of 4), fall back to the raw
-/// text length so the caller over-estimates and errs on the side of caution.
+/// standard base64 whose text length is always a multiple of 4 and whose
+/// non-padding bytes are all in `[A-Za-z0-9+/]`. If either invariant breaks
+/// (bad length, or illegal chars inside the body — e.g. whitespace, `=` in
+/// the middle), fall back to the raw text length so the caller over-estimates
+/// decoded size and errs on the side of rejecting oversized bodies.
 fn base64_decoded_len(s: &str) -> usize {
     let len = s.len();
     if !len.is_multiple_of(4) {
         return len;
     }
-    let padding = s.bytes().rev().take_while(|&b| b == b'=').count().min(2);
+    let bytes = s.as_bytes();
+    let padding = bytes
+        .iter()
+        .rev()
+        .take_while(|&&b| b == b'=')
+        .count()
+        .min(2);
+    let body_end = len - padding;
+    for &b in &bytes[..body_end] {
+        let ok = b.is_ascii_alphanumeric() || b == b'+' || b == b'/';
+        if !ok {
+            return len;
+        }
+    }
     (len / 4) * 3 - padding
 }
 
@@ -1873,6 +1888,11 @@ mod tests {
         // Not a multiple of 4 → caller should treat as "at least this big"
         // and err toward rejecting; returning the raw length is safe.
         assert_eq!(base64_decoded_len("abc"), 3);
+        // Multiple of 4 but contains non-base64 chars — formula would
+        // under-estimate and let bodies slip past the size cap. Fall back.
+        assert_eq!(base64_decoded_len("ab!d"), 4);
+        assert_eq!(base64_decoded_len("ab\n\n"), 4); // whitespace/newline
+        assert_eq!(base64_decoded_len("a=bc"), 4); // `=` mid-string
     }
 
     /// Start a mock WebSocket server. Returns the URL and a channel that

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -425,6 +425,20 @@ pub struct NetworkRequestsFilter {
     pub status: Option<String>,
 }
 
+/// Compute how many bytes a standard-base64 string would decode to, without
+/// allocating the decoded buffer. CDP's `Network.getResponseBody` returns
+/// unpadded-free standard base64 whose text length is always a multiple of 4;
+/// if we encounter malformed input (not a multiple of 4), fall back to the raw
+/// text length so the caller over-estimates and errs on the side of caution.
+fn base64_decoded_len(s: &str) -> usize {
+    let len = s.len();
+    if !len.is_multiple_of(4) {
+        return len;
+    }
+    let padding = s.bytes().rev().take_while(|&b| b == b'=').count().min(2);
+    (len / 4) * 3 - padding
+}
+
 fn normalize_headers(headers: Option<&Value>) -> HashMap<String, String> {
     let Some(obj) = headers.and_then(|v| v.as_object()) else {
         return HashMap::new();
@@ -1217,6 +1231,13 @@ impl CdpSession {
             }
         }
 
+        // Clear event subscribers so their recv() returns None instead of
+        // hanging. Normally `reader_loop`'s exit path does this, but the
+        // abort above short-circuits that cleanup — waiters such as
+        // `browser/navigation/goto.rs` and `browser/wait/navigation.rs` rely
+        // on the channel closing to unblock on session close/restart.
+        self.event_subs.lock().await.clear();
+
         // Bounded wait for the writer to flush its Close frame.
         if let Some(handle) = self.writer_handle.lock().await.take() {
             let aborter = handle.abort_handle();
@@ -1670,13 +1691,14 @@ impl CdpSession {
                                                     // string is ~4/3 larger than the
                                                     // decoded bytes; compare against
                                                     // decoded length so the byte cap
-                                                    // means what it says.
+                                                    // means what it says. Derive the
+                                                    // decoded length from the text
+                                                    // without allocating — decoding
+                                                    // multi-MB bodies just to get a
+                                                    // size would double peak memory
+                                                    // and risk OOM in the daemon.
                                                     let decoded_len = if base64 {
-                                                        use base64::Engine as _;
-                                                        base64::engine::general_purpose::STANDARD
-                                                            .decode(&b)
-                                                            .map(|v| v.len())
-                                                            .unwrap_or(b.len())
+                                                        base64_decoded_len(&b)
                                                     } else {
                                                         b.len()
                                                     };
@@ -1830,6 +1852,28 @@ mod tests {
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn base64_decoded_len_matches_reference_for_sampled_inputs() {
+        use base64::Engine as _;
+        let enc = base64::engine::general_purpose::STANDARD;
+        // Cover all three padding cases (0, 1, 2 `=` chars) plus empty input.
+        for sample in ["", "a", "ab", "abc", "abcd", "abcdef", "Hello, world!!"] {
+            let encoded = enc.encode(sample.as_bytes());
+            assert_eq!(
+                base64_decoded_len(&encoded),
+                sample.len(),
+                "formula disagreed with reference decoder for sample {sample:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn base64_decoded_len_malformed_falls_back_to_text_len() {
+        // Not a multiple of 4 → caller should treat as "at least this big"
+        // and err toward rejecting; returning the raw length is safe.
+        assert_eq!(base64_decoded_len("abc"), 3);
+    }
 
     /// Start a mock WebSocket server. Returns the URL and a channel that
     /// yields each accepted connection's (reader, writer) pair.


### PR DESCRIPTION
Follow-up to #546 — both issues flagged by Codex CLI post-fix review.

## Summary
- **P1 (shutdown hang)**: `CdpSession::close()` aborts `reader_loop` for prompt shutdown, but the abort skips the loop's tail cleanup (`event_subs.lock().await.clear()`). Subscribers from `subscribe_events()` (used by `browser/navigation/goto.rs`, `browser/wait/navigation.rs`) rely on `rx.recv()` returning `None` on session close/restart — without the clear they hang to the outer timeout or indefinitely. Fix: clear subscribers explicitly after the abort.
- **P2 (memory/OOM)**: HAR body-size check used `STANDARD.decode(&b)` only to measure the decoded length. For multi-MB binary responses this allocates the full decoded `Vec<u8>`, roughly doubling peak daemon memory even when the body is about to be dropped. Fix: `base64_decoded_len(&str)` derives the length from text without materializing the payload.

## Test plan
- [x] `cargo test --lib` — 423 pass (2 new tests for `base64_decoded_len` covering all three padding cases + malformed input)
- [x] `cargo fmt --check` + `cargo clippy -- -D warnings` clean
- [ ] Manual: repro a scenario where `goto` waits on a `Page.loadEventFired` sub while another task calls `browser close --session` → channel now closes immediately instead of hanging