### PR TITLE
[extension] Prefix tab group title with ⋈ logo (ACT-994)

### DIFF
--- a/.changeset/extension-tabgroup-bowtie-icon.md
+++ b/.changeset/extension-tabgroup-bowtie-icon.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/extension": patch
+---
+
+Prefix the Actionbook Chrome tab-group title with the bowtie logo ⋈ so agent-driven tabs are identifiable at a glance (ACT-994). Existing installs will create a new "⋈ Actionbook" group on upgrade; any previously-named "Actionbook" group becomes orphaned and can be closed manually.

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -16,7 +16,7 @@ const L3_CONFIRM_TIMEOUT_MS = 30000;
 // users can tell agent-driven tabs apart at a glance and collapse/close them
 // in bulk. The group is looked up by title in the tab's own window — we do
 // NOT persist groupId, since it's unstable across sessions and windows.
-const ACTIONBOOK_GROUP_TITLE = "Actionbook";
+const ACTIONBOOK_GROUP_TITLE = "⋈ Actionbook";
 const ACTIONBOOK_GROUP_COLOR = "grey";
 // User-facing toggle (chrome.storage.local key: "groupTabs"). Default on.
 let groupingEnabled = true;


### PR DESCRIPTION
## Summary
- Prefix the Actionbook Chrome tab-group title with the `⋈` bowtie glyph (U+22C8) — the same mark used on actionbook.dev — so agent-driven tabs are identifiable at a glance.
- Chrome `tabGroups` API titles are plain text only, so a Unicode glyph is the only way to show an "icon" there; one-line change to the shared `ACTIONBOOK_GROUP_TITLE` constant covers all three call sites (query / update / listTabs filter).
- Adds a patch changeset for `@actionbookdev/extension` so CI bumps 0.4.1 → 0.4.2 and publishes a new ZIP to GitHub Release.

Linear: [ACT-994](https://linear.app/actionbook/issue/ACT-994)

## Test plan
- [ ] Load `packages/actionbook-extension/` as an unpacked extension in Chrome.
- [ ] Launch the CLI daemon and have an agent open a tab → new tab lands in a grey group titled `⋈ Actionbook`.
- [ ] Open a second agent tab in the same window → reuses the same group (no duplicate).
- [ ] Open an agent tab in a different window → each window gets its own independent `⋈ Actionbook` group.
- [ ] `Extension.listTabs` still returns only managed tabs (regression check on the title-based filter).

## Notes on upgrade
Existing users with a legacy `Actionbook`-titled group won't have it auto-migrated — on first post-upgrade use, a fresh `⋈ Actionbook` group is created and the old one becomes orphaned. Acceptable one-time friction; a migration pass would add meaningful complexity for limited benefit.