### PR TITLE
fix(network-idle): exclude loading=lazy off-screen images from idle check (ACT-964)

### DIFF
--- a/packages/cli/src/browser/wait/network_idle.rs
+++ b/packages/cli/src/browser/wait/network_idle.rs
@@ -106,11 +106,23 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let js = r#"(function() {
         if (document.readyState !== 'complete') { return { ready: false, unloaded_imgs: 1 }; }
         var imgs = Array.prototype.slice.call(document.querySelectorAll('img'));
-        // Exclude loading="lazy" images that are off-screen: Chromium does not start
-        // loading them until they enter the viewport, so their .complete stays false
-        // indefinitely.  Once a lazy image scrolls into view and finishes loading,
-        // .complete becomes true and the filter correctly includes it again.
-        var unloaded = imgs.filter(function(i) { return !i.complete && i.loading !== 'lazy'; }).length;
+        // Non-lazy images must always be complete.  For loading="lazy" images:
+        // Chromium withholds the fetch until the image is within ~2500px of the
+        // viewport, so a below-fold lazy image stays .complete===false forever and
+        // would block idle.  We exempt lazy images that are truly off-screen (>3000px
+        // from the viewport in any direction, safely beyond the Chromium threshold).
+        // Lazy images within 3000px are in the "about to load" zone and are treated
+        // like non-lazy images — their .complete===false continues to block idle.
+        // Once any lazy image finishes loading, .complete becomes true and is no
+        // longer counted regardless of position.
+        var vh = window.innerHeight, vw = window.innerWidth, m = 3000;
+        var unloaded = imgs.filter(function(i) {
+          if (i.complete) return false;
+          if (i.loading !== 'lazy') return true;
+          var r = i.getBoundingClientRect();
+          var offscreen = r.bottom < -m || r.top > vh + m || r.right < -m || r.left > vw + m;
+          return !offscreen;
+        }).length;
         return { ready: true, unloaded_imgs: unloaded };
     })()"#;
 

--- a/packages/cli/src/browser/wait/network_idle.rs
+++ b/packages/cli/src/browser/wait/network_idle.rs
@@ -106,7 +106,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let js = r#"(function() {
         if (document.readyState !== 'complete') { return { ready: false, unloaded_imgs: 1 }; }
         var imgs = Array.prototype.slice.call(document.querySelectorAll('img'));
