### PR TITLE
fix(wait): dual-threshold stability for already-loaded navigation (ACT-938-a)

### DIFF
--- a/packages/cli/src/browser/wait/navigation.rs
+++ b/packages/cli/src/browser/wait/navigation.rs
@@ -30,7 +30,7 @@ const URL_STABILITY_MS: u64 = 300;
 /// (e.g. 1200ms) will not fire before the window expires, so the intermediate
 /// page may be incorrectly accepted.  This is a deliberate tradeoff — the
 /// pre-fix behaviour was a guaranteed TIMEOUT for this case.  A follow-up
-/// (ACT-938-b) will explore a more robust signal (network-idle or explicit
+/// (ACT-963) will explore a more robust signal (network-idle or explicit
 /// flag) for callers that need to tolerate longer redirect delays.
 const URL_STABILITY_SAME_URL_MS: u64 = 800;
 

--- a/packages/cli/src/browser/wait/navigation.rs
+++ b/packages/cli/src/browser/wait/navigation.rs
@@ -25,6 +25,13 @@ const URL_STABILITY_MS: u64 = 300;
 /// before this window expires, preventing premature acceptance of intermediate
 /// pages.  When no redirect fires the window expires and we accept the page as
 /// already-completed.
+///
+/// Known limitation: a `setTimeout` redirect scheduled beyond this window
+/// (e.g. 1200ms) will not fire before the window expires, so the intermediate
+/// page may be incorrectly accepted.  This is a deliberate tradeoff — the
+/// pre-fix behaviour was a guaranteed TIMEOUT for this case.  A follow-up
+/// (ACT-938-b) will explore a more robust signal (network-idle or explicit
+/// flag) for callers that need to tolerate longer redirect delays.
 const URL_STABILITY_SAME_URL_MS: u64 = 800;
 
 const READY_STATE_JS: &str =

--- a/packages/cli/src/browser/wait/navigation.rs
+++ b/packages/cli/src/browser/wait/navigation.rs
@@ -13,12 +13,19 @@ use crate::output::ResponseContext;
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const POLL_INTERVAL_MS: u64 = 100;
 
-/// After detecting `url != prev_url + readyState=complete` we require the URL
-/// to remain stable (same value, still complete) for this many milliseconds
-/// before accepting.  This window must exceed the longest intermediate-redirect
-/// delay we expect to encounter so that delayed-redirect chains are not
-/// prematurely accepted at an intermediate page.
+/// After detecting `readyState=complete` with a URL that differs from the
+/// registry baseline, require the URL to remain stable (same value, still
+/// complete) for this many milliseconds before accepting.  Short because when
+/// the URL has already changed we mainly want confirmation that it settled.
 const URL_STABILITY_MS: u64 = 300;
+
+/// Stability window when the observed URL matches the registry baseline.
+/// Must exceed the longest JS-redirect delay we expect to encounter: the
+/// `Page.frameNavigated` event from a pending redirect will reset the tracker
+/// before this window expires, preventing premature acceptance of intermediate
+/// pages.  When no redirect fires the window expires and we accept the page as
+/// already-completed.
+const URL_STABILITY_SAME_URL_MS: u64 = 800;
 
 const READY_STATE_JS: &str =
     "(function(){ return { url: location.href, ready_state: document.readyState }; })()";
@@ -130,8 +137,6 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let start = Instant::now();
 
     // Read the tab URL recorded when the previous command completed.
