### PR TITLE
fix(cli): route plain-text error output to stderr

### DIFF
--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -233,7 +233,7 @@ async fn handle_browser(
                     println!("{}", serde_json::to_string(&envelope)?);
                 } else {
                     let text = output::format_text("browser start", &context, &result);
-                    println!("{text}");
+                    eprintln!("{text}");
                 }
                 flush_and_exit(1);
             }
@@ -265,7 +265,7 @@ async fn handle_browser(
                 println!("{}", serde_json::to_string(&envelope)?);
             } else {
                 let text = output::format_text(&command_name, &context, &result);
-                println!("{text}");
+                eprintln!("{text}");
             }
             flush_and_exit(1);
         }
@@ -293,7 +293,7 @@ async fn handle_browser(
                     println!("{}", serde_json::to_string(&envelope)?);
                 } else {
                     let text = output::format_text(&command_name, &context, &result);
-                    println!("{text}");
+                    eprintln!("{text}");
                 }
                 flush_and_exit(1);
             }
@@ -312,7 +312,11 @@ async fn handle_browser(
         println!("{}", serde_json::to_string(&envelope)?);
     } else {
         let text = output::format_text(&command_name, &context, &result);
-        println!("{text}");
+        if result.is_ok() {
+            println!("{text}");
+        } else {
+            eprintln!("{text}");
+        }
     }
 
     if !result.is_ok() {
@@ -424,7 +428,11 @@ async fn handle_extension(
         println!("{}", serde_json::to_string(&envelope)?);
     } else {
         let text = output::format_text(command_name, &None, &result);
-        println!("{text}");
+        if result.is_ok() {
+            println!("{text}");
+        } else {
+            eprintln!("{text}");
+        }
     }
 
     if !result.is_ok() {


### PR DESCRIPTION
## Summary

Errors returned in plain-text mode (no `--json`) were written to stdout via `println!`, which violates the standard Unix convention that error diagnostics belong on stderr. Patterns like `actionbook browser start --session X 2>/dev/null` silently dropped all error visibility.

## Repro

```
$ actionbook browser start --session holder
[holder t1] chrome://newtab/
ok browser start

$ actionbook browser start --session other 2>/dev/null
error SESSION_ALREADY_EXISTS: profile 'actionbook' is already in use...
# ← bug: error appeared on stdout (should have been gone with 2>/dev/null)

$ actionbook browser start --session other 2>&1 >/dev/null
# ← bug: stderr was silent, nothing here
```

## Fix

At the four plain-text render sites in `packages/cli/src/main.rs`, choose the output channel based on `ActionResult::is_ok()`. Success text stays on stdout; any `Retryable` / `UserAction` / `Fatal` goes to stderr. JSON mode is unchanged — structured output on stdout is part of the agent contract.

Sites updated:

- `browser start` provider-init failure (always an error path → `eprintln!`)
- `to_action` returned None (unsupported command, always error → `eprintln!`)
- global request timeout (always error → `eprintln!`)
- in-flight daemon result (either channel, branches on `result.is_ok()`)
- extension commands (either channel, branches on `result.is_ok()`)

No behavioral change for any success path. No changes to JSON envelope shape. Agents that script around `2>&1` merging keep working.

## Verification

```
$ ./target/debug/actionbook browser start --session holder
$ ./target/debug/actionbook browser start --session other 2>/dev/null
# stdout now empty ✓

$ ./target/debug/actionbook browser start --session other 2>&1 1>/dev/null
error SESSION_ALREADY_EXISTS: profile 'actionbook' is already in use by session 'holder'
hint: each Chrome profile can only be used by one session at a time. Use --session holder to reuse it, ...
# stderr now carries the error + hint ✓
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --tests -- -D warnings` — clean
- [x] `cargo test` — 423 pre-existing unit tests green, no regressions
- [x] `RUN_E2E_TESTS=false cargo test --test e2e` — 605 gated-off E2E green

## Context

Surfaced while adapting a downstream CLI consumer that was redirecting stderr with `2>/dev/null` to silence boot noise and losing all actual error visibility. Unix-style channel discipline restores that without requiring callers to re-learn the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
