### PR TITLE
test(eval): red phase for file and stdin browser eval inputs (ACT-975)

### DIFF
--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -1152,6 +1152,23 @@ mod tests {
     }
 
     #[test]
+    fn try_parse_from_accepts_browser_eval_file_flag() {
+        let cli = Cli::try_parse_from([
+            "actionbook",
+            "browser",
+            "eval",
+            "--file",
+            "/tmp/script.js",
+            "--session",
+            "session-1",
+            "--tab",
+            "tab-1",
+        ]);
+
+        assert!(cli.is_ok(), "browser eval should accept --file");
+    }
+
+    #[test]
     fn try_parse_from_accepts_browser_mouse_move_command() {
         let cli = Cli::try_parse_from([
             "actionbook",

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -5,9 +5,14 @@
 //! `browser fill`, and `browser select`,
 //! per api-reference.md §11.
 
+use std::io::Write;
+use std::process::Stdio;
+
+use assert_cmd::cargo::cargo_bin;
+
 use crate::harness::{
-    SessionGuard, assert_failure, assert_success, headless, headless_json, parse_json, skip,
-    stderr_str, stdout_str, unique_session, wait_page_ready,
+    SessionGuard, assert_failure, assert_success, headless, headless_json, parse_json,
+    shared_env, skip, stderr_str, stdout_str, unique_session, wait_page_ready,
 };
 
 const TEST_URL: &str = "https://example.com";
@@ -581,6 +586,37 @@ fn eval_failure_json_with_flags(
 fn eval_value(session_id: &str, tab_id: &str, expression: &str) -> String {
     let v = eval_json_with_flags(session_id, tab_id, expression, &[]);
     v["data"]["value"].as_str().unwrap_or("").to_string()
+}
+
+fn eval_json_with_stdin(session_id: &str, tab_id: &str, stdin_expr: &str) -> serde_json::Value {
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(session_id)
+        .arg("--tab")
+        .arg(tab_id)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn browser eval stdin command");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin pipe");
+        stdin
+            .write_all(stdin_expr.as_bytes())
+            .expect("write stdin expression");
+    }
+    let out = child
+        .wait_with_output()
+        .expect("wait for browser eval stdin command");
+    assert_success(&out, "browser eval stdin");
+    parse_json(&out)
 }
 
 fn install_click_fixture(session_id: &str, tab_id: &str) {
@@ -5854,6 +5890,146 @@ fn eval_async_trailing_line_comment() {
         serde_json::json!(1),
         "async expression with trailing line comment should resolve to 1"
     );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_basic_executes_expression() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(script.path(), "(() => ({ a: 1, ok: true }))()").expect("write eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "browser eval --file basic");
+    let v = parse_json(&out);
+    assert_eq!(v["data"]["value"]["a"], 1);
+    assert_eq!(v["data"]["value"]["ok"], true);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_preserves_complex_javascript() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(
+        script.path(),
+        r#"(() => ({ regex: /\w+/.toString(), text: "quote:\" slash:\\" }))()"#,
+    )
+    .expect("write complex eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "browser eval --file complex");
+    let v = parse_json(&out);
+    assert_eq!(v["data"]["value"]["regex"], "/\\w+/");
+    assert_eq!(v["data"]["value"]["text"], r#"quote:" slash:\"#);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_stdin_dash_reads_expression() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_stdin(&sid, &tid, "(() => ({ via: 'stdin', value: 1 }))()");
+    assert_eq!(v["data"]["value"]["via"], "stdin");
+    assert_eq!(v["data"]["value"]["value"], 1);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_missing_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            "/tmp/actionbook-eval-file-missing.js",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_failure(&out, "browser eval --file missing");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_FILE_NOT_FOUND");
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_and_expression_conflict_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(script.path(), "(() => 1)()").expect("write eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "(() => 2)()",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_failure(&out, "browser eval positional + file conflict");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_ARGS_CONFLICT");
 
     close_session(&sid);
 }


### PR DESCRIPTION
## Summary
- add red coverage for `browser eval --file <path>` and stdin (`-`) input modes
- keep the scope to input channels only; no structured error work in this PR
- verify parser and runtime gaps independently

## Acceptance mapping
- `--file <path>` basic success path
- `--file` preserves complex JS without shell escaping issues
- stdin mode (`browser eval -`) reads the expression from stdin
- missing `--file` path returns structured failure
- positional expression + `--file` conflict returns structured failure

## Verification
- `RUN_E2E_TESTS=true cargo test --manifest-path packages/cli/Cargo.toml --test e2e browser_eval_file_ -- --nocapture --test-threads=1`
- `RUN_E2E_TESTS=true cargo test --manifest-path packages/cli/Cargo.toml --test e2e browser_eval_stdin_ -- --nocapture --test-threads=1`
- `cargo test --manifest-path packages/cli/Cargo.toml try_parse_from_accepts_browser_eval_file_flag -- --nocapture`
- current red state:
  - `browser_eval_file_`: `0 passed / 4 failed`
  - `browser_eval_stdin_`: `0 passed / 1 failed`
  - parse surface: `try_parse_from_accepts_browser_eval_file_flag` fails

## Notes
- red phase only; no implementation changes
- isolated from ACT-967 / ACT-973 failure-shape work

Refs: ACT-975, ACT-913