-    // Used as the baseline: if the live URL already differs from this on the
-    // first poll, navigation completed between the last command and now.
     let prev_url = {
         let reg = registry.lock().await;
         reg.get_tab_url_title(&cmd.session, &cmd.tab)
@@ -167,10 +172,12 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let mut poll_interval = tokio::time::interval(Duration::from_millis(POLL_INTERVAL_MS));
     poll_interval.tick().await; // consume the immediate first tick
 
-    // Time-based stability tracker for the "already-navigated" fast-redirect case.
-    // When we first detect `current_url != prev_url + readyState=complete` we start
-    // the clock.  We accept only when the URL remains stable for URL_STABILITY_MS.
-    // Any intervening frameNavigated event or non-complete readyState resets this.
+    // Time-based stability tracker.  When readyState first becomes "complete" we
+    // start the clock.  The required stability window depends on whether the current
+    // URL matches the registry baseline: a matching URL may have a pending JS redirect
+    // so we use a longer window (URL_STABILITY_SAME_URL_MS); a differing URL just needs
+    // short confirmation (URL_STABILITY_MS).  Any intervening frameNavigated event or
+    // non-complete readyState resets this.
     let mut stable_since: Option<(Instant, String)> = None;
 
     loop {
@@ -229,17 +236,23 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                     return build_ok(elapsed_ms, &current_url, &title);
                 }
 
-                // Weak-signal path: URL differs from registry baseline.
-                // We can't immediately accept because this might be an intermediate
-                // page in a redirect chain.  Require URL_STABILITY_MS of continuous
-                // stability (same URL + complete) before accepting.
-                if current_url != prev_url && ready_state == "complete" {
+                // Weak-signal path: page is complete — accept after the appropriate
+                // stability window has elapsed with the same URL.  When the observed URL
+                // matches the registry baseline we use the longer window so that a pending
+                // JS redirect (which resets the tracker via frameNavigated) fires before
+                // we accept the intermediate page.
+                if ready_state == "complete" {
+                    let threshold_ms = if current_url == prev_url {
+                        URL_STABILITY_SAME_URL_MS
+                    } else {
+                        URL_STABILITY_MS
+                    };
                     match &stable_since {
                         None => {
                             stable_since = Some((Instant::now(), current_url));
                         }
                         Some((since, tracked_url)) if *tracked_url == current_url => {
-                            if since.elapsed().as_millis() >= URL_STABILITY_MS as u128 {
+                            if since.elapsed().as_millis() >= threshold_ms as u128 {
                                 let title = nav_helpers::get_tab_title(&cdp, &target_id).await;
                                 let elapsed_ms = start.elapsed().as_millis() as u64;
                                 return build_ok(elapsed_ms, &current_url, &title);
@@ -252,7 +265,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                         }
                     }
                 } else {
-                    // Page is in motion (loading or still at prev_url) → reset stability.
+                    // Page is in motion (not yet complete) → reset stability.
                     stable_since = None;
                 }
             }

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -536,6 +536,28 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/redirect-delayed-long" {
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Redirect Delayed Long</title></head>
+<body>
+<h1>Redirect Delayed Long</h1>
+<script>
+setTimeout(() => {{
+  window.location.href = "http://127.0.0.1:{}/page-b";
+}}, 600);
+</script>
+</body></html>"#,
+            local_server().port
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // ── Mock API for search/manual e2e tests ──────────────────────────
 
     if path.starts_with("/api/search") {
@@ -835,6 +857,19 @@ pub fn url_fast_redirect() -> String {
 /// URL that redirects to page B after a short client-side delay.
 pub fn url_delayed_redirect() -> String {
     format!("http://127.0.0.1:{}/redirect-delayed", local_server().port)
+}
+
+/// URL that redirects to page B after a longer client-side delay.
+pub fn url_delayed_redirect_long() -> String {
+    format!(
+        "http://127.0.0.1:{}/redirect-delayed-long",
+        local_server().port
+    )
+}
+
+/// Root URL without a trailing slash. Browsers normalize this to `/`.
+pub fn url_home_no_trailing_slash() -> String {
+    format!("http://127.0.0.1:{}", local_server().port)
 }
 
 /// URL for a slow page used to verify CLI-level timeouts.

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -3,7 +3,8 @@
 use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
-    url_delayed_redirect, url_fast_redirect, wait_page_ready,
+    url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
+    wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -88,6 +89,15 @@ fn schedule_navigation_to(sid: &str, tid: &str, destination_url: &str) {
         10,
     );
     assert_success(&out, "schedule delayed navigation");
+}
+
+fn open_new_tab(sid: &str, url: &str) -> String {
+    let out = headless_json(&["browser", "new-tab", url, "--session", sid], 30);
+    assert_success(&out, "open new tab");
+    parse_json(&out)["data"]["tab"]["tab_id"]
+        .as_str()
+        .unwrap()
+        .to_string()
 }
 
 #[test]
@@ -333,6 +343,95 @@ fn wait_navigation_detects_fast_redirect_when_final_url_is_already_loaded() {
 }
 
 #[test]
+fn wait_navigation_accepts_stable_complete_state_at_current_url() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_a());
+    wait_page_ready(&sid, &tid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "navigation",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "1500",
+        ],
+        10,
+    );
+    assert_success(&out, "wait navigation after page already settled");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait navigation");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["kind"], "navigation");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert!(
+        v["data"]["observed_value"]["url"]
+            .as_str()
+            .unwrap_or("")
+            .contains("page-a"),
+        "observed_value.url must stay on page-a: {}",
+        v["data"]["observed_value"]
+    );
+    assert_eq!(v["data"]["observed_value"]["ready_state"], "complete");
+}
+
+#[test]
+fn wait_navigation_keeps_root_url_without_trailing_slash_regression_green() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_home_no_trailing_slash());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "navigation",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "3000",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait navigation after root url without trailing slash",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait navigation");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["kind"], "navigation");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert_eq!(v["context"]["title"], "Home");
+    assert_eq!(v["data"]["observed_value"]["ready_state"], "complete");
+    assert!(
+        v["data"]["observed_value"]["url"]
+            .as_str()
+            .unwrap_or("")
+            .ends_with('/'),
+        "root URL should normalize to trailing slash: {}",
+        v["data"]["observed_value"]
+    );
+}
+
+#[test]
 fn wait_navigation_detects_delayed_redirect_via_real_page_navigation() {
     if skip() {
         return;
@@ -386,6 +485,47 @@ fn wait_navigation_detects_delayed_redirect_via_real_page_navigation() {
             .unwrap_or("")
             .contains("page-b"),
         "observed_value.url must point at page-b: {}",
+        v["data"]["observed_value"]
+    );
+}
+
+#[test]
+fn wait_navigation_does_not_accept_intermediate_complete_url_before_long_redirect() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_delayed_redirect_long());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "navigation",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "5000",
+        ],
+        10,
+    );
+    assert_success(&out, "wait navigation after long delayed redirect");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait navigation");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["kind"], "navigation");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert!(
+        v["data"]["observed_value"]["url"]
+            .as_str()
+            .unwrap_or("")
+            .contains("page-b"),
+        "wait must accept only the final redirect URL: {}",
         v["data"]["observed_value"]
     );
 }

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -363,7 +363,7 @@ fn wait_navigation_accepts_stable_complete_state_at_current_url() {
             "--tab",
             &tid,
             "--timeout",
-            "1500",
+            "2500",
         ],
         10,
     );


