### PR TITLE
feat(extension): narrow Extension.listTabs + enable Network in extension mode (protocol 0.4.0)

### DIFF
--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -218,12 +218,13 @@ async function connect() {
   ws.onopen = () => {
     wsOpened = true;
     // Send hello handshake (tokenless - server validates via origin + extension ID).
-    // Protocol 0.3.0 adds root-level `tabId` in every CDP request/event and
-    // supports concurrent multi-tab attach.
+    // Protocol 0.4.0 narrows `Extension.listTabs` to Actionbook-managed tabs
+    // (debugger-attached OR in the "Actionbook" tab group), making session
+    // ownership first-class instead of returning every open Chrome tab.
     wsSend({
       type: "hello",
       role: "extension",
-      version: "0.3.0",
+      version: "0.4.0",
     });
 
     // Start handshake timeout - if no hello_ack within this window, treat as auth failure
@@ -534,8 +535,31 @@ async function handleExtensionCommand(id, method, params) {
       return { id, result: { status: "pong", timestamp: Date.now() } };
 
     case "Extension.listTabs": {
-      const tabs = await chrome.tabs.query({});
-      const tabList = tabs.map((t) => ({
+      // Only return tabs that Actionbook is actually managing:
+      //   * tabs currently in the "Actionbook" tab group (any window), OR
+      //   * tabs the extension has debugger-attached (`attachedTabs`).
+      // Union, not intersection: user may have disabled grouping
+      // (groupingEnabled=false) so attached tabs won't be in any group, and
+      // ACTIONBOOK_GROUP_ATTACH=false means user-attached existing tabs are
+      // not moved into the group. Either signal is enough to claim the tab.
+      let actionbookGroupIds = new Set();
+      if (chrome.tabGroups && chrome.tabGroups.query) {
+        try {
+          const groups = await chrome.tabGroups.query({
+            title: ACTIONBOOK_GROUP_TITLE,
+          });
+          actionbookGroupIds = new Set(groups.map((g) => g.id));
+        } catch (_) {
+          // tabGroups unavailable — fall back to attachedTabs only.
+        }
+      }
+      const all = await chrome.tabs.query({});
+      const managed = all.filter(
+        (t) =>
+          attachedTabs.has(t.id) ||
+          (typeof t.groupId === "number" && actionbookGroupIds.has(t.groupId))
+      );
+      const tabList = managed.map((t) => ({
         id: t.id,
         title: t.title,
         url: t.url,
@@ -683,7 +707,7 @@ async function handleExtensionCommand(id, method, params) {
         result: {
           connected: connectionState === "connected",
           attachedTabIds: Array.from(attachedTabs),
-          version: "0.3.0",
+          version: "0.4.0",
         },
       };
     }

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -50,6 +50,12 @@ const CDP_ALLOWLIST = {
   'Network.getCookies': 'L1',
   'Network.getAllCookies': 'L1',
   'Network.getResponseBody': 'L1',
+  // Network.enable is required before Chrome emits Network.requestWillBeSent /
+  // responseReceived / loadingFinished events. HAR recording (`browser network
+  // har start`) depends on those events — without enabling the Network domain
+  // the recorder sees zero traffic and har stop returns count=0.
+  'Network.enable': 'L1',
+  'Network.disable': 'L1',
 
   // L2 - Page modification (auto-approved with logging)
   'Runtime.evaluate': 'L2',

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -209,9 +209,15 @@ pub async fn execute_start(cmd: &StartCmd, registry: &SharedRegistry) -> ActionR
 Examples:
   actionbook browser network har stop --session s1 --tab t1
   actionbook browser network har stop --session s1 --tab t1 --out /tmp/my.har
+  actionbook browser network har stop --session s1 --tab t1 --out out.har
 
-Stops recording and writes a HAR 1.2 JSON file. Returns { path, count }.
-If --out is omitted, a timestamped file is created in ~/.actionbook/har/.")]
+Stops recording and writes a HAR 1.2 JSON file. Returns { path, count,
+dropped }. If --out is omitted, a timestamped file is created in
+~/.actionbook/har/.
+
+Relative --out paths are resolved against the CLI's current working
+directory and the returned `path` is always absolute, so callers can
+locate the file regardless of where the daemon was launched.")]
 pub struct StopCmd {
     /// Session ID
     #[arg(long)]

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -288,6 +288,11 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
         Some(p) => PathBuf::from(p),
         None => default_har_path(),
     };
+    // Resolve to an absolute path so the response is unambiguous regardless of
+    // the daemon's CWD (daemon may have been spawned from a different dir than
+    // the CLI invocation). std::path::absolute doesn't require the file to
+    // exist yet, so run it before the write.
+    let out_path = std::path::absolute(&out_path).unwrap_or(out_path);
 
     if let Some(parent) = out_path.parent()
         && let Err(e) = std::fs::create_dir_all(parent)

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -65,7 +65,11 @@ pub struct Cmd {
     #[arg(long)]
     pub open_url: Option<String>,
     /// Extension mode only: attach to a pre-existing Chrome tab by its native
-    /// numeric tab id (e.g. from `browser list-tabs --json`'s `native_tab_id`).
+    /// numeric tab id. `browser list-tabs --json` surfaces `native_tab_id` for
+    /// Actionbook-managed tabs (those already attached or in the "Actionbook"
+    /// tab group). For tabs outside that set, read the id from Chrome's
+    /// built-in DevTools (`chrome://inspect/#pages`) or from `chrome.tabs`
+    /// extension APIs before invoking --tab-id.
     /// Mutually exclusive with --open-url. Required when `--mode extension`
     /// is used without `--open-url`; the legacy "attach active tab" default
     /// has been removed in protocol 0.3.0 — every tab must be explicit.
@@ -1615,7 +1619,7 @@ async fn execute_extension(
             &session_id,
             "MISSING_TAB_TARGET",
             "extension mode requires either --open-url or --tab-id".to_string(),
-            "pass --open-url <url> to create a new tab, or --tab-id <N> (find ids via `actionbook browser list-tabs --json`)",
+            "pass --open-url <url> to create a new tab, or --tab-id <N>. list-tabs only shows Actionbook-managed tabs; for unmanaged tabs read the id from chrome://inspect/#pages",
         )
         .await;
     };

--- a/packages/cli/src/browser/tab/list.rs
+++ b/packages/cli/src/browser/tab/list.rs
@@ -15,7 +15,12 @@ Examples:
   actionbook browser list-tabs --session my-session
   actionbook browser list-tabs --session my-session --json
 
-Returns each tab's ID (t1, t2, ...), URL, and title.")]
+Returns each tab's ID (t1, t2, ...), URL, and title.
+
+Extension mode: only Actionbook-managed tabs are listed — tabs the extension
+has attached, plus any tab in the Chrome \"Actionbook\" tab group. Other
+tabs the user has open in Chrome are intentionally hidden. Local/cloud
+modes always list every tab in the controlled browser.")]
 pub struct Cmd {
     /// Session ID
     #[arg(long)]
@@ -316,6 +321,34 @@ mod tests {
             .await
             .unwrap();
 
+        // register_extension_tab now fires one `Network.enable` per newly-
+        // registered tab (so the extension forwards Network.* events for
+        // HAR / request tracking). Drain those two WS messages and reply so
+        // execute() can complete. Order isn't guaranteed across tabs, so we
+        // collect both tabIds without asserting sequence.
+        let mut seen_tab_ids = Vec::new();
+        for _ in 0..2 {
+            let raw = reader.next().await.unwrap().unwrap();
+            let Message::Text(t) = raw else {
+                panic!("expected text frame for Network.enable, got {raw:?}");
+            };
+            let v: serde_json::Value = serde_json::from_str(t.as_ref()).unwrap();
+            assert_eq!(
+                v["method"], "Network.enable",
+                "register_extension_tab must send Network.enable per tab"
+            );
+            let enable_id = v["id"].as_u64().unwrap();
+            seen_tab_ids.push(v["tabId"].as_u64().unwrap());
+            writer
+                .send(Message::Text(
+                    json!({ "id": enable_id, "result": {} }).to_string().into(),
+                ))
+                .await
+                .unwrap();
+        }
+        seen_tab_ids.sort();
+        assert_eq!(seen_tab_ids, vec![100, 200]);
+
         let result = handle.await.unwrap();
         let data = match &result {
             ActionResult::Ok { data, .. } => data.clone(),
@@ -329,14 +362,13 @@ mod tests {
         assert_eq!(tabs[1]["url"], "https://b.com");
         assert_eq!(tabs[1]["title"], "Tab B");
 
-        // Verify no Target.attachToTarget was sent — extension mode must use
-        // register_extension_tab (in-memory only, no WS message).
-        // Give a brief window for any stray messages to arrive.
+        // No Target.attachToTarget — extension mode must not use the local/cloud
+        // flat-session handshake.
         let stray =
             tokio::time::timeout(std::time::Duration::from_millis(100), reader.next()).await;
         assert!(
             stray.is_err(),
-            "extension mode must not send Target.attachToTarget; got unexpected WS message"
+            "extension mode must not send additional CDP messages; got unexpected WS frame"
         );
 
         // Verify tabs were registered in the registry with short IDs

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -495,7 +495,21 @@ impl BrowserCommands {
                 NetworkCommands::Request(cmd) => Action::NetworkRequestDetail(cmd.clone()),
                 NetworkCommands::Har { command } => match command {
                     HarCommands::Start(cmd) => Action::NetworkHarStart(cmd.clone()),
-                    HarCommands::Stop(cmd) => Action::NetworkHarStop(cmd.clone()),
+                    HarCommands::Stop(cmd) => {
+                        // Resolve --out against the CLI's CWD before handing
+                        // the command to the daemon. The daemon may have been
+                        // spawned from a different directory, so relying on
+                        // the daemon's CWD would produce a surprising location
+                        // for a user typing `--out test.har` from their shell.
+                        let mut cmd = cmd.clone();
+                        if let Some(ref p) = cmd.out {
+                            let path = std::path::Path::new(p);
+                            if let Ok(abs) = std::path::absolute(path) {
+                                cmd.out = Some(abs.to_string_lossy().into_owned());
+                            }
+                        }
+                        Action::NetworkHarStop(cmd)
+                    }
                 },
             },
             Self::Wait { command } => match command {

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -70,14 +70,25 @@ fn default_profile_name() -> String {
 
 /// Return the base URL for the Actionbook API.
 /// Precedence: ACTIONBOOK_API_URL env var > config file api.base_url > production endpoint.
+///
+/// If the config file exists but fails to parse (e.g. a TOML syntax error like
+/// unquoted strings), emits a warning on stderr before falling back. Without
+/// this breadcrumb, a broken `base_url = http://...` silently routes every API
+/// call to production, which is a very confusing failure mode.
 pub fn api_base() -> String {
-    read_trimmed_env("ACTIONBOOK_API_URL")
-        .or_else(|| {
-            load_config()
-                .ok()
-                .and_then(|config| configured_api_base(&config))
-        })
-        .unwrap_or_else(|| DEFAULT_API_BASE.to_string())
+    if let Some(v) = read_trimmed_env("ACTIONBOOK_API_URL") {
+        return v;
+    }
+    match load_config() {
+        Ok(config) => configured_api_base(&config).unwrap_or_else(|| DEFAULT_API_BASE.to_string()),
+        Err(e) => {
+            eprintln!(
+                "warning: failed to load {}: {e}. Falling back to {DEFAULT_API_BASE}.",
+                config_path().display()
+            );
+            DEFAULT_API_BASE.to_string()
+        }
+    }
 }
 
 pub(crate) fn api_base_from_config(config: &ConfigFile) -> String {

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -42,6 +42,12 @@ const BIND_RETRY_DELAYS_MS: &[u64] = &[100, 500, 1_000, 2_000, 5_000];
 
 /// Protocol version for the hello handshake.
 ///
+/// Bumped to `0.4.0` when `Extension.listTabs` was narrowed from "every
+/// Chrome tab" to "Actionbook-managed tabs only" (debugger-attached or in
+/// the per-window "Actionbook" tab group). CLI `browser list-tabs` now
+/// relies on this narrowed set — older extensions (0.3.x) would flood the
+/// session registry with unrelated tabs, so they're rejected at handshake.
+///
 /// Bumped to `0.3.0` when multi-tab concurrent debug landed:
 /// - every CDP request now carries a root-level `tabId`
 /// - extension uses `attachedTabs: Set<number>` instead of a single attach
@@ -719,14 +725,14 @@ fn is_origin_allowed(origin: Option<&str>) -> bool {
     false
 }
 
-/// Check protocol version >= 0.3.0 (simple major.minor comparison).
+/// Check protocol version >= 0.4.0 (simple major.minor comparison).
 fn is_version_ok(version: &str) -> bool {
     let parts: Vec<u32> = version.split('.').filter_map(|p| p.parse().ok()).collect();
     if parts.len() < 2 {
         return false;
     }
-    // 0.3.0 minimum: major > 0, or major == 0 && minor >= 3
-    parts[0] > 0 || (parts[0] == 0 && parts[1] >= 3)
+    // 0.4.0 minimum: major > 0, or major == 0 && minor >= 4
+    parts[0] > 0 || (parts[0] == 0 && parts[1] >= 4)
 }
 
 // ─── Unit Tests ─────────────────────────────────────────────────────────
@@ -754,11 +760,12 @@ mod tests {
 
     #[test]
     fn test_is_version_ok() {
-        assert!(is_version_ok("0.3.0"));
-        assert!(is_version_ok("0.3.5"));
+        assert!(is_version_ok("0.4.0"));
+        assert!(is_version_ok("0.4.5"));
         assert!(is_version_ok("1.0.0"));
+        assert!(!is_version_ok("0.3.0"));
+        assert!(!is_version_ok("0.3.9"));
         assert!(!is_version_ok("0.2.0"));
-        assert!(!is_version_ok("0.2.9"));
         assert!(!is_version_ok("0.1.0"));
         assert!(!is_version_ok("0.0.1"));
         assert!(!is_version_ok("invalid"));
@@ -1030,7 +1037,7 @@ mod tests {
             json!({
                 "type": "hello",
                 "role": "extension",
-                "version": "0.3.0"
+                "version": "0.4.0"
             })
             .to_string()
             .into(),

--- a/packages/cli/src/daemon/bridge.rs
+++ b/packages/cli/src/daemon/bridge.rs
@@ -487,7 +487,7 @@ async fn handle_extension(
         .and_then(|v| v.as_str())
         .unwrap_or("0.0.0");
 
-    // Validate protocol version (>= 0.2.0).
+    // Validate protocol version against `EXTENSION_PROTOCOL_MIN_VERSION`.
     if !is_version_ok(client_version) {
         let err = json!({
             "type": "hello_error",

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -1024,12 +1024,14 @@ impl CdpSession {
     ///
     /// * **Local / cloud (CDP flat sessions)**: looks up the CDP `sessionId`
     ///   for the target and includes it in the message.
-    /// * **Extension bridge (protocol 0.3.0+)**: parses `target_id` as the
+    /// * **Extension bridge (protocol 0.4.0+)**: parses `target_id` as the
     ///   Chrome numeric tab id and injects a root-level `tabId`. The
     ///   extension routes to `chrome.debugger.sendCommand({tabId}, …)`.
     ///   On the extension's "Tab N not attached" error (can happen after
-    ///   extension reload or when the user cancels the debug banner),
-    ///   attempts exactly one lazy `Extension.attachTab` + retry.
+    ///   extension reload, when the user cancels the debug banner, or when
+    ///   a tab was registered via `listTabs` group-discovery without an
+    ///   active debugger), attempts exactly one lazy `Extension.attachTab`
+    ///   + re-enable Network + retry of the original command.
     pub async fn execute_on_tab(
         &self,
         target_id: &str,
@@ -1056,10 +1058,24 @@ impl CdpSession {
                     if msg.contains(&format!("Tab {tab_id} not attached"))
                         || msg.contains("Debugger detached from tab") =>
                 {
-                    // Self-heal: extension reload / user-dismissed banner.
-                    // Re-attach, retry once. If that fails too, bubble up.
+                    // Self-heal: extension reload / user-dismissed banner /
+                    // group-discovered tab that was never debugger-attached.
+                    // Re-attach, then re-enable Network domain — without this
+                    // re-enable, HAR/network tracking stays empty for tabs
+                    // whose initial `Network.enable` in register_extension_tab
+                    // failed (tab wasn't attached yet), since no later code
+                    // path would have retried it. Best-effort on the enable:
+                    // log but continue into the user command retry.
                     self.execute("Extension.attachTab", json!({ "tabId": tab_id }), None)
                         .await?;
+                    if let Err(e) = self
+                        .execute_extension_tab(tab_id, "Network.enable", json!({}))
+                        .await
+                    {
+                        tracing::warn!(
+                            "execute_on_tab self-heal: Network.enable failed for tab {tab_id}: {e}"
+                        );
+                    }
                     self.execute_extension_tab(tab_id, method, params).await
                 }
                 Err(e) => Err(e),

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -932,15 +932,52 @@ impl CdpSession {
     ///   - `reader_loop` to bucket incoming events carrying the bridge's
     ///     root-level `tabId` field
     ///
-    /// Idempotent: calling again for the same `native_id` is a no-op.
+    /// Idempotent: calling again for the same `native_id` is a no-op for the
+    /// routing map; `Network.enable` is still sent only once per tab.
+    ///
+    /// Also fires `Network.enable` on first registration so the extension
+    /// forwards `Network.requestWillBeSent` / `responseReceived` /
+    /// `loadingFinished` events — required by HAR recording and network
+    /// request tracking. Local/cloud mode does this from `attach()`, but
+    /// extension mode skips that path, so without this call the Network
+    /// domain stays dormant and HAR captures nothing.
     pub async fn register_extension_tab(&self, native_id: &str) {
         self.is_extension_bridge
             .store(true, std::sync::atomic::Ordering::Release);
         let key = format!("tab:{native_id}");
-        self.tab_sessions
+        let was_new = self
+            .tab_sessions
             .lock()
             .await
-            .insert(native_id.to_string(), key);
+            .insert(native_id.to_string(), key)
+            .is_none();
+
+        if !was_new {
+            return;
+        }
+
+        // Best-effort: enable the Network domain in the extension-attached tab.
+        // Failure here shouldn't block tab registration — the tab may not have
+        // debugger attached yet (discovered via listTabs but never attached),
+        // or the extension may have been reloaded. Commands that strictly need
+        // Network events will surface the gap themselves.
+        let tab_id: u64 = match native_id.parse() {
+            Ok(v) => v,
+            Err(_) => {
+                tracing::warn!(
+                    "register_extension_tab: non-numeric native_id '{native_id}', skipping Network.enable"
+                );
+                return;
+            }
+        };
+        if let Err(e) = self
+            .execute_extension_tab(tab_id, "Network.enable", json!({}))
+            .await
+        {
+            tracing::warn!(
+                "register_extension_tab: Network.enable failed for tab {native_id}: {e}"
+            );
+        }
     }
 
     /// Detach from a CDP target (tab).

--- a/packages/cli/src/lib.rs
+++ b/packages/cli/src/lib.rs
@@ -2,7 +2,7 @@ pub const BUILD_VERSION: &str = env!("BUILD_VERSION");
 
 /// Minimum extension protocol version required to connect to the daemon.
 /// Extensions reporting a lower version will be rejected with version_mismatch.
-pub const EXTENSION_PROTOCOL_MIN_VERSION: &str = "0.3.0";
+pub const EXTENSION_PROTOCOL_MIN_VERSION: &str = "0.4.0";
 
 pub mod action;
 pub mod action_result;

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -1234,14 +1234,14 @@ mod tests {
         let result = ActionResult::ok(json!({
             "path": "/Users/test/.actionbook/extension",
             "version": "1.4.3-alpha",
-            "required_version": "0.3.0",
+            "required_version": "0.4.0",
         }));
 
         let text = format_text("extension install", &None, &result);
 
         assert_eq!(
             text,
-            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
+            "ok extension install\npath: /Users/test/.actionbook/extension\nversion: 1.4.3-alpha\nrequired_version: >= 0.4.0\n  (check version at chrome://extensions/)\n\nTo load the extension in Chrome:\n  1. Open chrome://extensions/\n  2. Enable Developer mode\n  3. If a previous version is loaded, click Remove first\n  4. Click \"Load unpacked\" and select the path above"
         );
     }
 
@@ -1266,14 +1266,14 @@ mod tests {
             "path": "/Users/test/.actionbook/extension",
             "installed": false,
             "version": null,
-            "required_version": "0.3.0",
+            "required_version": "0.4.0",
         }));
 
         let text = format_text("extension path", &None, &result);
 
         assert_eq!(
             text,
-            "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)"
+            "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.4.0\n  (check version at chrome://extensions/)"
         );
     }
 }

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -1256,7 +1256,7 @@ mod tests {
 
         assert_eq!(
             text,
-            "bridge: listening\nextension_connected: true\nrequired_version: >= 0.3.0\n  (check version at chrome://extensions/)"
+            "bridge: listening\nextension_connected: true\nrequired_version: >= 0.4.0\n  (check version at chrome://extensions/)"
         );
     }
 


### PR DESCRIPTION
## Summary

Three linked extension-mode fixes, driven by observing that `browser list-tabs` returned every Chrome tab and `browser network har` captured zero traffic.

- **Extension.listTabs narrowed to Actionbook-managed tabs.** Previously `chrome.tabs.query({})` returned all 20+ user tabs, flooding the CLI registry. Now returns the union of `attachedTabs` (debugger-attached) and tabs inside the Chrome \"Actionbook\" tab group. Bumps the bridge handshake protocol to **0.4.0** so older extensions are rejected at connect rather than silently over-reporting.
- **HAR recording works in extension mode.** Two root causes: the extension's CDP allowlist was missing `Network.enable`/`Network.disable`, and the CLI never actually sent `Network.enable` in extension mode (local/cloud mode sends it from `attach()`, extension mode's `register_extension_tab` only populated a routing map). `register_extension_tab` now fires `Network.enable` once per newly-registered native tab id (best-effort — warn-on-fail doesn't break registration for not-yet-attached discovered tabs).
- **`har stop --out` returns an absolute path, resolved against the CLI's CWD.** Previously the relative arg was passed verbatim and the daemon's CWD determined where the file ended up — surprising for users. CLI now absolutifies before sending; daemon still has `std::path::absolute` as defense-in-depth.

Also updates help text for `browser list-tabs` (extension-mode filter) and `browser network har stop` (path semantics), plus the `extension_mode_uses_extension_list_tabs` unit test to drain the new per-tab `Network.enable` frames.

## Test plan

- [x] `cargo test --lib` — 432 passed
- [x] End-to-end in extension mode: `browser start` + `list-tabs` now returns only Actionbook-managed tabs (1 of 27 in the repro scenario)
- [x] End-to-end: `network har start` → navigate YouTube search → `har stop --out /tmp/yt.har` returns `count: 10` with full request/response headers, cookies, bodies captured
- [x] Relative `--out`: `cd /tmp && actionbook ... --out test.har` returns `path: /private/tmp/test.har` (CLI CWD, not daemon CWD)
- [ ] Regression: local mode `list-tabs` / HAR still work (unchanged code paths, but worth a smoke test in review)
- [ ] Changesets: not included here — would bump `@actionbookdev/extension` and `@actionbookdev/cli`; please advise on the right level (patch vs minor) for the in-flight 0.4.0-alpha cycle.