### PR TITLE
[cli] feat: add HYPERBROWSER_PROXY_COUNTRY env var

### DIFF
--- a/.changeset/cli-hyperbrowser-proxy-country.md
+++ b/.changeset/cli-hyperbrowser-proxy-country.md
@@ -2,7 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-Add proxy-country configuration to the Hyperbrowser provider and introduce a cross-provider fallback env var.
-
-- New vendor-specific env var `HYPERBROWSER_PROXY_COUNTRY` — forwarded as `proxyCountry` on Hyperbrowser's create-session request. When unset, the field is omitted so Hyperbrowser's own default applies.
-- New cross-provider env var `ACTIONBOOK_PROXY_COUNTRY` — acts as a fallback for all three providers when their vendor-specific name isn't set. An agent can now set one variable and have it map to `proxyCountry` (Hyperbrowser), `proxyCountryCode` (Browser Use), or `country` (driver.dev) automatically. Vendor-specific env vars still take precedence.
+Add optional `HYPERBROWSER_PROXY_COUNTRY` env var to pin the Hyperbrowser proxy exit region (ISO country code, e.g. `US`, `JP`). Forwarded as `proxyCountry` on the create-session request; when unset, the field is omitted and Hyperbrowser's own default applies. Matches the existing per-provider pattern (`DRIVER_DEV_COUNTRY`, `BROWSER_USE_PROXY_COUNTRY_CODE`).

--- a/.changeset/cli-hyperbrowser-proxy-country.md
+++ b/.changeset/cli-hyperbrowser-proxy-country.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": minor
+---
+
+Add `HYPERBROWSER_PROXY_COUNTRY` env var to pin the Hyperbrowser proxy exit region (ISO country code, e.g. `JP`). Defaults to `US` when unset, so every Hyperbrowser session now includes an explicit `proxyCountry` in the create-session request.

--- a/.changeset/cli-hyperbrowser-proxy-country.md
+++ b/.changeset/cli-hyperbrowser-proxy-country.md
@@ -2,4 +2,7 @@
 "@actionbookdev/cli": minor
 ---
 
-Add `HYPERBROWSER_PROXY_COUNTRY` env var to pin the Hyperbrowser proxy exit region (ISO country code, e.g. `JP`). Defaults to `US` when unset, so every Hyperbrowser session now includes an explicit `proxyCountry` in the create-session request.
+Add proxy-country configuration to the Hyperbrowser provider and introduce a cross-provider fallback env var.
+
+- New vendor-specific env var `HYPERBROWSER_PROXY_COUNTRY` — forwarded as `proxyCountry` on Hyperbrowser's create-session request. When unset, the field is omitted so Hyperbrowser's own default applies.
+- New cross-provider env var `ACTIONBOOK_PROXY_COUNTRY` — acts as a fallback for all three providers when their vendor-specific name isn't set. An agent can now set one variable and have it map to `proxyCountry` (Hyperbrowser), `proxyCountryCode` (Browser Use), or `country` (driver.dev) automatically. Vendor-specific env vars still take precedence.

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -829,9 +829,18 @@ mod tests {
         ]);
         let current = env_with(&[("ACTIONBOOK_PROXY_COUNTRY", "JP")]);
         let merged = merge_provider_env(saved, current);
-        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("saved-key"));
-        assert_eq!(merged.get("HYPERBROWSER_USE_PROXY").map(String::as_str), Some("true"));
-        assert_eq!(merged.get("ACTIONBOOK_PROXY_COUNTRY").map(String::as_str), Some("JP"));
+        assert_eq!(
+            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
+            Some("saved-key")
+        );
+        assert_eq!(
+            merged.get("HYPERBROWSER_USE_PROXY").map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            merged.get("ACTIONBOOK_PROXY_COUNTRY").map(String::as_str),
+            Some("JP")
+        );
     }
 
     #[test]
