### PR TITLE
test(eval): red phase for structured browser eval failures (ACT-967, ACT-973)

### DIFF
--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -1152,6 +1152,24 @@ mod tests {
     }
 
     #[test]
+    fn try_parse_from_accepts_browser_eval_timeout_flag() {
+        let cli = Cli::try_parse_from([
+            "actionbook",
+            "browser",
+            "eval",
+            "await Promise.resolve(1)",
+            "--session",
+            "session-1",
+            "--tab",
+            "tab-1",
+            "--timeout",
+            "250",
+        ]);
+
+        assert!(cli.is_ok(), "browser eval should accept --timeout");
+    }
+
+    #[test]
     fn try_parse_from_accepts_browser_mouse_move_command() {
         let cli = Cli::try_parse_from([
             "actionbook",

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -694,6 +694,28 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/api/eval-json-403" {
+        let body = r#"{"error":"forbidden","provider":"fixture"}"#;
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json; charset=utf-8\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
+    if path == "/api/eval-html-403" {
+        let body = "<!DOCTYPE html><html><head><title>Denied</title></head><body><h1>Access denied</h1><p>challenge</p></body></html>";
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Type: text/html; charset=utf-8\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     if path == "/network-fixture.css" {
         let body = "body { background: rgb(245, 248, 255); }";
         let response = format!(

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -6,8 +6,8 @@
 //! per api-reference.md §11.
 
 use crate::harness::{
-    SessionGuard, assert_failure, assert_success, headless, headless_json, parse_json, skip,
-    stderr_str, stdout_str, unique_session, wait_page_ready,
+    SessionGuard, api_base_url, assert_failure, assert_success, headless, headless_json,
+    parse_json, skip, stderr_str, stdout_str, unique_session, wait_page_ready,
 };
 
 const TEST_URL: &str = "https://example.com";
@@ -581,6 +581,15 @@ fn eval_failure_json_with_flags(
 fn eval_value(session_id: &str, tab_id: &str, expression: &str) -> String {
     let v = eval_json_with_flags(session_id, tab_id, expression, &[]);
     v["data"]["value"].as_str().unwrap_or("").to_string()
+}
+
+fn assert_browser_eval_structured_failure(v: &serde_json::Value, expected_code: &str) {
+    assert_eq!(v["command"], "browser eval");
+    assert_error_envelope(v, expected_code);
+    assert!(
+        v["error"]["details"]["reason"].is_string(),
+        "structured eval failures must expose details.reason"
+    );
 }
 
 fn install_click_fixture(session_id: &str, tab_id: &str) {
@@ -5853,6 +5862,221 @@ fn eval_async_trailing_line_comment() {
         v["data"]["value"],
         serde_json::json!(1),
         "async expression with trailing line comment should resolve to 1"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_runtime_error_reference_error_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "(() => { throw new ReferenceError('x'); })()",
+        &[],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_RUNTIME_ERROR");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("ReferenceError"),
+        "reason must preserve the runtime error class"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_runtime_error_type_error_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "(() => { let x = null; return x.map(() => 1); })()",
+        &[],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_RUNTIME_ERROR");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("TypeError"),
+        "reason must preserve the runtime type error"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_cross_origin_fetch_failure_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  try {{
+    await fetch("{}/api/data?source=cors").then(r => r.json());
+    return "unexpected-success";
+  }} catch (e) {{
+    throw {{
+      code: "EVAL_CROSS_ORIGIN",
+      reason: String(e),
+      hint: "Use same-origin fetch or proxy the request server-side"
+    }};
+  }}
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_CROSS_ORIGIN");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("fetch"),
+        "reason must preserve the blocked fetch details"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_non_json_html_response_is_guarded() {
+    if skip() {
+        return;
+    }
+    let local_page = format!("{}/page-a", api_base_url());
+    let (sid, tid) = start_session(&local_page);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  const response = await fetch("{}/api/eval-html-403");
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  if (!contentType.includes("application/json")) {{
+    throw {{
+      code: "EVAL_RESPONSE_NOT_JSON",
+      reason: "Expected JSON but got " + contentType,
+      hint: "Check response.headers.get('content-type') before parsing JSON",
+      status: response.status,
+      content_type: contentType,
+      body_head: body.slice(0, 64)
+    }};
+  }}
+  return JSON.parse(body);
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_RESPONSE_NOT_JSON");
+    assert_eq!(v["error"]["details"]["status"], 403);
+    assert!(
+        v["error"]["details"]["content_type"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("text/html"),
+        "content_type must preserve the HTML response type"
+    );
+    assert!(
+        v["error"]["details"]["body_head"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("<!DOCTYPE html>"),
+        "body_head must capture the leading HTML body snippet"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_non_ok_json_response_is_guarded() {
+    if skip() {
+        return;
+    }
+    let local_page = format!("{}/page-a", api_base_url());
+    let (sid, tid) = start_session(&local_page);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  const response = await fetch("{}/api/eval-json-403");
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  if (!response.ok) {{
+    throw {{
+      code: "EVAL_RESPONSE_NOT_OK",
+      reason: "HTTP " + response.status,
+      hint: "Handle non-2xx fetch responses before decoding the body",
+      status: response.status,
+      content_type: contentType,
+      body_head: body.slice(0, 64)
+    }};
+  }}
+  return JSON.parse(body);
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_RESPONSE_NOT_OK");
+    assert_eq!(v["error"]["details"]["status"], 403);
+    assert!(
+        v["error"]["details"]["content_type"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("application/json"),
+        "content_type must preserve the JSON response type"
+    );
+    assert!(
+        v["error"]["details"]["body_head"]
+            .as_str()
+            .unwrap_or("")
+            .contains("forbidden"),
+        "body_head must capture the leading response body"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_timeout_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "await new Promise(() => {})",
+        &["--timeout", "100"],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_TIMEOUT");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("timed out"),
+        "timeout reason must preserve the timeout failure"
     );
 
     close_session(&sid);


### PR DESCRIPTION
## Summary
- add red e2e coverage for structured `browser eval` failures
- pin the shared ACT-967 / ACT-973 failure shape without adding new subcommands
- add minimal fixture endpoints for 403 JSON and 403 HTML responses

## Acceptance mapping
- runtime error -> expects `EVAL_RUNTIME_ERROR`
- type error -> expects `EVAL_RUNTIME_ERROR`
- cross-origin fetch failure -> expects `EVAL_CROSS_ORIGIN`
- non-JSON HTML body -> expects `EVAL_RESPONSE_NOT_JSON` with `status`, `content_type`, `body_head`
- non-2xx JSON body -> expects `EVAL_RESPONSE_NOT_OK` with `status`, `content_type`, `body_head`
- timeout -> expects `EVAL_TIMEOUT`

## Verification
- `RUN_E2E_TESTS=true cargo test --manifest-path packages/cli/Cargo.toml --test e2e browser_eval_ -- --nocapture --test-threads=1`
- current red state: `0 passed / 6 failed`
- all failures are focused on the missing structured error code/details shape

## Notes
- red phase only; no implementation changes
- does not add `browser fetch` or `--as-json-fetch`

Refs: ACT-967, ACT-973, ACT-913