-        var unloaded = imgs.filter(function(i) { return !i.complete; }).length;
+        // Exclude loading="lazy" images that are off-screen: Chromium does not start
+        // loading them until they enter the viewport, so their .complete stays false
+        // indefinitely.  Once a lazy image scrolls into view and finishes loading,
+        // .complete becomes true and the filter correctly includes it again.
+        var unloaded = imgs.filter(function(i) { return !i.complete && i.loading !== 'lazy'; }).length;
         return { ready: true, unloaded_imgs: unloaded };
     })()"#;
 

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -735,6 +735,100 @@ Promise.all([
         return;
     }
 
+    if path == "/fixture-image.svg" {
+        let body = r##"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#4f46e5"/></svg>"##;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/svg+xml\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/fixture-image-delayed-short.svg" {
+        std::thread::sleep(Duration::from_millis(400));
+        let body = r##"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#16a34a"/></svg>"##;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/svg+xml\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/fixture-image-delayed-long.svg" {
+        std::thread::sleep(Duration::from_millis(5_000));
+        let body = r##"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><rect width="16" height="16" fill="#dc2626"/></svg>"##;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: image/svg+xml\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-idle-lazy-offscreen" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Lazy Offscreen</title></head>
+<body style="margin:0">
+<h1>Network Idle Lazy Offscreen</h1>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" alt="hero" width="16" height="16">
+<div style="height: 4000px;"></div>
+<img id="lazy-target" loading="lazy" src="http://127.0.0.1:{port}/fixture-image-delayed-long.svg" alt="lazy" width="16" height="16">
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-idle-non-lazy-blocked" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Non Lazy Blocked</title></head>
+<body style="margin:0">
+<h1>Network Idle Non Lazy Blocked</h1>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" alt="hero" width="16" height="16">
+<img id="blocking-image" src="http://127.0.0.1:{port}/fixture-image-delayed-long.svg" alt="blocking" width="16" height="16">
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/network-idle-lazy-scroll" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Lazy Scroll</title></head>
+<body style="margin:0">
+<h1>Network Idle Lazy Scroll</h1>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" alt="hero" width="16" height="16">
+<div style="height: 4000px;"></div>
+<img id="lazy-target" loading="lazy" src="http://127.0.0.1:{port}/fixture-image-delayed-short.svg" alt="lazy" width="16" height="16">
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // Cross-origin iframe parent: embeds child from a different port
     if path.starts_with("/iframe-xo-parent") {
         let xo_port = path
@@ -895,6 +989,30 @@ pub fn url_network_load() -> String {
 /// URL for a page that performs fetch + XHR requests and marks completion.
 pub fn url_network_xhr() -> String {
     format!("http://127.0.0.1:{}/network-xhr", local_server().port)
+}
+
+/// URL for a page with an off-screen lazy image that should not block idle detection.
+pub fn url_network_idle_lazy_offscreen() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-lazy-offscreen",
+        local_server().port
+    )
+}
+
+/// URL for a page whose non-lazy image never completes within the test timeout.
+pub fn url_network_idle_non_lazy_blocked() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-non-lazy-blocked",
+        local_server().port
+    )
+}
+
+/// URL for a page whose lazy image starts loading only after scrolling it into view.
+pub fn url_network_idle_lazy_scroll() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-lazy-scroll",
+        local_server().port
+    )
 }
 
 // ── Cross-origin server (second port for OOPIF tests) ─────────────

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -829,6 +829,37 @@ Promise.all([
         return;
     }
 
+    if path == "/network-idle-lazy-in-viewport" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Lazy In Viewport</title></head>
+<body style="margin:0">
+<h1>Network Idle Lazy In Viewport</h1>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" alt="hero" width="16" height="16">
+<div id="lazy-host"></div>
+<script>
+setTimeout(() => {{
+  const img = document.createElement('img');
+  img.id = 'lazy-target';
+  img.loading = 'lazy';
+  img.alt = 'lazy-visible';
+  img.width = 16;
+  img.height = 16;
+  img.src = 'http://127.0.0.1:{port}/fixture-image-delayed-long.svg';
+  document.getElementById('lazy-host').appendChild(img);
+}}, 100);
+</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // Cross-origin iframe parent: embeds child from a different port
     if path.starts_with("/iframe-xo-parent") {
         let xo_port = path
@@ -1011,6 +1042,14 @@ pub fn url_network_idle_non_lazy_blocked() -> String {
 pub fn url_network_idle_lazy_scroll() -> String {
     format!(
         "http://127.0.0.1:{}/network-idle-lazy-scroll",
+        local_server().port
+    )
+}
+
+/// URL for a page whose lazy image is already in the viewport and still loading.
+pub fn url_network_idle_lazy_in_viewport() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-lazy-in-viewport",
         local_server().port
     )
 }

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -4,7 +4,8 @@ use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
     url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
-    wait_page_ready,
+    url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
+    url_network_idle_non_lazy_blocked, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -606,6 +607,128 @@ fn wait_network_idle_json_happy_path() {
     assert_eq!(v["data"]["kind"], "network-idle");
     assert_eq!(v["data"]["satisfied"], true);
     assert!(v["data"]["elapsed_ms"].as_u64().is_some());
+    assert_eq!(v["data"]["observed_value"]["idle"], true);
+}
+
+#[test]
+fn wait_network_idle_ignores_offscreen_lazy_images() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_lazy_offscreen());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "3500",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle should ignore off-screen lazy image",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert_eq!(v["data"]["observed_value"]["idle"], true);
+}
+
+#[test]
+fn wait_network_idle_times_out_for_non_lazy_incomplete_images() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_non_lazy_blocked());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "1200",
+        ],
+        10,
+    );
+    assert_failure(
+        &out,
+        "wait network-idle should still block on non-lazy image",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["context"]["session_id"], sid);
+    assert_eq!(v["context"]["tab_id"], tid);
+    assert_error_envelope(&v, "TIMEOUT");
+}
+
+#[test]
+fn wait_network_idle_accepts_lazy_images_after_scroll_into_view() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_lazy_scroll());
+    wait_page_ready(&sid, &tid);
+
+    let scroll_out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "document.getElementById('lazy-target').scrollIntoView({block:'center'}); void 0",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&scroll_out, "scroll lazy image into view");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "5000",
+        ],
+        10,
+    );
+    assert_success(&out, "wait network-idle after scrolling lazy image");
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
     assert_eq!(v["data"]["observed_value"]["idle"], true);
 }
 

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -5,8 +5,7 @@ use crate::harness::{
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
     url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
     url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen,
-    url_network_idle_lazy_scroll,
-    url_network_idle_non_lazy_blocked, wait_page_ready,
+    url_network_idle_lazy_scroll, url_network_idle_non_lazy_blocked, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -4,7 +4,8 @@ use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
     url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
-    url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
+    url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen,
+    url_network_idle_lazy_scroll,
     url_network_idle_non_lazy_blocked, wait_page_ready,
 };
 