@@ -839,14 +848,20 @@ mod tests {
         let saved = env_with(&[("HYPERBROWSER_API_KEY", "old-key")]);
         let current = env_with(&[("HYPERBROWSER_API_KEY", "new-key")]);
         let merged = merge_provider_env(saved, current);
-        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("new-key"));
+        assert_eq!(
+            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
+            Some("new-key")
+        );
     }
 
     #[test]
     fn merge_provider_env_falls_back_to_saved_when_current_is_empty() {
         let saved = env_with(&[("HYPERBROWSER_API_KEY", "saved-key")]);
         let merged = merge_provider_env(saved, ProviderEnv::new());
-        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("saved-key"));
+        assert_eq!(
+            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
+            Some("saved-key")
+        );
     }
 
     #[test]

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -409,11 +409,16 @@ async fn connect_hyperbrowser(
     let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
         .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
     let use_proxy = parse_env_bool(env, "HYPERBROWSER_USE_PROXY").unwrap_or(false);
+    let proxy_country = read_trimmed_env(env, "HYPERBROWSER_PROXY_COUNTRY")
+        .unwrap_or_else(|| "US".to_string());
     let persist_changes = parse_env_bool(env, "HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
     let profile_id = read_trimmed_env(env, "HYPERBROWSER_PROFILE_ID")
         .or_else(|| non_default_profile(profile_name));
 
-    let mut body = json!({ "useProxy": use_proxy });
+    let mut body = json!({
+        "useProxy": use_proxy,
+        "proxyCountry": proxy_country,
+    });
     if let Some(profile_id) = profile_id {
         body["profile"] = json!({
             "id": normalize_hyperbrowser_profile_id(&profile_id)?,
@@ -906,6 +911,50 @@ mod tests {
         let request = request_handle.join().expect("request join");
         assert!(request.starts_with("PUT /api/session/hb-s-1/stop HTTP/1.1"));
         assert!(request.to_ascii_lowercase().contains("content-length: 0"));
+    }
+
+    #[tokio::test]
+    async fn connect_hyperbrowser_sends_default_proxy_country() {
+        let response: &'static str = Box::leak(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 57\r\n\r\n{\"id\":\"hb-s-1\",\"wsEndpoint\":\"wss://hb.test/ws/session-1\"}"
+                .to_string()
+                .into_boxed_str(),
+        );
+        let (base_url, request_handle) = spawn_single_response_server(response);
+        let env = env_with(&[
+            ("HYPERBROWSER_API_URL", &base_url),
+            ("HYPERBROWSER_API_KEY", "hb-key"),
+        ]);
+
+        connect_hyperbrowser(crate::config::DEFAULT_PROFILE, &env)
+            .await
+            .expect("hyperbrowser connect should succeed");
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("POST /api/session HTTP/1.1"));
+        assert!(request.contains("\"proxyCountry\":\"US\""));
+    }
+
+    #[tokio::test]
+    async fn connect_hyperbrowser_forwards_custom_proxy_country() {
+        let response: &'static str = Box::leak(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 57\r\n\r\n{\"id\":\"hb-s-2\",\"wsEndpoint\":\"wss://hb.test/ws/session-2\"}"
+                .to_string()
+                .into_boxed_str(),
+        );
+        let (base_url, request_handle) = spawn_single_response_server(response);
+        let env = env_with(&[
+            ("HYPERBROWSER_API_URL", &base_url),
+            ("HYPERBROWSER_API_KEY", "hb-key"),
+            ("HYPERBROWSER_PROXY_COUNTRY", "  JP  "),
+        ]);
+
+        connect_hyperbrowser(crate::config::DEFAULT_PROFILE, &env)
+            .await
+            .expect("hyperbrowser connect should succeed");
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.contains("\"proxyCountry\":\"JP\""));
     }
 
     #[test]

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -35,41 +35,17 @@ pub type ProviderEnv = BTreeMap<String, String>;
 /// forward them in the IPC payload.
 pub const PROVIDER_ENV_PREFIXES: &[&str] = &["DRIVER_", "HYPERBROWSER_", "BROWSER_USE_"];
 
-/// Cross-provider env vars that aren't tied to any specific vendor prefix but
-/// still need to travel from the client shell to the daemon. Kept as an
-/// explicit allowlist so we don't open the floodgates on the broader
-/// `ACTIONBOOK_*` namespace (API keys, browser mode, etc. are read
-/// client-side and must not leak into `ProviderEnv`).
-pub const PROVIDER_ENV_NAMES: &[&str] = &["ACTIONBOOK_PROXY_COUNTRY"];
-
-/// Collect every env var on the current process that matches either a known
-/// provider prefix or the cross-provider allowlist. Called from the CLI client
-/// (NOT the daemon) right before sending a Start/Restart action.
+/// Collect every env var on the current process whose name starts with one of
+/// the provider prefixes. Called from the CLI client (NOT the daemon) right
+/// before sending a Start/Restart action.
 pub fn collect_provider_env_from_process() -> ProviderEnv {
     std::env::vars()
         .filter(|(name, _)| {
             PROVIDER_ENV_PREFIXES
                 .iter()
                 .any(|prefix| name.starts_with(prefix))
-                || PROVIDER_ENV_NAMES.contains(&name.as_str())
         })
         .collect()
-}
-
-/// Merge the provider env we saved at session-start time with whatever the
-/// caller's current shell just forwarded. Used by `restart` so:
-/// - A new `*_API_KEY` in the current shell wins over the saved one
-///   (credential rotation).
-/// - A shell that only exports a non-credential tweak (e.g. the cross-provider
-///   `ACTIONBOOK_PROXY_COUNTRY`) layers onto the saved snapshot instead of
-///   wiping it — otherwise the restart would lose its API key and fail.
-/// - An empty current shell falls back entirely to the saved snapshot.
-pub fn merge_provider_env(saved: ProviderEnv, current: ProviderEnv) -> ProviderEnv {
-    let mut merged = saved;
-    for (name, value) in current {
-        merged.insert(name, value);
-    }
-    merged
 }
 
 /// HTTP request timeout for cloud provider control-plane API calls.
@@ -340,7 +316,7 @@ async fn connect_driver_dev(
     // Build optional session-creation body. Empty `{}` is valid; only set fields
     // when the user actually configured them.
     let mut body = json!({});
-    if let Some(country) = read_proxy_country(env, "DRIVER_DEV_COUNTRY") {
+    if let Some(country) = read_trimmed_env(env, "DRIVER_DEV_COUNTRY") {
         body["country"] = json!(country);
     }
     if let Some(node_id) = read_trimmed_env(env, "DRIVER_DEV_NODE_ID") {
@@ -433,7 +409,7 @@ async fn connect_hyperbrowser(
     let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
         .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
     let use_proxy = parse_env_bool(env, "HYPERBROWSER_USE_PROXY").unwrap_or(false);
-    let proxy_country = read_proxy_country(env, "HYPERBROWSER_PROXY_COUNTRY");
+    let proxy_country = read_trimmed_env(env, "HYPERBROWSER_PROXY_COUNTRY");
     let persist_changes = parse_env_bool(env, "HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
     let profile_id = read_trimmed_env(env, "HYPERBROWSER_PROFILE_ID")
         .or_else(|| non_default_profile(profile_name));
@@ -520,7 +496,7 @@ async fn connect_browser_use(
         .unwrap_or_else(|| BROWSER_USE_API_BASE.to_string());
 
     let mut body = json!({});
-    if let Some(value) = read_proxy_country(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
+    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
         body["proxyCountryCode"] = json!(value);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROFILE_ID")
@@ -600,18 +576,6 @@ fn read_trimmed_env(env: &ProviderEnv, name: &str) -> Option<String> {
 fn read_required_env(env: &ProviderEnv, name: &str) -> Result<String, CliError> {
     read_trimmed_env(env, name)
         .ok_or_else(|| CliError::InvalidArgument(format!("{name} environment variable is not set")))
-}
-
-/// Resolve the proxy-country value a caller wants for this session. Each
-/// provider exposes its own vendor-specific env var (e.g. `proxyCountry` on
-/// Hyperbrowser, `proxyCountryCode` on Browser Use, `country` on driver.dev)
-/// — we read that first so existing setups keep working unchanged. When the
-/// vendor-specific name is absent, fall back to the cross-provider
-/// `ACTIONBOOK_PROXY_COUNTRY` so an agent can set one env var and have it
-/// apply regardless of which provider handles the session.
-fn read_proxy_country(env: &ProviderEnv, provider_specific: &str) -> Option<String> {
-    read_trimmed_env(env, provider_specific)
-        .or_else(|| read_trimmed_env(env, "ACTIONBOOK_PROXY_COUNTRY"))
 }
 
 fn parse_env_bool(env: &ProviderEnv, name: &str) -> Option<bool> {
@@ -779,89 +743,6 @@ mod tests {
         let env = ProviderEnv::new();
         let err = read_required_env(&env, "DRIVER_API_KEY").unwrap_err();
         assert!(matches!(err, CliError::InvalidArgument(_)));
-    }
-
-    #[test]
-    fn read_proxy_country_prefers_vendor_specific_over_cross_provider() {
-        let env = env_with(&[
-            ("HYPERBROWSER_PROXY_COUNTRY", "JP"),
-            ("ACTIONBOOK_PROXY_COUNTRY", "US"),
-        ]);
-        assert_eq!(
-            read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"),
-            Some("JP".to_string())
-        );
-    }
-
-    #[test]
-    fn read_proxy_country_falls_back_to_cross_provider() {
-        let env = env_with(&[("ACTIONBOOK_PROXY_COUNTRY", "DE")]);
-        assert_eq!(
-            read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"),
-            Some("DE".to_string())
-        );
-        // Works for the other providers' vendor-specific names too.
-        assert_eq!(
-            read_proxy_country(&env, "DRIVER_DEV_COUNTRY"),
-            Some("DE".to_string())
-        );
-        assert_eq!(
-            read_proxy_country(&env, "BROWSER_USE_PROXY_COUNTRY_CODE"),
-            Some("DE".to_string())
-        );
-    }
-
-    #[test]
-    fn read_proxy_country_returns_none_when_both_missing() {
-        let env = ProviderEnv::new();
-        assert_eq!(read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"), None);
-    }
-
-    #[test]
-    fn merge_provider_env_preserves_saved_creds_when_current_only_has_cross_provider_tweak() {
-        // Regression: before merge-based restart, a shell that only exported
-        // `ACTIONBOOK_PROXY_COUNTRY` (non-credential) would wipe the saved
-        // `*_API_KEY` and break restart. The merge must keep the saved key and
-        // layer the country on top.
-        let saved = env_with(&[
-            ("HYPERBROWSER_API_KEY", "saved-key"),
-            ("HYPERBROWSER_USE_PROXY", "true"),
-        ]);
-        let current = env_with(&[("ACTIONBOOK_PROXY_COUNTRY", "JP")]);
-        let merged = merge_provider_env(saved, current);
-        assert_eq!(
-            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
-            Some("saved-key")
-        );
-        assert_eq!(
-            merged.get("HYPERBROWSER_USE_PROXY").map(String::as_str),
-            Some("true")
-        );
-        assert_eq!(
-            merged.get("ACTIONBOOK_PROXY_COUNTRY").map(String::as_str),
-            Some("JP")
-        );
-    }
-
-    #[test]
-    fn merge_provider_env_lets_current_override_saved_for_credential_rotation() {
-        let saved = env_with(&[("HYPERBROWSER_API_KEY", "old-key")]);
-        let current = env_with(&[("HYPERBROWSER_API_KEY", "new-key")]);
-        let merged = merge_provider_env(saved, current);
-        assert_eq!(
-            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
-            Some("new-key")
-        );
-    }
-
-    #[test]
-    fn merge_provider_env_falls_back_to_saved_when_current_is_empty() {
-        let saved = env_with(&[("HYPERBROWSER_API_KEY", "saved-key")]);
-        let merged = merge_provider_env(saved, ProviderEnv::new());
-        assert_eq!(
-            merged.get("HYPERBROWSER_API_KEY").map(String::as_str),
-            Some("saved-key")
-        );
     }
 
     #[test]
@@ -1118,12 +999,10 @@ mod tests {
         // Smoke test: should never panic, should not include unrelated vars.
         let env = collect_provider_env_from_process();
         for name in env.keys() {
-            let prefix_match = PROVIDER_ENV_PREFIXES
-                .iter()
-                .any(|prefix| name.starts_with(prefix));
-            let allowlist_match = PROVIDER_ENV_NAMES.contains(&name.as_str());
             assert!(
-                prefix_match || allowlist_match,
+                PROVIDER_ENV_PREFIXES
+                    .iter()
+                    .any(|prefix| name.starts_with(prefix)),
                 "unexpected env var leaked into provider env: {name}"
             );
         }

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -35,15 +35,23 @@ pub type ProviderEnv = BTreeMap<String, String>;
 /// forward them in the IPC payload.
 pub const PROVIDER_ENV_PREFIXES: &[&str] = &["DRIVER_", "HYPERBROWSER_", "BROWSER_USE_"];
 
-/// Collect every env var on the current process whose name starts with one of
-/// the provider prefixes. Called from the CLI client (NOT the daemon) right
-/// before sending a Start/Restart action.
+/// Cross-provider env vars that aren't tied to any specific vendor prefix but
+/// still need to travel from the client shell to the daemon. Kept as an
+/// explicit allowlist so we don't open the floodgates on the broader
+/// `ACTIONBOOK_*` namespace (API keys, browser mode, etc. are read
+/// client-side and must not leak into `ProviderEnv`).
+pub const PROVIDER_ENV_NAMES: &[&str] = &["ACTIONBOOK_PROXY_COUNTRY"];
+
+/// Collect every env var on the current process that matches either a known
+/// provider prefix or the cross-provider allowlist. Called from the CLI client
+/// (NOT the daemon) right before sending a Start/Restart action.
 pub fn collect_provider_env_from_process() -> ProviderEnv {
     std::env::vars()
         .filter(|(name, _)| {
             PROVIDER_ENV_PREFIXES
                 .iter()
                 .any(|prefix| name.starts_with(prefix))
+                || PROVIDER_ENV_NAMES.contains(&name.as_str())
         })
         .collect()
 }
@@ -316,7 +324,7 @@ async fn connect_driver_dev(
     // Build optional session-creation body. Empty `{}` is valid; only set fields
     // when the user actually configured them.
     let mut body = json!({});
-    if let Some(country) = read_trimmed_env(env, "DRIVER_DEV_COUNTRY") {
+    if let Some(country) = read_proxy_country(env, "DRIVER_DEV_COUNTRY") {
         body["country"] = json!(country);
     }
     if let Some(node_id) = read_trimmed_env(env, "DRIVER_DEV_NODE_ID") {
@@ -409,16 +417,15 @@ async fn connect_hyperbrowser(
     let api_base = read_trimmed_env(env, "HYPERBROWSER_API_URL")
         .unwrap_or_else(|| HYPERBROWSER_API_BASE.to_string());
     let use_proxy = parse_env_bool(env, "HYPERBROWSER_USE_PROXY").unwrap_or(false);
-    let proxy_country = read_trimmed_env(env, "HYPERBROWSER_PROXY_COUNTRY")
-        .unwrap_or_else(|| "US".to_string());
+    let proxy_country = read_proxy_country(env, "HYPERBROWSER_PROXY_COUNTRY");
     let persist_changes = parse_env_bool(env, "HYPERBROWSER_PERSIST_CHANGES").unwrap_or(true);
     let profile_id = read_trimmed_env(env, "HYPERBROWSER_PROFILE_ID")
         .or_else(|| non_default_profile(profile_name));
 
-    let mut body = json!({
-        "useProxy": use_proxy,
-        "proxyCountry": proxy_country,
-    });
+    let mut body = json!({ "useProxy": use_proxy });
+    if let Some(country) = proxy_country {
+        body["proxyCountry"] = json!(country);
+    }
     if let Some(profile_id) = profile_id {
         body["profile"] = json!({
             "id": normalize_hyperbrowser_profile_id(&profile_id)?,
@@ -497,7 +504,7 @@ async fn connect_browser_use(
         .unwrap_or_else(|| BROWSER_USE_API_BASE.to_string());
 
     let mut body = json!({});
-    if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
+    if let Some(value) = read_proxy_country(env, "BROWSER_USE_PROXY_COUNTRY_CODE") {
         body["proxyCountryCode"] = json!(value);
     }
     if let Some(value) = read_trimmed_env(env, "BROWSER_USE_PROFILE_ID")
@@ -577,6 +584,18 @@ fn read_trimmed_env(env: &ProviderEnv, name: &str) -> Option<String> {
 fn read_required_env(env: &ProviderEnv, name: &str) -> Result<String, CliError> {
     read_trimmed_env(env, name)
         .ok_or_else(|| CliError::InvalidArgument(format!("{name} environment variable is not set")))
+}
+
+/// Resolve the proxy-country value a caller wants for this session. Each
+/// provider exposes its own vendor-specific env var (e.g. `proxyCountry` on
+/// Hyperbrowser, `proxyCountryCode` on Browser Use, `country` on driver.dev)
+/// — we read that first so existing setups keep working unchanged. When the
+/// vendor-specific name is absent, fall back to the cross-provider
+/// `ACTIONBOOK_PROXY_COUNTRY` so an agent can set one env var and have it
+/// apply regardless of which provider handles the session.
+fn read_proxy_country(env: &ProviderEnv, provider_specific: &str) -> Option<String> {
+    read_trimmed_env(env, provider_specific)
+        .or_else(|| read_trimmed_env(env, "ACTIONBOOK_PROXY_COUNTRY"))
 }
 
 fn parse_env_bool(env: &ProviderEnv, name: &str) -> Option<bool> {
@@ -747,6 +766,42 @@ mod tests {
     }
 
     #[test]
+    fn read_proxy_country_prefers_vendor_specific_over_cross_provider() {
+        let env = env_with(&[
+            ("HYPERBROWSER_PROXY_COUNTRY", "JP"),
+            ("ACTIONBOOK_PROXY_COUNTRY", "US"),
+        ]);
+        assert_eq!(
+            read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"),
+            Some("JP".to_string())
+        );
+    }
+
+    #[test]
+    fn read_proxy_country_falls_back_to_cross_provider() {
+        let env = env_with(&[("ACTIONBOOK_PROXY_COUNTRY", "DE")]);
+        assert_eq!(
+            read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"),
+            Some("DE".to_string())
+        );
+        // Works for the other providers' vendor-specific names too.
+        assert_eq!(
+            read_proxy_country(&env, "DRIVER_DEV_COUNTRY"),
+            Some("DE".to_string())
+        );
+        assert_eq!(
+            read_proxy_country(&env, "BROWSER_USE_PROXY_COUNTRY_CODE"),
+            Some("DE".to_string())
+        );
+    }
+
+    #[test]
+    fn read_proxy_country_returns_none_when_both_missing() {
+        let env = ProviderEnv::new();
+        assert_eq!(read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"), None);
+    }
+
+    #[test]
     fn parse_env_bool_understands_truthy_values() {
         let env = env_with(&[
             ("HYPERBROWSER_USE_PROXY", "true"),
@@ -914,7 +969,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn connect_hyperbrowser_sends_default_proxy_country() {
+    async fn connect_hyperbrowser_omits_proxy_country_when_unset() {
         let response: &'static str = Box::leak(
             "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 57\r\n\r\n{\"id\":\"hb-s-1\",\"wsEndpoint\":\"wss://hb.test/ws/session-1\"}"
                 .to_string()
@@ -932,7 +987,9 @@ mod tests {
 
         let request = request_handle.join().expect("request join");
         assert!(request.starts_with("POST /api/session HTTP/1.1"));
-        assert!(request.contains("\"proxyCountry\":\"US\""));
+        // No env var set → keep the CLI out of Hyperbrowser's region-default
+        // decision; absent field lets the provider pick its own default.
+        assert!(!request.contains("proxyCountry"));
     }
 
     #[tokio::test]
@@ -998,10 +1055,12 @@ mod tests {
         // Smoke test: should never panic, should not include unrelated vars.
         let env = collect_provider_env_from_process();
         for name in env.keys() {
+            let prefix_match = PROVIDER_ENV_PREFIXES
+                .iter()
+                .any(|prefix| name.starts_with(prefix));
+            let allowlist_match = PROVIDER_ENV_NAMES.contains(&name.as_str());
             assert!(
-                PROVIDER_ENV_PREFIXES
-                    .iter()
-                    .any(|prefix| name.starts_with(prefix)),
+                prefix_match || allowlist_match,
                 "unexpected env var leaked into provider env: {name}"
             );
         }

--- a/packages/cli/src/browser/session/provider.rs
+++ b/packages/cli/src/browser/session/provider.rs
@@ -56,6 +56,22 @@ pub fn collect_provider_env_from_process() -> ProviderEnv {
         .collect()
 }
 
+/// Merge the provider env we saved at session-start time with whatever the
+/// caller's current shell just forwarded. Used by `restart` so:
+/// - A new `*_API_KEY` in the current shell wins over the saved one
+///   (credential rotation).
+/// - A shell that only exports a non-credential tweak (e.g. the cross-provider
+///   `ACTIONBOOK_PROXY_COUNTRY`) layers onto the saved snapshot instead of
+///   wiping it — otherwise the restart would lose its API key and fail.
+/// - An empty current shell falls back entirely to the saved snapshot.
+pub fn merge_provider_env(saved: ProviderEnv, current: ProviderEnv) -> ProviderEnv {
+    let mut merged = saved;
+    for (name, value) in current {
+        merged.insert(name, value);
+    }
+    merged
+}
+
 /// HTTP request timeout for cloud provider control-plane API calls.
 /// Provider APIs occasionally hang; without an explicit timeout the daemon
 /// thread is stuck indefinitely waiting on `connect_provider`.
@@ -799,6 +815,38 @@ mod tests {
     fn read_proxy_country_returns_none_when_both_missing() {
         let env = ProviderEnv::new();
         assert_eq!(read_proxy_country(&env, "HYPERBROWSER_PROXY_COUNTRY"), None);
+    }
+
+    #[test]
+    fn merge_provider_env_preserves_saved_creds_when_current_only_has_cross_provider_tweak() {
+        // Regression: before merge-based restart, a shell that only exported
+        // `ACTIONBOOK_PROXY_COUNTRY` (non-credential) would wipe the saved
+        // `*_API_KEY` and break restart. The merge must keep the saved key and
+        // layer the country on top.
+        let saved = env_with(&[
+            ("HYPERBROWSER_API_KEY", "saved-key"),
+            ("HYPERBROWSER_USE_PROXY", "true"),
+        ]);
+        let current = env_with(&[("ACTIONBOOK_PROXY_COUNTRY", "JP")]);
+        let merged = merge_provider_env(saved, current);
+        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("saved-key"));
+        assert_eq!(merged.get("HYPERBROWSER_USE_PROXY").map(String::as_str), Some("true"));
+        assert_eq!(merged.get("ACTIONBOOK_PROXY_COUNTRY").map(String::as_str), Some("JP"));
+    }
+
+    #[test]
+    fn merge_provider_env_lets_current_override_saved_for_credential_rotation() {
+        let saved = env_with(&[("HYPERBROWSER_API_KEY", "old-key")]);
+        let current = env_with(&[("HYPERBROWSER_API_KEY", "new-key")]);
+        let merged = merge_provider_env(saved, current);
+        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("new-key"));
+    }
+
+    #[test]
+    fn merge_provider_env_falls_back_to_saved_when_current_is_empty() {
+        let saved = env_with(&[("HYPERBROWSER_API_KEY", "saved-key")]);
+        let merged = merge_provider_env(saved, ProviderEnv::new());
+        assert_eq!(merged.get("HYPERBROWSER_API_KEY").map(String::as_str), Some("saved-key"));
     }
 
     #[test]

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -190,13 +190,14 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         };
 
     // Stateful restart needs provider env to mint a fresh remote session.
-    // Merge the saved snapshot (from start time) with the current shell's env,
-    // letting the current shell override individual keys — see
-    // `merge_provider_env` for the rationale.
-    let effective_provider_env = super::provider::merge_provider_env(
-        saved_provider_env.unwrap_or_default(),
-        cmd.provider_env.clone(),
-    );
+    // Prefer the env the user supplied with the restart call (latest shell
+    // state) so credential rotation works; fall back to the snapshot we saved
+    // at start time so restarts from a different shell don't break.
+    let effective_provider_env = if !cmd.provider_env.is_empty() {
+        cmd.provider_env.clone()
+    } else {
+        saved_provider_env.unwrap_or_default()
+    };
 
     let start_cmd = super::start::Cmd {
         mode: Some(mode),

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -190,14 +190,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         };
 
     // Stateful restart needs provider env to mint a fresh remote session.
-    // Prefer the env the user supplied with the restart call (latest shell
-    // state) so credential rotation works; fall back to the snapshot we saved
-    // at start time so restarts from a different shell don't break.
-    let effective_provider_env = if !cmd.provider_env.is_empty() {
-        cmd.provider_env.clone()
-    } else {
-        saved_provider_env.unwrap_or_default()
-    };
+    // Merge the saved snapshot (from start time) with the current shell's env,
+    // letting the current shell override individual keys — see
+    // `merge_provider_env` for the rationale.
+    let effective_provider_env = super::provider::merge_provider_env(
+        saved_provider_env.unwrap_or_default(),
+        cmd.provider_env.clone(),
+    );
 
     let start_cmd = super::start::Cmd {
         mode: Some(mode),


### PR DESCRIPTION
## Summary

Add optional `HYPERBROWSER_PROXY_COUNTRY` env var. When set, forwarded as `proxyCountry` on Hyperbrowser's `POST /api/session`; when unset, the field is omitted and Hyperbrowser's own default applies. Matches the per-provider pattern already used by `DRIVER_DEV_COUNTRY` and `BROWSER_USE_PROXY_COUNTRY_CODE`.

## Non-goals

Earlier iterations introduced a cross-provider `ACTIONBOOK_PROXY_COUNTRY` fallback + `merge_provider_env` restart workaround; those were reverted on review feedback to keep the PR tight. Each provider's vendor-specific env var stays the only way to set country.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --lib browser::session::provider::` — two new HTTP-mock tests:
  - `connect_hyperbrowser_omits_proxy_country_when_unset` — no env → body omits `proxyCountry`
  - `connect_hyperbrowser_forwards_custom_proxy_country` — `HYPERBROWSER_PROXY_COUNTRY="  JP  "` → body contains `"proxyCountry":"JP"`
- [x] Manual smoke: `HYPERBROWSER_USE_PROXY=true` + `HYPERBROWSER_PROXY_COUNTRY=US` → `ipinfo.io` reports `country=US`; `https://ohiomeansjobs.ohio.gov/` loads cleanly.

## Follow-ups (not in this PR)

- Mirror in `packages/dify-plugin/providers/hyperbrowser.py`.