### PR TITLE
fix: sweep empty session dirs + stale __fetch_*.json on daemon start/stop

### DIFF
--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -786,7 +786,10 @@ base_url = "  https://config-api.example.com  "
         sweep_session_orphans();
 
         assert!(!empty.exists(), "empty session dir must be swept");
-        assert!(non_empty.exists(), "non-empty session dir must be preserved");
+        assert!(
+            non_empty.exists(),
+            "non-empty session dir must be preserved"
+        );
         assert!(non_empty.join("snapshot.yaml").exists());
     }
 
@@ -807,7 +810,10 @@ base_url = "  https://config-api.example.com  "
 
         assert!(!stale_a.exists());
         assert!(!stale_b.exists());
-        assert!(keep.exists(), "non-__fetch__ session files must be preserved");
+        assert!(
+            keep.exists(),
+            "non-__fetch__ session files must be preserved"
+        );
     }
 
     #[test]

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -143,6 +143,53 @@ pub fn session_data_dir(session_id: &str) -> PathBuf {
     sessions_dir().join(session_id)
 }
 
+/// Housekeeping sweep for `~/.actionbook/sessions/`:
+///
+/// - Remove subdirectories that are empty. `browser session start` eagerly
+///   creates per-session data dirs; sessions closed via `browser session
+///   close` remove them, but short-lived flows (e.g. single-shot `new-tab
+///   → text → close-tab` without an explicit `session close`) leave empty
+///   orphan dirs behind.
+/// - Remove stale `__fetch_{pid}__.json` files from a removed `actionbook-rs`
+///   code path (browser fetch sub-command). The code that created these
+///   was ripped out, but the CLI still runs into leftovers on machines
+///   that used pre-0.8 versions.
+///
+/// Best-effort: all I/O errors are swallowed — this is a maintenance
+/// pass, not a critical operation.
+pub fn sweep_session_orphans() {
+    let base = sessions_dir();
+    let Ok(entries) = fs::read_dir(&base) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        // Stale `__fetch_{pid}__.json` files from the removed browser-fetch
+        // subcommand (actionbook-rs 0.7→0.8). Drop regardless of PID state
+        // — we're only in this sweep on daemon shutdown / startup, so any
+        // in-flight fetch that was still writing would be the daemon's own,
+        // and it's not using this pattern anymore.
+        if name.starts_with("__fetch_") && name.ends_with("__.json") && path.is_file() {
+            let _ = fs::remove_file(&path);
+            continue;
+        }
+        // Empty session-data subdirs. Only rmdir truly empty ones so a
+        // session that wrote artifacts but wasn't explicitly closed
+        // doesn't lose them.
+        if path.is_dir() {
+            let empty = fs::read_dir(&path)
+                .map(|mut rd| rd.next().is_none())
+                .unwrap_or(false);
+            if empty {
+                let _ = fs::remove_dir(&path);
+            }
+        }
+    }
+}
+
 fn ensure_actionbook_home() -> Result<PathBuf, CliError> {
     let dir = actionbook_home();
     fs::create_dir_all(&dir)?;
@@ -720,5 +767,60 @@ base_url = "  https://config-api.example.com  "
             std::path::PathBuf::from("/test-user-profile/.actionbook"),
             "should use USERPROFILE when HOME is not set"
         );