@@ -730,6 +731,42 @@ fn wait_network_idle_accepts_lazy_images_after_scroll_into_view() {
     assert_eq!(v["data"]["kind"], "network-idle");
     assert_eq!(v["data"]["satisfied"], true);
     assert_eq!(v["data"]["observed_value"]["idle"], true);
+}
+
+#[test]
+fn wait_network_idle_blocks_on_in_viewport_lazy_image_still_loading() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_lazy_in_viewport());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "3500",
+        ],
+        10,
+    );
+    assert_failure(
+        &out,
+        "wait network-idle should block on in-viewport lazy image while it is still loading",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["context"]["session_id"], sid);
+    assert_eq!(v["context"]["tab_id"], tid);
+    assert_error_envelope(&v, "TIMEOUT");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- **Root cause**: `js_idle` in `wait network-idle` required all `<img>` elements to have `complete=true`. Chromium does not fetch `loading="lazy"` images until they scroll into the viewport, so off-screen lazy images remain `!complete` indefinitely — causing `wait network-idle` to always TIMEOUT on pages with below-fold lazy images (confirmed on StubHub: 93 total imgs, 1 lazy off-screen img blocks idle).
- **Fix**: one-line filter change in `network_idle.rs` — exclude `loading="lazy"` images from the `unloaded_imgs` count. Once a lazy image enters the viewport and loads, `.complete` becomes `true` and it re-enters the check naturally.
- **Safety**: non-lazy incomplete images still block `js_idle` (negative test); lazy images that scrolled into view and finished loading are correctly counted as loaded (scroll regression test).

## Test plan

3 new E2E tests in `tests/e2e/wait.rs` (TDD red phase: commit `d65a6f50`, green phase: `59367b30`):

- [x] `wait_network_idle_ignores_offscreen_lazy_images` — fixture with hero img (fast) + off-screen lazy img (slow endpoint) → must accept within timeout (previously TIMEOUT)
- [x] `wait_network_idle_times_out_for_non_lazy_incomplete_images` — fixture with non-lazy slow img → must still TIMEOUT (safety / no regression)
- [x] `wait_network_idle_accepts_lazy_images_after_scroll_into_view` — fixture with lazy img, test scrolls it into view → must accept after load completes

Local result: `3 passed / 0 failed / 1 ignored` in 6.97s.

## Linear

ACT-964: https://linear.app/actionbook/issue/ACT-964