### PR DESCRIPTION
## Summary

Fixes [ACT-938](https://linear.app/actionbook/issue/ACT-938) — `browser wait navigation` times out when the page is already loaded at the same URL as the registry baseline.

**Root cause**: the old weak-signal path required `current_url != prev_url` before starting the stability tracker. When the caller invokes `wait navigation` after the page has already finished loading at the baseline URL (e.g. after `goto` or `new-tab` + `wait page-ready`), `current_url == prev_url` is always true so the tracker never starts → guaranteed TIMEOUT.

**Fix**: dual stability thresholds based on whether the live URL matches the registry baseline:
- `current_url == prev_url && ready_state == complete` → `URL_STABILITY_SAME_URL_MS = 800ms` (new slow path). Long enough that any pending JS redirect fires its `Page.frameNavigated` event and resets the tracker before the window expires, preventing premature acceptance of intermediate pages.
- `current_url != prev_url && ready_state == complete` → `URL_STABILITY_MS = 300ms` (existing fast path, unchanged). URL has already changed; just needs short confirmation it settled.

All three reset conditions remain in place: `frameNavigated`, URL change within the tracker, and `ready_state != complete`.

## Repro (before fix)

```bash
# start a session, open page-a, wait for it to be ready, then call wait navigation
# → used to timeout every time because current_url == prev_url == page-a
RUN_E2E_TESTS=true cargo test --test e2e wait_navigation_accepts_stable_complete_state_at_current_url -- --nocapture
```

## Test matrix (all 4 must be green)

| # | Test | Scenario | Expected |
|---|------|----------|----------|
| 1 | `wait_navigation_accepts_stable_complete_state_at_current_url` | Page already `readyState=complete` at baseline URL (positive fix target) | ✅ accept after 800ms stability |
| 2 | `wait_navigation_keeps_root_url_without_trailing_slash_regression_green` | Root URL without trailing slash; browser normalises to `/` so `current_url != prev_url` | ✅ accept via 300ms fast path |
| 3 | `wait_navigation_does_not_accept_intermediate_complete_url_before_long_redirect` | Page briefly completes at `/redirect-delayed-long`, JS redirect fires at 600ms | ✅ `frameNavigated` resets tracker before 800ms window; accepts final page-b |
| 4 | `wait_navigation_detects_delayed_redirect_via_real_page_navigation` | Short (150ms) in-flight JS redirect; `current_url != prev_url` since eval doesn't update registry | ✅ 300ms fast path picks up page-b |

## Test plan

```bash
RUN_E2E_TESTS=true cargo test --manifest-path packages/cli/Cargo.toml \
  --test e2e wait_navigation_ -- --test-threads=1 --nocapture
# expected: 7 passed; 0 failed — finished in ~11s
```