### PR TITLE
fix(network-idle): edge-triggered semantics — ignore pre-existing connections (ACT-965)

### DIFF
--- a/packages/cli/src/browser/wait/network_idle.rs
+++ b/packages/cli/src/browser/wait/network_idle.rs
@@ -1,4 +1,3 @@
-use std::collections::VecDeque;
 use std::time::{Duration, Instant};
 
 use clap::Args;
@@ -13,23 +12,27 @@ use crate::output::ResponseContext;
 
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const POLL_INTERVAL_MS: u64 = 100;
-/// Strict idle: zero in-flight requests for this long.
-const STRICT_IDLE_QUIET_MS: u64 = 500;
-/// Relaxed idle: fewer than RELAXED_MAX_REQUESTS new requests in the sliding
-/// window, sustained for this long.  Used when a page has persistent
-/// background activity (analytics pings, health-checks, etc.) that would
-/// otherwise prevent the strict condition from ever being satisfied.
-const RELAXED_IDLE_QUIET_MS: u64 = 3_000;
-/// Sliding-window length for the relaxed-idle request-rate check.
-const RELAXED_WINDOW_MS: u64 = 10_000;
-/// Max new requests allowed inside the sliding window to qualify as relaxed idle.
-const RELAXED_MAX_REQUESTS: usize = 5;
+/// Both the load gate and the post-start network gate must be satisfied
+/// continuously for this long before declaring idle.
+const IDLE_QUIET_MS: u64 = 500;
 
-/// Wait for network activity to become idle
+/// Wait for the page to settle: readyState=complete, images loaded, and any
+/// network requests started *after* this command begins have finished.
+///
+/// Pre-existing connections (SSE, WebSocket, long-poll) do not block idle —
+/// only requests whose `requestWillBeSent` event arrives after the command
+/// starts are tracked.  This is an agent-friendly settle signal, not a
+/// guarantee of global network silence.
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
 #[command(after_help = "\
 Examples:
-  actionbook browser wait network-idle --session s1 --tab t1 --timeout 10000")]
+  actionbook browser wait network-idle --session s1 --tab t1 --timeout 10000
+
+Notes:
+  Only tracks requests started after the command begins.
+  Pre-existing background connections (SSE, WebSocket, analytics) are ignored.
+  Intended as an agent-friendly settle signal, not a guarantee that all
+  background activity has stopped.")]
 pub struct Cmd {
     /// Session ID
     #[arg(long)]
@@ -88,9 +91,6 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     let timeout_ms = cmd.timeout.unwrap_or(DEFAULT_TIMEOUT_MS);
     let start = Instant::now();
 
-    // Resolve the CDP flat-session ID.  `attach()` already called `Network.enable`
-    // on this session, so `tab_net_pending` tracks ALL requests since tab attachment —
-    // including those that started before this `wait network-idle` call.
     let cdp_session_id = match cdp.get_cdp_session_id(&target_id).await {
         Some(sid) => sid,
         None => {
@@ -126,40 +126,25 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         return { ready: true, unloaded_imgs: unloaded };
     })()"#;
 
-    // --- idle tracking state ---
-    // Timestamps of request-start events within the relaxed sliding window.
-    // Each time `pending` increases we push one entry per new request.
-    let mut request_events: VecDeque<Instant> = VecDeque::new();
-    let mut prev_pending: i64 = 0;
-    // When the idle condition first becomes true, record when it started so we
-    // can enforce the required quiet window before declaring success.
+    // Edge-triggered pending: snapshot in-flight count at command start.
+    // Any increase above effective_baseline represents a post-start request.
+    // effective_baseline can only decrease (when pre-existing requests finish),
+    // so pre-existing connections never inflate above_baseline.
+    let baseline_pending = cdp.network_pending(&cdp_session_id).await;
+    let mut effective_baseline: i64 = baseline_pending;
     let mut quiet_start: Option<Instant> = None;
-    // Whether the current quiet window is running in relaxed mode.
-    let mut quiet_is_relaxed = false;
 
     loop {
-        // Read the live in-flight counter maintained by reader_loop.
         let pending = cdp.network_pending(&cdp_session_id).await;
 
-        // Track new request starts: any increase in `pending` means at least that
-        // many requests were initiated since the last poll.
-        if pending > prev_pending {
-            let new_reqs = (pending - prev_pending) as usize;
-            let now = Instant::now();
-            for _ in 0..new_reqs {
-                request_events.push_back(now);
-            }
+        // Lower effective_baseline when pre-existing requests finish.
+        if pending < effective_baseline {
+            effective_baseline = pending;
         }
-        prev_pending = pending;
 
-        // Evict events that have aged out of the sliding window.
-        let window_cutoff = Instant::now() - Duration::from_millis(RELAXED_WINDOW_MS);
-        while request_events.front().is_some_and(|t| *t < window_cutoff) {
-            request_events.pop_front();
-        }
-        let recent_requests = request_events.len();
+        // Requests started after the command began: any pending above the baseline.
+        let above_baseline = pending - effective_baseline;
 
-        // JS fallback: readyState + DOM-attached img.complete.
         let js_idle = cdp
             .execute_on_tab(
                 &target_id,
@@ -179,55 +164,29 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             })
             .unwrap_or(false);
 
-        // Determine which idle mode (if any) applies this tick.
-        let strict_idle = pending == 0 && js_idle;
-        // Relaxed idle: page is done (js_idle), the request rate over the last
-        // 10 s is below the threshold, AND there are no more than that many
-        // requests currently in-flight.  The `pending` guard prevents declaring
-        // idle when long-lived connections aged out of the sliding window but
-        // are still genuinely open (e.g. 10 WebSocket connections all started
-        // > 10 s ago would show recent_requests=0 but pending still > 0).
-        let relaxed_idle = js_idle
-            && recent_requests < RELAXED_MAX_REQUESTS
-            && pending <= RELAXED_MAX_REQUESTS as i64;
-
-        if strict_idle || relaxed_idle {
-            let required_quiet = if strict_idle {
-                STRICT_IDLE_QUIET_MS
-            } else {
-                RELAXED_IDLE_QUIET_MS
-            };
-            // If we just switched from relaxed→strict (or newly entered idle),
-            // reset the quiet window so strict mode gets a fresh 500 ms run.
-            let mode_changed = quiet_start.is_some() && quiet_is_relaxed && strict_idle;
-            if quiet_start.is_none() || mode_changed {
+        if js_idle && above_baseline == 0 {
+            if quiet_start.is_none() {
                 quiet_start = Some(Instant::now());
-                quiet_is_relaxed = !strict_idle;
             }
             let quiet_elapsed_ms = quiet_start.unwrap().elapsed().as_millis() as u64;
-            if quiet_elapsed_ms >= required_quiet {
+            if quiet_elapsed_ms >= IDLE_QUIET_MS {
                 let elapsed_ms = start.elapsed().as_millis() as u64;
                 let url = navigation::get_tab_url(&cdp, &target_id).await;
                 let title = navigation::get_tab_title(&cdp, &target_id).await;
-                let mode = if strict_idle { "strict" } else { "relaxed" };
                 return ActionResult::ok(json!({
                     "kind": "network-idle",
                     "satisfied": true,
-                    "mode": mode,
                     "elapsed_ms": elapsed_ms,
                     "observed_value": {
                         "idle": true,
                         "pending": pending,
-                        "recent_requests_10s": recent_requests,
                     },
                     "__ctx_url": url,
                     "__ctx_title": title,
                 }));
             }
         } else {
-            // Not idle — reset the quiet window entirely.
             quiet_start = None;
-            quiet_is_relaxed = false;
         }
 
         let elapsed = start.elapsed().as_millis() as u64;

--- a/packages/cli/src/browser/wait/network_idle.rs
+++ b/packages/cli/src/browser/wait/network_idle.rs
@@ -16,21 +16,22 @@ const POLL_INTERVAL_MS: u64 = 100;
 /// continuously for this long before declaring idle.
 const IDLE_QUIET_MS: u64 = 500;
 
-/// Wait for the page to settle: readyState=complete, images loaded, and any
-/// network requests started *after* this command begins have finished.
+/// Wait for the page to settle: readyState=complete, images loaded, and all
+/// tracked in-flight fetch/XHR requests finished.
 ///
-/// Pre-existing connections (SSE, WebSocket, long-poll) do not block idle —
-/// only requests whose `requestWillBeSent` event arrives after the command
-/// starts are tracked.  This is an agent-friendly settle signal, not a
-/// guarantee of global network silence.
+/// Persistent connections (WebSocket, SSE/EventSource, favicon, data: URLs)
+/// are excluded at the CDP-session level and never block idle.  Orphaned
+/// cross-origin iframe requests are evicted after 3 s by the tab-level
+/// pending set.  This is an agent-friendly settle signal, not a guarantee of
+/// global network silence.
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
 #[command(after_help = "\
 Examples:
   actionbook browser wait network-idle --session s1 --tab t1 --timeout 10000
 
 Notes:
-  Only tracks requests started after the command begins.
-  Pre-existing background connections (SSE, WebSocket, analytics) are ignored.
+  Waits for all tracked in-flight fetch/XHR requests to settle.
+  Persistent connections (WebSocket, SSE) are excluded and do not block.
   Intended as an agent-friendly settle signal, not a guarantee that all
   background activity has stopped.")]
 pub struct Cmd {
@@ -126,24 +127,14 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         return { ready: true, unloaded_imgs: unloaded };
     })()"#;
 
-    // Edge-triggered pending: snapshot in-flight count at command start.
-    // Any increase above effective_baseline represents a post-start request.
-    // effective_baseline can only decrease (when pre-existing requests finish),
-    // so pre-existing connections never inflate above_baseline.
-    let baseline_pending = cdp.network_pending(&cdp_session_id).await;
-    let mut effective_baseline: i64 = baseline_pending;
+    // Wait for tracked in-flight fetch/XHR to drain. Persistent connection
+    // types (WebSocket, SSE/EventSource) are excluded at CDP event ingest,
+    // so they never appear in the pending set. Orphaned iframe requests are
+    // evicted after 3 s by the tab-level pending map.
     let mut quiet_start: Option<Instant> = None;
 
     loop {
         let pending = cdp.network_pending(&cdp_session_id).await;
-
-        // Lower effective_baseline when pre-existing requests finish.
-        if pending < effective_baseline {
-            effective_baseline = pending;
-        }
-
-        // Requests started after the command began: any pending above the baseline.
-        let above_baseline = pending - effective_baseline;
 
         let js_idle = cdp
             .execute_on_tab(
@@ -164,7 +155,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             })
             .unwrap_or(false);
 
-        if js_idle && above_baseline == 0 {
+        if js_idle && pending == 0 {
             if quiet_start.is_none() {
                 quiet_start = Some(Instant::now());
             }

--- a/packages/cli/src/browser/wait/network_idle.rs
+++ b/packages/cli/src/browser/wait/network_idle.rs
@@ -16,22 +16,25 @@ const POLL_INTERVAL_MS: u64 = 100;
 /// continuously for this long before declaring idle.
 const IDLE_QUIET_MS: u64 = 500;
 
-/// Wait for the page to settle: readyState=complete, images loaded, and all
-/// tracked in-flight fetch/XHR requests finished.
+/// Wait for the page to settle: readyState=complete, images loaded, and any
+/// fetch/XHR requests *started after this command began* have finished.
 ///
-/// Persistent connections (WebSocket, SSE/EventSource, favicon, data: URLs)
-/// are excluded at the CDP-session level and never block idle.  Orphaned
-/// cross-origin iframe requests are evicted after 3 s by the tab-level
-/// pending set.  This is an agent-friendly settle signal, not a guarantee of
-/// global network silence.
+/// Edge-triggered: only requests whose `requestWillBeSent` fires strictly
+/// after `cmd_start` count toward the pending set.  Pre-existing background
+/// connections (WebSocket, SSE, in-flight analytics, in-flight API calls)
+/// never block idle.  Persistent connection types are additionally filtered
+/// at the CDP-session level, and orphaned cross-origin iframe requests are
+/// evicted after 3 s by the tab-level pending map.  This is an agent-friendly
+/// settle signal, not a guarantee of global network silence.
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
 #[command(after_help = "\
 Examples:
   actionbook browser wait network-idle --session s1 --tab t1 --timeout 10000
 
 Notes:
-  Waits for all tracked in-flight fetch/XHR requests to settle.
-  Persistent connections (WebSocket, SSE) are excluded and do not block.
+  Only tracks fetch/XHR requests started after the command begins.
+  Pre-existing background connections (SSE, WebSocket, in-flight fetches)
+  are ignored and do not block.
   Intended as an agent-friendly settle signal, not a guarantee that all
   background activity has stopped.")]
 pub struct Cmd {
@@ -90,6 +93,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     };
 
     let timeout_ms = cmd.timeout.unwrap_or(DEFAULT_TIMEOUT_MS);
+    // Edge trigger: only block on requests whose requestWillBeSent fires
+    // strictly after this instant. Any entries already in the tab's pending
+    // map at this point are pre-existing and must not block.
     let start = Instant::now();
 
     let cdp_session_id = match cdp.get_cdp_session_id(&target_id).await {
@@ -127,14 +133,16 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         return { ready: true, unloaded_imgs: unloaded };
     })()"#;
 
-    // Wait for tracked in-flight fetch/XHR to drain. Persistent connection
-    // types (WebSocket, SSE/EventSource) are excluded at CDP event ingest,
-    // so they never appear in the pending set. Orphaned iframe requests are
-    // evicted after 3 s by the tab-level pending map.
+    // Wait for post-start in-flight fetch/XHR to drain. Persistent connection
+    // types (WebSocket, SSE/EventSource) are excluded at CDP event ingest.
+    // Orphaned iframe requests are evicted after 3 s by the tab-level pending
+    // map.  We filter to requests whose requestWillBeSent timestamp is
+    // strictly after cmd_start — equivalent to a req-id-set snapshot — so
+    // pre-existing requests never block.
     let mut quiet_start: Option<Instant> = None;
 
     loop {
-        let pending = cdp.network_pending(&cdp_session_id).await;
+        let pending = cdp.network_pending_since(&cdp_session_id, start).await;
 
         let js_idle = cdp
             .execute_on_tab(

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -1178,6 +1178,29 @@ impl CdpSession {
         }
     }
 
+    /// Return the count of in-flight network requests for this session whose
+    /// `requestWillBeSent` timestamp is strictly after `since`.  Used by
+    /// `wait network-idle` to get edge-triggered semantics: pre-existing
+    /// fetches (captured before the command started) never contribute.
+    ///
+    /// Same 3 s stale-eviction policy as [`network_pending`] — a request whose
+    /// `loadingFinished` fires on a different CDP session (cross-origin
+    /// iframe) is not permitted to block forever.
+    pub async fn network_pending_since(
+        &self,
+        cdp_session_id: &str,
+        since: std::time::Instant,
+    ) -> i64 {
+        let mut tp = self.tab_net_pending.lock().await;
+        if let Some(map) = tp.get_mut(cdp_session_id) {
+            let cutoff = std::time::Instant::now() - std::time::Duration::from_secs(3);
+            map.retain(|_, ts| *ts > cutoff);
+            map.values().filter(|ts| **ts > since).count() as i64
+        } else {
+            0
+        }
+    }
+
     /// Return all tracked network requests for a tab's CDP session, applying optional filters.
     pub async fn network_requests(
         &self,

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -910,6 +910,28 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/network-idle-preexisting-fetch-page" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Preexisting Fetch Page</title></head>
+<body>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" width="16" height="16">
+<script>
+window.addEventListener('DOMContentLoaded', () => {{
+  fetch("http://127.0.0.1:{port}/api/delayed-data-short?source=preexisting").catch(() => {{}});
+}});
+</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     if path == "/network-idle-post-start-non-lazy-blocked" {
         let port = local_server().port;
         let body = format!(
@@ -1151,6 +1173,14 @@ pub fn url_network_idle_lazy_in_viewport() -> String {
 pub fn url_network_idle_sse_page() -> String {
     format!(
         "http://127.0.0.1:{}/network-idle-sse-page",
+        local_server().port
+    )
+}
+
+/// URL for a page that starts a same-origin delayed fetch before the wait begins.
+pub fn url_network_idle_preexisting_fetch_page() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-preexisting-fetch-page",
         local_server().port
     )
 }

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -860,6 +860,33 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/sse-stream" {
+        // Keep the SSE connection open without sending events.
+        // Used to simulate a pre-existing persistent connection (tests edge-triggered semantics).
+        let headers = "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nCache-Control: no-cache\r\nAccess-Control-Allow-Origin: *\r\nConnection: keep-alive\r\n\r\n";
+        let _ = stream.write_all(headers.as_bytes());
+        std::thread::sleep(Duration::from_secs(12));
+        return;
+    }
+
+    if path == "/network-idle-sse-page" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle SSE Page</title></head>
+<body>
+<img src="http://127.0.0.1:{port}/fixture-image.svg" width="16" height="16">
+<script>new EventSource("http://127.0.0.1:{port}/sse-stream");</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // Cross-origin iframe parent: embeds child from a different port
     if path.starts_with("/iframe-xo-parent") {
         let xo_port = path
@@ -1050,6 +1077,14 @@ pub fn url_network_idle_lazy_scroll() -> String {
 pub fn url_network_idle_lazy_in_viewport() -> String {
     format!(
         "http://127.0.0.1:{}/network-idle-lazy-in-viewport",
+        local_server().port
+    )
+}
+
+/// URL for a page that opens a persistent SSE connection before idle is checked.
+pub fn url_network_idle_sse_page() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-sse-page",
         local_server().port
     )
 }

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -932,6 +932,36 @@ window.addEventListener('DOMContentLoaded', () => {{
         return;
     }
 
+    if path == "/network-idle-post-start-setinterval-page" {
+        // Fires 8 same-origin fetches 400ms apart after DOMContentLoaded, covering
+        // ~2.8s so that at least one fetch reliably fires after wait's cmd_start
+        // regardless of subprocess-spawn jitter (eval subprocess shutdown +
+        // wait subprocess startup can drift 500-2000ms).
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Post-Start SetInterval Page</title></head>
+<body>
+<script>
+window.addEventListener('DOMContentLoaded', () => {{
+  let count = 0;
+  const id = setInterval(() => {{
+    if (count >= 8) {{ clearInterval(id); return; }}
+    count++;
+    fetch("http://127.0.0.1:{port}/api/delayed-data-short?source=post-start&n=" + count).catch(() => {{}});
+  }}, 400);
+}});
+</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     if path == "/network-idle-post-start-non-lazy-blocked" {
         let port = local_server().port;
         let body = format!(
@@ -1124,14 +1154,6 @@ pub fn url_network_xhr() -> String {
     format!("http://127.0.0.1:{}/network-xhr", local_server().port)
 }
 
-/// URL for a delayed JSON response used to verify post-start request tracking.
-pub fn url_api_data_delayed_short() -> String {
-    format!(
-        "http://127.0.0.1:{}/api/delayed-data-short?source=post-start",
-        local_server().port
-    )
-}
-
 /// URL that drops the connection to force a request failure / loadingFailed.
 pub fn url_api_fail_reset() -> String {
     format!("http://127.0.0.1:{}/api/fail-reset", local_server().port)
@@ -1181,6 +1203,16 @@ pub fn url_network_idle_sse_page() -> String {
 pub fn url_network_idle_preexisting_fetch_page() -> String {
     format!(
         "http://127.0.0.1:{}/network-idle-preexisting-fetch-page",
+        local_server().port
+    )
+}
+
+/// URL for a page that fires 8 same-origin delayed fetches 400ms apart after
+/// DOMContentLoaded. Guarantees at least one fetch fires after wait's
+/// cmd_start regardless of subprocess-spawn jitter.
+pub fn url_network_idle_post_start_setinterval_page() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-post-start-setinterval-page",
         local_server().port
     )
 }

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -656,6 +656,29 @@ setTimeout(() => {{
         return;
     }
 
+    if path.starts_with("/api/delayed-data-short") {
+        std::thread::sleep(Duration::from_millis(1_000));
+        let source = path
+            .split("source=")
+            .nth(1)
+            .and_then(|value| value.split('&').next())
+            .unwrap_or("delayed");
+        let body = format!(r#"{{"ok":true,"source":"{source}","delay_ms":1000}}"#);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nX-Ab-Fixture: api-data-delayed-short\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/api/fail-reset" {
+        // Drop the TCP connection without sending an HTTP response so the browser
+        // reports a network failure (`loadingFailed`) instead of a completed response.
+        return;
+    }
+
     if path == "/network-fixture.css" {
         let body = "body { background: rgb(245, 248, 255); }";
         let response = format!(
@@ -887,6 +910,36 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/network-idle-post-start-non-lazy-blocked" {
+        let port = local_server().port;
+        let body = format!(
+            r#"<!DOCTYPE html><html><head><title>Network Idle Post Start Non Lazy Blocked</title></head>
+<body style="margin:0">
+<h1>Network Idle Post Start Non Lazy Blocked</h1>
+<img id="hero-image" src="http://127.0.0.1:{port}/fixture-image.svg" alt="hero" width="16" height="16">
+<div id="image-host"></div>
+<script>
+setTimeout(() => {{
+  const img = document.createElement('img');
+  img.id = 'post-start-blocking-image';
+  img.alt = 'post-start-blocking-image';
+  img.width = 16;
+  img.height = 16;
+  img.src = 'http://127.0.0.1:{port}/fixture-image-delayed-long.svg';
+  document.getElementById('image-host').appendChild(img);
+}}, 100);
+</script>
+</body></html>"#
+        );
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     // Cross-origin iframe parent: embeds child from a different port
     if path.starts_with("/iframe-xo-parent") {
         let xo_port = path
@@ -1049,6 +1102,19 @@ pub fn url_network_xhr() -> String {
     format!("http://127.0.0.1:{}/network-xhr", local_server().port)
 }
 
+/// URL for a delayed JSON response used to verify post-start request tracking.
+pub fn url_api_data_delayed_short() -> String {
+    format!(
+        "http://127.0.0.1:{}/api/delayed-data-short?source=post-start",
+        local_server().port
+    )
+}
+
+/// URL that drops the connection to force a request failure / loadingFailed.
+pub fn url_api_fail_reset() -> String {
+    format!("http://127.0.0.1:{}/api/fail-reset", local_server().port)
+}
+
 /// URL for a page with an off-screen lazy image that should not block idle detection.
 pub fn url_network_idle_lazy_offscreen() -> String {
     format!(
@@ -1085,6 +1151,14 @@ pub fn url_network_idle_lazy_in_viewport() -> String {
 pub fn url_network_idle_sse_page() -> String {
     format!(
         "http://127.0.0.1:{}/network-idle-sse-page",
+        local_server().port
+    )
+}
+
+/// URL for a page that injects a non-lazy image after idle waiting has begun.
+pub fn url_network_idle_post_start_non_lazy_blocked() -> String {
+    format!(
+        "http://127.0.0.1:{}/network-idle-post-start-non-lazy-blocked",
         local_server().port
     )
 }

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -4,10 +4,10 @@ use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_api_fail_reset, url_b,
     url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
-    url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
-    url_network_idle_non_lazy_blocked, url_network_idle_post_start_non_lazy_blocked,
-    url_network_idle_post_start_setinterval_page, url_network_idle_preexisting_fetch_page,
-    url_network_idle_sse_page, wait_page_ready,
+    url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen,
+    url_network_idle_lazy_scroll, url_network_idle_non_lazy_blocked,
+    url_network_idle_post_start_non_lazy_blocked, url_network_idle_post_start_setinterval_page,
+    url_network_idle_preexisting_fetch_page, url_network_idle_sse_page, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -108,7 +108,10 @@ fn schedule_fetch_after_delay(sid: &str, tid: &str, url: &str) {
         "setTimeout(() => {{ fetch({}).catch(() => {{}}); }}, 100); void 0",
         serde_json::to_string(url).unwrap()
     );
-    let out = headless_json(&["browser", "eval", &js, "--session", sid, "--tab", tid], 10);
+    let out = headless_json(
+        &["browser", "eval", &js, "--session", sid, "--tab", tid],
+        10,
+    );
     assert_success(&out, "schedule delayed fetch");
 }
 

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -5,7 +5,8 @@ use crate::harness::{
     headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
     url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
     url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen,
-    url_network_idle_lazy_scroll, url_network_idle_non_lazy_blocked, wait_page_ready,
+    url_network_idle_lazy_scroll, url_network_idle_non_lazy_blocked, url_network_idle_sse_page,
+    wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -766,6 +767,46 @@ fn wait_network_idle_blocks_on_in_viewport_lazy_image_still_loading() {
     assert_eq!(v["context"]["session_id"], sid);
     assert_eq!(v["context"]["tab_id"], tid);
     assert_error_envelope(&v, "TIMEOUT");
+}
+
+// Verifies that a pre-existing persistent connection (SSE) does not block
+// `wait network-idle`.  Edge-triggered implementation: SSE is counted in
+// baseline_pending at command start, so above_baseline stays 0 throughout.
+// Old level-triggered implementation: SSE keeps pending=1 → relaxed mode
+// requires 10 s sliding window + 3 s quiet → times out within 5 000 ms.
+#[test]
+fn wait_network_idle_unblocked_by_preexisting_sse() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_sse_page());
+    wait_page_ready(&sid, &tid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "5000",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle must not block on a pre-existing SSE connection",
+    );
+    let v = parse_json(&out);
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
 }
 
 #[test]

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -819,14 +819,22 @@ fn wait_network_idle_unblocked_by_preexisting_sse() {
     assert_eq!(v["data"]["satisfied"], true);
 }
 
+// Fetch initiator must be same-origin with the API target: Chrome's Private
+// Network Access policy blocks a fetch from an `about:blank` (null origin)
+// page to `http://127.0.0.1` with `corsError='InsecureLocalNetwork'`, so the
+// fetch fails instantly and never contributes to the in-flight count.  Opening
+// the tab on a local-server page moves the initiator onto 127.0.0.1, making
+// the delayed fetch same-origin and observable.
 #[test]
 fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
     if skip() {
         return;
     }
 
-    let (sid, tid) = start_session("about:blank");
+    let (sid, _) = start_session("about:blank");
     let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_a());
+    wait_page_ready(&sid, &tid);
     schedule_fetch_after_delay(&sid, &tid, &url_api_data_delayed_short());
 
     let out = headless_json(

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -884,9 +884,9 @@ fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
             "--tab",
             &tid,
             "--timeout",
-            "5000",
+            "12000",
         ],
-        10,
+        17,
     );
     assert_success(
         &out,

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -2,12 +2,12 @@
 
 use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
-    headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_api_data_delayed_short,
-    url_api_fail_reset, url_b, url_delayed_redirect, url_delayed_redirect_long,
-    url_fast_redirect, url_home_no_trailing_slash,
+    headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_api_fail_reset, url_b,
+    url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
     url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
     url_network_idle_non_lazy_blocked, url_network_idle_post_start_non_lazy_blocked,
-    url_network_idle_preexisting_fetch_page, url_network_idle_sse_page, wait_page_ready,
+    url_network_idle_post_start_setinterval_page, url_network_idle_preexisting_fetch_page,
+    url_network_idle_sse_page, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -854,12 +854,12 @@ fn wait_network_idle_unblocked_by_preexisting_same_origin_fetch() {
     assert_eq!(v["data"]["satisfied"], true);
 }
 
-// Fetch initiator must be same-origin with the API target: Chrome's Private
-// Network Access policy blocks a fetch from an `about:blank` (null origin)
-// page to `http://127.0.0.1` with `corsError='InsecureLocalNetwork'`, so the
-// fetch fails instantly and never contributes to the in-flight count.  Opening
-// the tab on a local-server page moves the initiator onto 127.0.0.1, making
-// the delayed fetch same-origin and observable.
+// Fixture page fires a sustained burst of same-origin fetches (8 × 400ms after
+// DOMContentLoaded) so at least one `requestWillBeSent` is guaranteed to land
+// after `cmd_start`, regardless of subprocess-spawn jitter (eval shutdown +
+// wait subprocess startup can drift 500-2000ms). A single `setTimeout` cannot
+// reliably hit `[cmd_start, cmd_start + IDLE_QUIET_MS]`: too short and the
+// fetch is pre-existing, too long and the quiet window completes first.
 #[test]
 fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
     if skip() {
@@ -868,9 +868,8 @@ fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
 
     let (sid, _) = start_session("about:blank");
     let _guard = SessionGuard::new(&sid);
-    let tid = open_new_tab(&sid, &url_a());
+    let tid = open_new_tab(&sid, &url_network_idle_post_start_setinterval_page());
     wait_page_ready(&sid, &tid);
-    schedule_fetch_after_delay(&sid, &tid, &url_api_data_delayed_short());
 
     let out = headless_json(
         &[
@@ -882,7 +881,7 @@ fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
             "--tab",
             &tid,
             "--timeout",
-            "4000",
+            "5000",
         ],
         10,
     );
@@ -896,8 +895,8 @@ fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
     assert_eq!(v["data"]["kind"], "network-idle");
     assert_eq!(v["data"]["satisfied"], true);
     assert!(
-        v["data"]["elapsed_ms"].as_u64().unwrap_or_default() >= 1_000,
-        "elapsed_ms should include the delayed fetch plus quiet window"
+        v["data"]["elapsed_ms"].as_u64().unwrap_or_default() >= 1_200,
+        "elapsed_ms should include the post-start fetch batch plus quiet window"
     );
 }
 

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -7,7 +7,7 @@ use crate::harness::{
     url_fast_redirect, url_home_no_trailing_slash,
     url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
     url_network_idle_non_lazy_blocked, url_network_idle_post_start_non_lazy_blocked,
-    url_network_idle_sse_page, wait_page_ready,
+    url_network_idle_preexisting_fetch_page, url_network_idle_sse_page, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -812,6 +812,41 @@ fn wait_network_idle_unblocked_by_preexisting_sse() {
     assert_success(
         &out,
         "wait network-idle must not block on a pre-existing SSE connection",
+    );
+    let v = parse_json(&out);
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
+}
+
+#[test]
+fn wait_network_idle_unblocked_by_preexisting_same_origin_fetch() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_preexisting_fetch_page());
+    wait_page_ready(&sid, &tid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "1200",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle must not block on a same-origin fetch that was already in-flight before the command began",
     );
     let v = parse_json(&out);
     assert_eq!(v["command"], "browser wait network-idle");

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -2,11 +2,12 @@
 
 use crate::harness::{
     SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success, headless,
-    headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_b,
-    url_delayed_redirect, url_delayed_redirect_long, url_fast_redirect, url_home_no_trailing_slash,
-    url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen,
-    url_network_idle_lazy_scroll, url_network_idle_non_lazy_blocked, url_network_idle_sse_page,
-    wait_page_ready,
+    headless_json, parse_json, skip, stdout_str, unique_session, url_a, url_api_data_delayed_short,
+    url_api_fail_reset, url_b, url_delayed_redirect, url_delayed_redirect_long,
+    url_fast_redirect, url_home_no_trailing_slash,
+    url_network_idle_lazy_in_viewport, url_network_idle_lazy_offscreen, url_network_idle_lazy_scroll,
+    url_network_idle_non_lazy_blocked, url_network_idle_post_start_non_lazy_blocked,
+    url_network_idle_sse_page, wait_page_ready,
 };
 
 const ELEMENT_SELECTOR: &str = "#loaded";
@@ -100,6 +101,15 @@ fn open_new_tab(sid: &str, url: &str) -> String {
         .as_str()
         .unwrap()
         .to_string()
+}
+
+fn schedule_fetch_after_delay(sid: &str, tid: &str, url: &str) {
+    let js = format!(
+        "setTimeout(() => {{ fetch({}).catch(() => {{}}); }}, 100); void 0",
+        serde_json::to_string(url).unwrap()
+    );
+    let out = headless_json(&["browser", "eval", &js, "--session", sid, "--tab", tid], 10);
+    assert_success(&out, "schedule delayed fetch");
 }
 
 #[test]
@@ -807,6 +817,155 @@ fn wait_network_idle_unblocked_by_preexisting_sse() {
     assert_eq!(v["command"], "browser wait network-idle");
     assert_eq!(v["data"]["kind"], "network-idle");
     assert_eq!(v["data"]["satisfied"], true);
+}
+
+#[test]
+fn wait_network_idle_waits_for_post_start_fetch_batch_to_finish() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    schedule_fetch_after_delay(&sid, &tid, &url_api_data_delayed_short());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "4000",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle should block until a post-start fetch batch completes",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert!(
+        v["data"]["elapsed_ms"].as_u64().unwrap_or_default() >= 1_000,
+        "elapsed_ms should include the delayed fetch plus quiet window"
+    );
+}
+
+#[test]
+fn wait_network_idle_treats_post_start_failed_fetch_as_settled() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    schedule_fetch_after_delay(&sid, &tid, &url_api_fail_reset());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "3000",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle should treat a post-start failed fetch as settled once loadingFailed arrives",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
+}
+
+#[test]
+fn wait_network_idle_succeeds_after_quiet_window_when_no_new_requests() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "2000",
+        ],
+        10,
+    );
+    assert_success(
+        &out,
+        "wait network-idle should succeed after the quiet window when no new requests start",
+    );
+    let v = parse_json(&out);
+    let elapsed_ms = v["data"]["elapsed_ms"].as_u64().unwrap_or_default();
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["data"]["kind"], "network-idle");
+    assert_eq!(v["data"]["satisfied"], true);
+    assert!(
+        elapsed_ms >= 500 && elapsed_ms < 1_500,
+        "elapsed_ms should reflect the fixed quiet window, got {elapsed_ms}"
+    );
+}
+
+#[test]
+fn wait_network_idle_times_out_for_post_start_non_lazy_incomplete_image() {
+    if skip() {
+        return;
+    }
+
+    let (sid, _) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let tid = open_new_tab(&sid, &url_network_idle_post_start_non_lazy_blocked());
+
+    let out = headless_json(
+        &[
+            "browser",
+            "wait",
+            "network-idle",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+            "--timeout",
+            "1500",
+        ],
+        10,
+    );
+    assert_failure(
+        &out,
+        "wait network-idle should still time out if a post-start non-lazy image never completes",
+    );
+    let v = parse_json(&out);
+
+    assert_eq!(v["command"], "browser wait network-idle");
+    assert_eq!(v["context"]["session_id"], sid);
+    assert_eq!(v["context"]["tab_id"], tid);
+    assert_error_envelope(&v, "TIMEOUT");
 }
 
 #[test]

--- a/packages/cli/tests/e2e/wait.rs
+++ b/packages/cli/tests/e2e/wait.rs
@@ -972,7 +972,7 @@ fn wait_network_idle_succeeds_after_quiet_window_when_no_new_requests() {
     assert_eq!(v["data"]["kind"], "network-idle");
     assert_eq!(v["data"]["satisfied"], true);
     assert!(
-        elapsed_ms >= 500 && elapsed_ms < 1_500,
+        (500..1_500).contains(&elapsed_ms),
         "elapsed_ms should reflect the fixed quiet window, got {elapsed_ms}"
     );
 }


### PR DESCRIPTION
## Summary

- **Replaces** the strict/relaxed sliding-window heuristic with an **edge-triggered** approach: snapshot `pending` count at command start (`baseline_pending`); only requests that begin *after* the command count toward the idle check
- **Pre-existing connections** (SSE, WebSocket, long-poll, analytics pings) are absorbed into `baseline_pending` and never block idle — fixes the class of bugs where always-on background traffic caused TIMEOUT
- **Post-start requests** (XHR/fetch triggered by page interaction or late-load scripts) still block idle until they settle, fulfilling the "agent-friendly settle signal" intent
- `effective_baseline` can only decrease as pre-existing requests close, so a closing pre-existing connection cannot mask a simultaneously-started new one
- Removes strict/relaxed duality, VecDeque sliding window, and 10 s + 3 s complexity; output JSON drops `mode` and `recent_requests_10s` fields

**Success condition**: `js_idle` (readyState=complete + lazy-aware img check from ACT-964) AND `above_baseline == 0` sustained for 500 ms.

## Test plan

- [ ] Existing lazy-image tests (`ignores_offscreen_lazy_images`, `accepts_lazy_images_after_scroll_into_view`, `times_out_for_non_lazy_incomplete_images`, `blocks_on_in_viewport_lazy_image_still_loading`) continue to pass
- [ ] New test `wait_network_idle_unblocked_by_preexisting_sse`: page opens SSE connection before command; command succeeds within 5 000 ms (old code would timeout as SSE keeps pending=1 for 13+ s via relaxed mode)
- [ ] Verify on stubhub.com-style page: `wait network-idle` resolves without TIMEOUT