+    }
+
+    // Housekeeping sweep tests for sessions dir orphans.
+
+    #[test]
+    fn sweep_removes_empty_session_dirs() {
+        let _lock = test_lock();
+        let (_tmp, _guard) = make_home();
+        let sessions = sessions_dir();
+        fs::create_dir_all(&sessions).unwrap();
+        let empty = sessions.join("research-empty-x");
+        fs::create_dir_all(&empty).unwrap();
+        let non_empty = sessions.join("research-has-stuff");
+        fs::create_dir_all(&non_empty).unwrap();
+        fs::write(non_empty.join("snapshot.yaml"), "x").unwrap();
+
+        sweep_session_orphans();
+
+        assert!(!empty.exists(), "empty session dir must be swept");
+        assert!(non_empty.exists(), "non-empty session dir must be preserved");
+        assert!(non_empty.join("snapshot.yaml").exists());
+    }
+
+    #[test]
+    fn sweep_removes_stale_fetch_json_files() {
+        let _lock = test_lock();
+        let (_tmp, _guard) = make_home();
+        let sessions = sessions_dir();
+        fs::create_dir_all(&sessions).unwrap();
+        let stale_a = sessions.join("__fetch_1234__.json");
+        let stale_b = sessions.join("__fetch_99999__.json");
+        let keep = sessions.join("actionbook@default.json");
+        fs::write(&stale_a, r#"{"pid":1234}"#).unwrap();
+        fs::write(&stale_b, r#"{"pid":99999}"#).unwrap();
+        fs::write(&keep, r#"{"profile":"default"}"#).unwrap();
+
+        sweep_session_orphans();
+
+        assert!(!stale_a.exists());
+        assert!(!stale_b.exists());
+        assert!(keep.exists(), "non-__fetch__ session files must be preserved");
+    }
+
+    #[test]
+    fn sweep_is_best_effort_on_missing_sessions_dir() {
+        let _lock = test_lock();
+        let (_tmp, _guard) = make_home();
+        // sessions_dir() exists only when ensure_actionbook_home has run;
+        // the sweep must not panic if it's missing (early daemon start).
+        let sessions = sessions_dir();
+        if sessions.exists() {
+            let _ = fs::remove_dir_all(&sessions);
+        }
+        sweep_session_orphans();
+        // No panic, no side effect — pass.
     }
 }

--- a/packages/cli/src/daemon/server.rs
+++ b/packages/cli/src/daemon/server.rs
@@ -236,11 +236,6 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         std::process::id(),
         crate::BUILD_VERSION
     );
-    // Startup housekeeping: remove session-dir / fetch-file orphans from
-    // previous daemons that exited ungracefully (SIGKILL, panic=abort, or
-    // a hard crash that bypassed the shutdown sweep). Safe because we
-    // hold no state yet — any empty dir was orphaned by a prior run.
-    crate::config::sweep_session_orphans();
     let path = socket_path();
     let pid_file = pid_path();
     let ready_path = path.with_extension("ready");
@@ -286,6 +281,13 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         pid_file_fd.set_len(0)?;
         write!(&pid_file_fd, "{}", std::process::id())?;
     }
+
+    // Housekeeping under lock ownership: remove session-dir / fetch-file
+    // orphans from previous daemons that exited ungracefully (SIGKILL,
+    // panic=abort). Gated behind lock acquisition so a non-owner daemon
+    // that's about to bail out on lock failure can't mistake the real
+    // owner's empty session dirs for orphans.
+    crate::config::sweep_session_orphans();
 
     // Remove stale socket (verify it's actually a socket, not a symlink to something else)
     if path.exists() {
@@ -445,8 +447,6 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         std::process::id(),
         crate::BUILD_VERSION
     );
-    // Startup sweep (same rationale as the unix path).
-    crate::config::sweep_session_orphans();
     let pid_file = pid_path();
     let port_file = port_path();
     let lock_file = lock_path();
@@ -489,6 +489,11 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     // Write our PID to a separate (unlocked) file so the client can target us
     // with taskkill on version mismatch.
     std::fs::write(&pid_file, std::process::id().to_string())?;
+
+    // Housekeeping under lock ownership: same rationale as the unix path.
+    // Must run AFTER lock acquisition so a losing daemon can't mistake the
+    // winner's empty session dirs for orphans.
+    crate::config::sweep_session_orphans();
 
     // Bind TCP listener; OS assigns an ephemeral port in the dynamic range.
     let listener = TcpListener::bind("127.0.0.1:0").await?;

--- a/packages/cli/src/daemon/server.rs
+++ b/packages/cli/src/daemon/server.rs
@@ -236,6 +236,11 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         std::process::id(),
         crate::BUILD_VERSION
     );
