### PR TITLE
docs: auto-connect step-by-step guide with Chrome 144+ requirement

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -142,7 +142,12 @@ actionbook browser start --auto-connect --session s1
 ```
 
 <Note>
-  `--auto-connect` discovers a locally running Chrome by reading Chrome's `DevToolsActivePort` file, then probing ports `[9222, 9229]`. It is mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches the session — it does not kill the external Chrome process. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND`, `CHROME_CDP_UNREACHABLE`.
+  `--auto-connect` requires **Chrome 144+**. For older versions, use extension mode instead. Start Chrome with remote debugging enabled first:
+  ```bash
+  google-chrome --remote-debugging-port=9222   # Linux
+  # macOS: /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+  ```
+  Actionbook discovers Chrome by reading the `DevToolsActivePort` file, then probing ports `[9222, 9229]`. Mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches — it does not kill the external Chrome. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND`, `CHROME_CDP_UNREACHABLE`. See [Attach to a Running Chrome](/guides/browser#attach-to-a-running-chrome-auto-connect) for a step-by-step guide.
 </Note>
 
 <Note>

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -42,17 +42,59 @@ When done, close the browser:
 actionbook browser close --session s1
 ```
 
-### Attach to a Running Chrome
+### Attach to a Running Chrome (Auto-Connect)
 
-If Chrome is already running with remote debugging enabled, use `--auto-connect` to attach without launching a new instance:
+Use `--auto-connect` to attach to a Chrome instance you've already started — useful when you need your existing login sessions, extensions, or a specific Chrome configuration.
 
-```bash
-actionbook browser start --auto-connect --session s1
-actionbook browser snapshot --session s1 --tab t1
-```
+<Warning>
+  Auto-connect requires **Chrome 144 or newer**. For older Chrome versions, use [Extension mode](#extension-mode-setup) instead.
+</Warning>
+
+<Steps>
+  <Step title="Start Chrome with remote debugging enabled">
+    ```bash
+    # macOS
+    /Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+
+    # Linux
+    google-chrome --remote-debugging-port=9222
+
+    # Windows
+    "C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+    ```
+
+    You can also add `--user-data-dir=/tmp/chrome-debug` for a clean profile, or omit it to use your default profile with all your logged-in sessions.
+  </Step>
+
+  <Step title="Attach Actionbook to the running Chrome">
+    ```bash
+    actionbook browser start --auto-connect --session s1
+    ```
+
+    Actionbook auto-discovers the running Chrome by reading the `DevToolsActivePort` file, then probing ports `[9222, 9229]`. No manual endpoint configuration needed.
+  </Step>
+
+  <Step title="Use browser commands as usual">
+    ```bash
+    actionbook browser list-tabs --session s1
+    actionbook browser snapshot --session s1 --tab t1
+    actionbook browser click @e5 --session s1 --tab t1
+    ```
+
+    All browser commands work the same way. Existing tabs in Chrome are available immediately.
+  </Step>
+
+  <Step title="Detach when done">
+    ```bash
+    actionbook browser close --session s1
+    ```
+
+    This only detaches the Actionbook session — it does **not** kill the external Chrome process. Your Chrome stays running with all tabs intact.
+  </Step>
+</Steps>
 
 <Note>
-  `--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) discovers Chrome by reading the `DevToolsActivePort` file, then probing ports `[9222, 9229]`. It is mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches the session — it does not kill the external Chrome process.
+  `--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) is mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND` (no running Chrome found), `CHROME_CDP_UNREACHABLE` (Chrome found but CDP unreachable — verify `--remote-debugging-port` was set).
 </Note>
 
 ## Cloud Providers

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -56,7 +56,29 @@ actionbook browser restart --session s1                    # Restart a session
 
 Supported cloud providers: `driver` (`DRIVER_API_KEY`), `hyperbrowser` (`HYPERBROWSER_API_KEY`), `browseruse` (`BROWSER_USE_API_KEY`). `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
 
-`--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) auto-discovers a locally running Chrome with remote debugging enabled. Discovery order: Chrome's `DevToolsActivePort` file, then probe ports `[9222, 9229]`. Mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. `browser close` only detaches — it does not kill the external Chrome. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND` (no Chrome found), `CHROME_CDP_UNREACHABLE` (port found but CDP unreachable).
+`--auto-connect` (env: `ACTIONBOOK_AUTO_CONNECT`) attaches to a Chrome you've started with remote debugging enabled. **Requires Chrome 144+** — for older versions, use extension mode instead. **Prerequisite**: start Chrome with `--remote-debugging-port`:
+
+```bash
+# macOS
+/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --remote-debugging-port=9222
+
+# Linux
+google-chrome --remote-debugging-port=9222
+
+# Windows
+"C:\Program Files\Google\Chrome\Application\chrome.exe" --remote-debugging-port=9222
+```
+
+Then attach:
+
+```bash
+actionbook browser start --auto-connect --session s1
+actionbook browser list-tabs --session s1                  # See existing Chrome tabs
+actionbook browser snapshot --session s1 --tab t1
+actionbook browser close --session s1                      # Detach only — Chrome stays running
+```
+
+Discovery order: Chrome's `DevToolsActivePort` file, then probe ports `[9222, 9229]`. Mutually exclusive with `--cdp-endpoint`, `-p/--provider`, `--mode cloud`, and `--mode extension`. Error codes: `CHROME_AUTO_CONNECT_NOT_FOUND` (no Chrome found), `CHROME_CDP_UNREACHABLE` (port found but CDP unreachable).
 
 ## Tab
 


### PR DESCRIPTION
## Summary
- Expand auto-connect docs into a full step-by-step usage guide (referenced agent-browser style)
- Add **Chrome 144+** requirement — older versions should use extension mode
- Chrome startup commands for macOS, Linux, and Windows
- Full attach → use → detach workflow
- Emphasizes attach-to-existing semantics (not auto-launch)

## Files changed (3)
- `docs/guides/browser.mdx` — full Steps component with 4 steps, Warning for Chrome 144+
- `docs/api-reference/cli.mdx` — expanded Note with Chrome startup example + link to guide
- `skills/actionbook/references/command-reference.md` — prerequisite + 3-platform startup commands + attach workflow

## Test plan
- [ ] Verify docs site renders Steps/Warning/Note components correctly
- [ ] Verify command examples match implemented CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)