### PR TITLE
docs: update documentation for 1.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Actionbook provides tools for searching and retrieving action manuals. See the [
 
 ### Extension & Daemon
 
-The recommended way to install the Chrome extension is via the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.3.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome (`chrome://extensions` > Developer mode > Load unpacked).
+The recommended way to install the Chrome extension is via the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.4.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome (`chrome://extensions` > Developer mode > Load unpacked).
 
 ```bash
 actionbook extension status          # Bridge status + extension connection state

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -19,12 +19,12 @@ actionbook search [query]
 
 **Arguments:**
 
-- `query`: The search keyword (e.g., "airbnb", "google login").
+- `query`: The search keyword (e.g., "youtube", "youtube upload").
 
 **Example:**
 
 ```bash
-actionbook search "airbnb search"
+actionbook search "youtube"
 ```
 
 ## `actionbook get`
@@ -59,17 +59,17 @@ actionbook manual [site] [group] [action]
 
 **Arguments:**
 
-- `site`: Site name (e.g., "notion", "airbnb"). If omitted, lists available sites.
-- `group`: Group name within the site (e.g., "pages").
-- `action`: Action name within the group (e.g., "create_page").
+- `site`: Site name (e.g., "youtube", "airbnb"). If omitted, lists available sites.
+- `group`: Group name within the site (e.g., "videos").
+- `action`: Action name within the group (e.g., "search").
 
 **Examples:**
 
 ```bash
-actionbook manual notion                          # Overview of a site
-actionbook manual notion pages                    # Actions in a group
-actionbook manual notion pages create_page        # Detailed action docs
-actionbook man notion --json                      # Alias with JSON output
+actionbook manual youtube                         # Overview of a site
+actionbook manual youtube videos                  # Actions in a group
+actionbook manual youtube videos search           # Detailed action docs
+actionbook man youtube --json                     # Alias with JSON output
 ```
 
 ## `actionbook setup`

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -47,6 +47,31 @@ actionbook get [actionId]
 actionbook get "site/airbnb.com/page/home/element/search-button"
 ```
 
+## `actionbook manual`
+
+Get detailed manual information for a site, group, or action. Alias: `man`.
+
+**Usage:**
+
+```bash
+actionbook manual [site] [group] [action]
+```
+
+**Arguments:**
+
+- `site`: Site name (e.g., "notion", "airbnb"). If omitted, lists available sites.
+- `group`: Group name within the site (e.g., "pages").
+- `action`: Action name within the group (e.g., "create_page").
+
+**Examples:**
+
+```bash
+actionbook manual notion                          # Overview of a site
+actionbook manual notion pages                    # Actions in a group
+actionbook manual notion pages create_page        # Detailed action docs
+actionbook man notion --json                      # Alias with JSON output
+```
+
 ## `actionbook setup`
 
 Initial setup wizard for API key, browser preferences, health checks, and optional skills install.
@@ -258,6 +283,10 @@ actionbook browser wait condition "document.readyState === 'complete'" --session
 
 Default timeout: 30000ms. Override with `--timeout <ms>`.
 
+<Note>
+  `wait network-idle` automatically falls back from **strict** (zero in-flight requests for 500ms) to **relaxed** mode on pages with persistent background traffic. Relaxed mode requires fewer than 5 new requests in a 10s window with ≤5 pending, sustained for 3s. The response includes `mode` ("strict" or "relaxed") so callers know which condition was met.
+</Note>
+
 ### Logs & Network
 
 ```bash
@@ -313,7 +342,7 @@ actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
 
 Manage the Chrome extension used by extension mode. The extension bridge runs inside the actionbook daemon (auto-started by browser commands).
 
-The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.3.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, using the path from `actionbook extension path`.
+The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.4.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, using the path from `actionbook extension path`.
 
 ```bash
 actionbook extension status                   # Bridge status + extension connection state
@@ -325,6 +354,10 @@ actionbook extension path                     # Print install path, status, and 
 ```
 
 `extension status` returns the bridge state (`listening`, `not_listening`, or `failed`) and whether the extension is connected. `extension ping` connects to the bridge WebSocket at `ws://127.0.0.1:19222` and measures round-trip time.
+
+<Note>
+  **Extension 0.4.0 changes:** Tabs opened by Actionbook are automatically grouped into a Chrome tab group titled "Actionbook" (toggleable via the extension popup). In extension mode, `list-tabs` now returns only Actionbook-managed tabs (debugger-attached or in the Actionbook tab group) — other user tabs are hidden. Extension versions below 0.4.0 are rejected at handshake.
+</Note>
 
 ---
 

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -170,7 +170,7 @@ If you've configured `mode = "extension"` in your config file, you only need to 
 
 The `actionbook extension` commands manage the Chrome extension and its connection to the actionbook daemon.
 
-The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.3.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, using the path from `actionbook extension path`.
+The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.4.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, using the path from `actionbook extension path`.
 
 ```bash
 actionbook extension status                   # Bridge status + extension connection state
@@ -182,6 +182,10 @@ actionbook extension path                     # Print install path, status, and 
 ```
 
 The extension bridge runs inside the actionbook daemon (auto-started by browser commands). `extension status` shows whether the bridge is listening and the extension is connected. `extension ping` tests connectivity by connecting to the bridge WebSocket at `ws://127.0.0.1:19222`.
+
+<Note>
+  **Extension 0.4.0:** Tabs opened by Actionbook are automatically grouped into a Chrome "Actionbook" tab group (toggleable via extension popup). `list-tabs` in extension mode now returns only Actionbook-managed tabs — other user tabs are hidden. Extensions below 0.4.0 are rejected at handshake.
+</Note>
 
 ## Configuration
 
@@ -271,6 +275,10 @@ actionbook browser wait navigation --session s1 --tab t1
 actionbook browser wait network-idle --session s1 --tab t1
 actionbook browser wait condition "document.readyState === 'complete'" --session s1 --tab t1
 ```
+
+<Tip>
+  `wait network-idle` automatically falls back to **relaxed** mode on pages with persistent background traffic (analytics pings, health-checks). Relaxed mode tolerates low-rate background requests instead of requiring absolute silence. The response includes `mode` ("strict" or "relaxed").
+</Tip>
 
 ### Observation & Export
 

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: actionbook
 description: Browser action engine. Provides up-to-date action manuals for the modern web — operate any website instantly, one tab or dozens, concurrently.
-version: 1.4.3
+version: 1.5.0
 license: MIT
 platforms: [macos, linux, windows]
 metadata:
@@ -77,6 +77,8 @@ All commands support `--help` for full usage and examples.
 
 | Category | Key commands | Help |
 |----------|-------------|------|
+| Search | `search` | `actionbook search --help` |
+| Manual | `manual` (alias: `man`) | `actionbook manual --help` |
 | Session | `start`, `close`, `restart`, `list-sessions`, `status` | `actionbook browser start --help` |
 | Tab | `new-tab`, `close-tab`, `list-tabs` | `actionbook browser new-tab --help` |
 | Navigation | `goto`, `back`, `forward`, `reload` | `actionbook browser goto --help` |

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -4,6 +4,7 @@ Complete reference for all `actionbook` CLI commands.
 
 Every browser command requires `--session <SID>`. Most also require `--tab <TID>`.
 Session-level commands (start, close, restart, status, list-sessions) need only `--session` or nothing.
+Session IDs accept lowercase letters, digits, hyphens, and underscores (e.g., `s1`, `my-session`, `task_01`).
 
 Selectors accept CSS, XPath, or snapshot refs (`@eN` from `snapshot` output).
 
@@ -12,6 +13,23 @@ Selectors accept CSS, XPath, or snapshot refs (`@eN` from `snapshot` output).
 ```
 --json            Output as JSON envelope
 --timeout <ms>    Command timeout in milliseconds
+```
+
+## Search
+
+```bash
+actionbook search "airbnb"                                 # Search for action manuals by keyword
+actionbook search "google login" --json                    # Search with JSON output
+```
+
+## Manual
+
+```bash
+actionbook manual notion                                   # Overview of a site (groups & actions)
+actionbook manual notion pages                             # Actions in a group
+actionbook manual notion pages create_page                 # Detailed action documentation
+actionbook manual notion --json                            # JSON output
+actionbook man notion                                      # Alias for manual
 ```
 
 ## Session
@@ -262,6 +280,8 @@ actionbook browser wait condition "document.readyState === 'complete'" --session
 
 Default timeout for all wait commands: 30000ms. Override with `--timeout <ms>`.
 
+`wait network-idle` uses two modes automatically. **Strict**: zero in-flight requests for 500ms. **Relaxed** (fallback): when pages have persistent background traffic (analytics pings, health-checks), relaxed mode kicks in — requires fewer than 5 new requests in a 10s sliding window with ≤5 pending, sustained for 3s. The response includes `mode` ("strict" or "relaxed") so callers know which condition was satisfied.
+
 ## Cookies
 
 Cookie commands operate at session level (no `--tab` required).
@@ -316,7 +336,7 @@ actionbook browser batch-click @e5 @e6 @e7 --session s1 --tab t1
 
 Manage the Chrome extension used by extension mode. The extension bridge runs inside the actionbook daemon (auto-started by browser commands).
 
-The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.3.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, pointing to the path from `actionbook extension path`.
+The recommended install method is the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.4.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome via `chrome://extensions` > Developer mode > Load unpacked, pointing to the path from `actionbook extension path`.
 
 ```bash
 actionbook extension status                          # Bridge status + extension connection state
@@ -328,6 +348,8 @@ actionbook extension path                            # Print install path, insta
 ```
 
 `extension status` returns `bridge` state (`listening`, `not_listening`, or `failed`) and `extension_connected` (boolean). `extension ping` connects directly to the bridge WebSocket and measures round-trip time.
+
+**Extension 0.4.0 changes:** Tabs opened by Actionbook are automatically grouped into a Chrome tab group titled "Actionbook" (toggleable via extension popup). In extension mode, `list-tabs` returns only Actionbook-managed tabs (debugger-attached or in the Actionbook tab group) — other user tabs are hidden. Local/cloud modes are unaffected. Extensions below 0.4.0 are rejected at handshake with a protocol mismatch error.
 
 ## Daemon
 

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -18,18 +18,18 @@ Selectors accept CSS, XPath, or snapshot refs (`@eN` from `snapshot` output).
 ## Search
 
 ```bash
-actionbook search "airbnb"                                 # Search for action manuals by keyword
-actionbook search "google login" --json                    # Search with JSON output
+actionbook search "youtube"                                # Search for action manuals by keyword
+actionbook search "youtube upload" --json                  # Search with JSON output
 ```
 
 ## Manual
 
 ```bash
-actionbook manual notion                                   # Overview of a site (groups & actions)
-actionbook manual notion pages                             # Actions in a group
-actionbook manual notion pages create_page                 # Detailed action documentation
-actionbook manual notion --json                            # JSON output
-actionbook man notion                                      # Alias for manual
+actionbook manual youtube                                  # Overview of a site (groups & actions)
+actionbook manual youtube videos                           # Actions in a group
+actionbook manual youtube videos search                    # Detailed action documentation
+actionbook manual youtube --json                           # JSON output
+actionbook man youtube                                     # Alias for manual
 ```
 
 ## Session


### PR DESCRIPTION
## Summary
Comprehensive documentation update for the 1.5.0 release, covering all changes since 1.4.3.

- **`manual` command**: New top-level command (`actionbook manual [site] [group] [action]`, alias: `man`) added to cli.mdx, command-reference, SKILL.md
- **`search`/`manual` in SKILL.md**: Added to command categories table so AI agents discover them
- **Relaxed-idle mode**: Documented automatic fallback in `wait network-idle` for pages with background traffic (strict → relaxed)
- **Extension 0.4.0**: Version bump (0.3.0 → 0.4.0), tab grouping feature, `list-tabs` scoping to Actionbook-managed tabs, protocol handshake rejection for old extensions
- **Session ID underscores**: Noted that `_` is now valid in session IDs
- **SKILL.md version**: Bumped from 1.4.3 to 1.5.0

## Files changed (5)
- `README.md` — extension version 0.3.0 → 0.4.0
- `docs/api-reference/cli.mdx` — manual command, relaxed-idle note, extension 0.4.0 note
- `docs/guides/browser.mdx` — relaxed-idle tip, extension 0.4.0 note, version bump
- `skills/actionbook/SKILL.md` — version bump, search/manual in categories table
- `skills/actionbook/references/command-reference.md` — search/manual sections, relaxed-idle, extension 0.4.0, session ID format

## Test plan
- [ ] Verify docs site renders correctly (cli.mdx, browser.mdx)
- [ ] Verify command-reference matches implemented CLI
- [ ] Verify SKILL.md version matches release target

🤖 Generated with [Claude Code](https://claude.com/claude-code)