+    // Startup housekeeping: remove session-dir / fetch-file orphans from
+    // previous daemons that exited ungracefully (SIGKILL, panic=abort, or
+    // a hard crash that bypassed the shutdown sweep). Safe because we
+    // hold no state yet — any empty dir was orphaned by a prior run.
+    crate::config::sweep_session_orphans();
     let path = socket_path();
     let pid_file = pid_path();
     let ready_path = path.with_extension("ready");
@@ -416,6 +421,11 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::remove_file(version_path()).ok();
     std::fs::remove_file(&pid_file).ok();
 
+    // Sweep empty session data dirs + stale __fetch_*.json files left by
+    // previous short-lived flows or the removed browser-fetch subcommand.
+    // Best-effort — any I/O error is swallowed inside the helper.
+    crate::config::sweep_session_orphans();
+
     info!("daemon shutdown complete (pid={})", std::process::id());
 
     // `pid_file_fd` is dropped here → kernel releases flock
@@ -435,6 +445,8 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
         std::process::id(),
         crate::BUILD_VERSION
     );
+    // Startup sweep (same rationale as the unix path).
+    crate::config::sweep_session_orphans();
     let pid_file = pid_path();
     let port_file = port_path();
     let lock_file = lock_path();
@@ -581,6 +593,10 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     std::fs::remove_file(version_path()).ok();
     std::fs::remove_file(&pid_file).ok();
     std::fs::remove_file(&lock_file).ok();
+
+    // Sweep empty session data dirs + stale __fetch_*.json files (same
+    // housekeeping as the unix path).
+    crate::config::sweep_session_orphans();
 
     info!("daemon shutdown complete (pid={})", std::process::id());
     // Drop the lock fd — Windows releases the byte-range lock when the fd closes.


### PR DESCRIPTION
## Summary

Two historical cleanup leaks in `~/.actionbook/sessions/` that I observed on my own home dir and independently reproduced:

1. **Empty per-session dirs** — `browser session start` eagerly creates `~/.actionbook/sessions/{id}/`, but short-lived flows (e.g. research-CLI's `new-tab → text → close-tab` without an explicit `session close`) never trigger the rmdir in close.rs. Over weeks these accumulate as empty orphan dirs (`research-*/`, `s2/`, `same-tab-test/`, …).

2. **Stale `__fetch_{pid}__.json` files** — remnants of the `actionbook-rs` `browser fetch` subcommand that was removed in v0.8. The creating code is gone, but the files persist on disks that saw pre-0.8 versions. I had three on mine from March.

This is **distinct from PR #560** (E2E harness daemon leak — test-time only). The present leaks affect real user home dirs.

## Fix

`config::sweep_session_orphans()` — best-effort pass that:
- removes any empty subdirectory of `sessions_dir()`
- removes any `__fetch_*__.json` file in that dir

Wired into both daemon lifecycle ends:
- **startup** (unix + windows `run_daemon`): covers the crash case — SIGKILL / panic=abort skipped the shutdown sweep, so the next start catches it.
- **shutdown** (unix + windows, after session close + daemon file cleanup): normal graceful path.

Best-effort on purpose: every `fs::*` call's result is swallowed. The daemon should never fail to shut down because a rogue rmdir errored on a weird filesystem.

## Test plan

- [x] `cargo test --lib config::tests::sweep_` → 3 new tests pass
  - `sweep_removes_empty_session_dirs` — empty gone, non-empty preserved
  - `sweep_removes_stale_fetch_json_files` — `__fetch_*__.json` gone, `actionbook@default.json` preserved
  - `sweep_is_best_effort_on_missing_sessions_dir` — no panic when `sessions/` doesn't exist yet
- [x] `cargo test --lib config::` → full suite green (13 tests)
- [x] `cargo build --bin actionbook` clean
- [ ] Smoke: start daemon with a handful of empty `research-*/` seeded → shutdown → dirs gone
- [ ] Smoke: kill -9 daemon → restart → startup sweep removes orphans

## Not in scope

- Eager vs lazy `create_dir_all` in `session/start.rs` — refactor opportunity but safer to leave alone.
- `~/.actionbook/profiles/` sweep — profiles are cleaned by `session close` and have their own lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)