### PR TITLE
docs: add --auto-connect flag documentation

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -104,6 +104,7 @@ Start or attach a browser session. Entry point for all modes including cloud pro
 | `--profile <name>` | Profile name |
 | `--stealth` / `--no-stealth` | Anti-detection mode (default: enabled) |
 | `--max-tracked-requests <N>` | Network request buffer size per tab (default: 500, range: 1–100000) |
+| `--auto-connect` | Auto-discover and attach to a locally running Chrome (env: `ACTIONBOOK_AUTO_CONNECT`) |
 
 **Examples:**
 
@@ -112,7 +113,12 @@ actionbook browser start --set-session-id s1
 actionbook browser start --session s1 --open-url https://google.com
 actionbook browser start -p hyperbrowser --session s1
 actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/ws
+actionbook browser start --auto-connect --session s1
 ```
+
+<Note>
+  `--auto-connect` discovers a locally running Chrome by reading Chrome's `DevToolsActivePort` file, then probing ports `[9222, 9229]`. It is mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches the session — it does not kill the external Chrome process. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND`, `CHROME_CDP_UNREACHABLE`.
+</Note>
 
 <Note>
   `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -42,6 +42,19 @@ When done, close the browser:
 actionbook browser close --session s1
 ```
 
+### Attach to a Running Chrome
+
+If Chrome is already running with remote debugging enabled, use `--auto-connect` to attach without launching a new instance:
+
+```bash
+actionbook browser start --auto-connect --session s1
+actionbook browser snapshot --session s1 --tab t1
+```
+
+<Note>
+  `--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) discovers Chrome by reading the `DevToolsActivePort` file, then probing ports `[9222, 9229]`. It is mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches the session — it does not kill the external Chrome process.
+</Note>
+
 ## Cloud Providers
 
 Cloud mode lets you run browser sessions on a remote provider instead of launching a local Chrome. Use the `-p` (or `--provider`) flag with `browser start`:

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -497,6 +497,7 @@ Session-level commands need only --session. Start and list-sessions need neither
 
 Session:
   start                              Start or attach a browser session
+  start --auto-connect               Attach to a locally running Chrome (auto-discover)
   list-sessions                      List all active sessions
   status              --session      Show session status
   close               --session      Close a session (alias: stop)

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -52,6 +52,7 @@ Every browser command is **stateless** — pass `--session` and `--tab` explicit
 
 ```bash
 actionbook browser start --set-session-id s1
+actionbook browser start --auto-connect --session s1   # Attach to a locally running Chrome
 ```
 
 ### Core workflow: snapshot, act, wait

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -28,6 +28,7 @@ actionbook browser start --open-url https://example.com    # Open URL on start
 actionbook browser start --profile myprofile               # Use named profile
 actionbook browser start --no-stealth                      # Disable anti-detection mode
 actionbook browser start --max-tracked-requests 1000       # Custom network buffer size (default 500, range 1-100000)
+actionbook browser start --auto-connect                    # Auto-discover and attach to a locally running Chrome
 
 actionbook browser list-sessions                           # List all active sessions (includes max_tracked_requests)
 actionbook browser status --session s1                     # Show session status
@@ -36,6 +37,8 @@ actionbook browser restart --session s1                    # Restart a session
 ```
 
 Supported cloud providers: `driver` (`DRIVER_API_KEY`), `hyperbrowser` (`HYPERBROWSER_API_KEY`), `browseruse` (`BROWSER_USE_API_KEY`). `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
+
+`--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) auto-discovers a locally running Chrome with remote debugging enabled. Discovery order: Chrome's `DevToolsActivePort` file, then probe ports `[9222, 9229]`. Mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches — it does not kill the external Chrome. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND` (no Chrome found), `CHROME_CDP_UNREACHABLE` (port found but CDP unreachable).
 
 ## Tab
 


### PR DESCRIPTION
## Summary
- Document `browser start --auto-connect` flag (PR #545 / ACT-953) across all doc surfaces
- Updated 5 files: CLI help (`main.rs`), command reference, `cli.mdx`, `browser.mdx`, `SKILL.md`
- Covers discovery order, mutual exclusions, close semantics, env var, and error codes

## Files changed
- `packages/cli/src/main.rs` — added `start --auto-connect` to browser help Session section
- `skills/actionbook/references/command-reference.md` — added example line and description paragraph
- `skills/actionbook/SKILL.md` — added auto-connect example to "Start a session" section
- `docs/api-reference/cli.mdx` — added to options table, examples, and Note block
- `docs/guides/browser.mdx` — added "Attach to a Running Chrome" subsection under Local Mode

## Test plan
- [ ] Verify `actionbook browser start --help` shows auto-connect
- [ ] Verify docs site renders correctly (cli.mdx, browser.mdx)
- [ ] Verify command-reference.md is accurate against implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)