### PR TITLE
feat(cli): structured browser eval error returns (ACT-967/ACT-973)

### DIFF
--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -65,6 +65,14 @@ fn truncate_body_head(text: &str) -> String {
     text.chars().take(BODY_HEAD_LIMIT_CHARS).collect()
 }
 
+fn json_value_to_string(value: Value) -> Option<String> {
+    match value {
+        Value::Null => None,
+        Value::String(text) => Some(text),
+        other => Some(other.to_string()),
+    }
+}
+
 fn string_property<'a>(properties: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
     properties.get(key).and_then(|value| value.as_str())
 }
@@ -139,10 +147,67 @@ async fn read_exception_properties(
     properties
 }
 
+fn has_cross_origin_fetch_target(expression: &str, pre_origin: &str) -> bool {
+    if pre_origin.is_empty() || pre_origin == "null" {
+        return false;
+    }
+
+    let expression_lower = expression.to_ascii_lowercase();
+    if !expression_lower.contains("fetch(") && !expression_lower.contains("fetch (") {
+        return false;
+    }
+
+    let Ok(pre_origin_url) = reqwest::Url::parse(pre_origin) else {
+        return false;
+    };
+    let pre_origin = pre_origin_url.origin().ascii_serialization();
+
+    let mut chars = expression.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if !matches!(ch, '"' | '\'' | '`') {
+            continue;
+        }
+
+        let quote = ch;
+        let mut literal = String::new();
+        let mut escaped = false;
+        for ch in chars.by_ref() {
+            if escaped {
+                literal.push(ch);
+                escaped = false;
+                continue;
+            }
+            if ch == '\\' {
+                escaped = true;
+                continue;
+            }
+            if ch == quote {
+                break;
+            }
+            literal.push(ch);
+        }
+
+        if !(literal.starts_with("http://") || literal.starts_with("https://")) {
+            continue;
+        }
+
+        let Ok(url) = reqwest::Url::parse(&literal) else {
+            continue;
+        };
+        if url.origin().ascii_serialization() != pre_origin {
+            return true;
+        }
+    }
+
+    false
+}
+
 fn classify_eval_error(
     description: &str,
     error_type: &str,
     properties: &Map<String, Value>,
+    expression: &str,
+    pre_origin: &str,
 ) -> EvalErrorCode {
     if let Some(code) = string_property(properties, "code").and_then(EvalErrorCode::from_wire_code)
     {
@@ -163,13 +228,14 @@ fn classify_eval_error(
     }
     let haystack = haystack.to_ascii_lowercase();
 
-    if haystack.contains("failed to fetch")
-        || haystack.contains("securityerror")
+    if haystack.contains("securityerror")
         || haystack.contains("cross-origin")
         || haystack.contains("cross origin")
         || haystack.contains("same origin policy")
         || haystack.contains("blocked a frame with origin")
         || haystack.contains("content security policy")
+        || (haystack.contains("failed to fetch")
+            && has_cross_origin_fetch_target(expression, pre_origin))
     {
         EvalErrorCode::CrossOrigin
     } else {
@@ -193,13 +259,16 @@ fn build_eval_error_result(
 ) -> ActionResult {
     properties.remove("code");
     properties.remove("hint");
-
-    let body_head = string_property(&properties, "body_head").map(truncate_body_head);
-    let message = properties
-        .get("reason")
-        .and_then(|value| value.as_str())
-        .unwrap_or(&reason)
-        .to_string();
+    let normalized_reason = properties
+        .remove("reason")
+        .and_then(json_value_to_string)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(reason);
+    let body_head = properties
+        .remove("body_head")
+        .and_then(json_value_to_string)
+        .map(|value| truncate_body_head(&value));
+    let message = normalized_reason.clone();
     let hint = hint.unwrap_or_else(|| code.default_hint().to_string());
 
     let mut details = Map::new();
@@ -208,7 +277,7 @@ fn build_eval_error_result(
     details.insert("pre_origin".to_string(), json!(context.pre_origin));
     details.insert("pre_readyState".to_string(), json!(context.pre_ready_state));
     details.insert("error_type".to_string(), json!(context.error_type));
-    details.insert("reason".to_string(), json!(reason));
+    details.insert("reason".to_string(), json!(normalized_reason));
 
     for (key, value) in properties {
         details.insert(key, value);
@@ -367,7 +436,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 }
                 other => {
                     let reason = other.to_string();
-                    let code = classify_eval_error(&reason, "CdpError", &Map::new());
+                    let code = classify_eval_error(
+                        &reason,
+                        "CdpError",
+                        &Map::new(),
+                        &cmd.expression,
+                        &pre_origin,
+                    );
                     build_eval_error_result(
                         code,
                         reason,
@@ -409,7 +484,8 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             } else {
                 Map::new()
             };
-            let code = classify_eval_error(emsg, &error_type, &properties);
+            let code =
+                classify_eval_error(emsg, &error_type, &properties, &cmd.expression, &pre_origin);
             let reason = string_property(&properties, "reason")
                 .unwrap_or(emsg)
                 .to_string();
@@ -481,7 +557,11 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{BODY_HEAD_LIMIT_CHARS, EvalErrorCode, classify_eval_error, truncate_body_head};
+    use super::{
+        BODY_HEAD_LIMIT_CHARS, EvalErrorCode, EvalFailureContext, build_eval_error_result,
+        classify_eval_error, truncate_body_head,
+    };
+    use crate::action_result::ActionResult;
     use serde_json::{Map, json};
 
     #[test]
@@ -524,7 +604,13 @@ mod tests {
         properties.insert("code".to_string(), json!("EVAL_RESPONSE_NOT_JSON"));
 
         assert_eq!(
-            classify_eval_error("ignored", "Object", &properties),
+            classify_eval_error(
+                "ignored",
+                "Object",
+                &properties,
+                "1 + 1",
+                "https://example.com"
+            ),
             EvalErrorCode::ResponseNotJson
         );
     }
@@ -532,12 +618,69 @@ mod tests {
     #[test]
     fn classify_eval_error_detects_cross_origin_fallbacks() {
         assert_eq!(
-            classify_eval_error("TypeError: Failed to fetch", "TypeError", &Map::new()),
+            classify_eval_error(
+                "TypeError: Failed to fetch",
+                "TypeError",
+                &Map::new(),
+                r#"fetch("http://127.0.0.1:8080/api/data")"#,
+                "https://example.com",
+            ),
             EvalErrorCode::CrossOrigin
         );
         assert_eq!(
-            classify_eval_error("SecurityError: Blocked", "DOMException", &Map::new()),
+            classify_eval_error(
+                "SecurityError: Blocked",
+                "DOMException",
+                &Map::new(),
+                "document.cookie",
+                "https://example.com",
+            ),
             EvalErrorCode::CrossOrigin
         );
+    }
+
+    #[test]
+    fn classify_eval_error_does_not_promote_generic_failed_fetch_without_cross_origin_target() {
+        assert_eq!(
+            classify_eval_error(
+                "TypeError: Failed to fetch",
+                "TypeError",
+                &Map::new(),
+                r#"fetch("/api/data")"#,
+                "https://example.com",
+            ),
+            EvalErrorCode::RuntimeError
+        );
+    }
+
+    #[test]
+    fn build_eval_error_result_normalizes_reason_to_string() {
+        let mut properties = Map::new();
+        properties.insert("reason".to_string(), json!({ "kind": "bad-shape" }));
+
+        let result = build_eval_error_result(
+            EvalErrorCode::RuntimeError,
+            "fallback".to_string(),
+            None,
+            EvalFailureContext {
+                pre_url: "about:blank",
+                pre_origin: "null",
+                pre_ready_state: "complete",
+                error_type: "Object",
+            },
+            properties,
+        );
+
+        let ActionResult::Fatal {
+            message,
+            details: Some(serde_json::Value::Object(details)),
+            ..
+        } = result
+        else {
+            panic!("expected fatal result with details");
+        };
+
+        assert_eq!(message, r#"{"kind":"bad-shape"}"#);
+        assert_eq!(details["reason"], json!(r#"{"kind":"bad-shape"}"#));
     }
 }

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -1,13 +1,239 @@
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use serde_json::{Map, Value};
 
 use crate::action_result::ActionResult;
 use crate::browser::navigation;
 use crate::browser::observation::logs_console::ENSURE_LOG_CAPTURE_JS;
-use crate::daemon::cdp_session::get_cdp_and_target;
+use crate::daemon::cdp_session::{CdpSession, cdp_error_to_result, get_cdp_and_target};
 use crate::daemon::registry::SharedRegistry;
+use crate::error::CliError;
 use crate::output::ResponseContext;
+
+#[cfg_attr(not(test), allow(dead_code))]
+const BODY_HEAD_LIMIT_CHARS: usize = 256;
+
+#[cfg_attr(not(test), allow(dead_code))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EvalErrorCode {
+    RuntimeError,
+    CrossOrigin,
+    ResponseNotJson,
+    ResponseNotOk,
+    Timeout,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl EvalErrorCode {
+    fn from_wire_code(raw: &str) -> Option<Self> {
+        match raw {
+            "EVAL_RUNTIME_ERROR" | "RUNTIME_ERROR" => Some(EvalErrorCode::RuntimeError),
+            "EVAL_CROSS_ORIGIN" | "CROSS_ORIGIN" => Some(EvalErrorCode::CrossOrigin),
+            "EVAL_RESPONSE_NOT_JSON" | "RESPONSE_NOT_JSON" => Some(EvalErrorCode::ResponseNotJson),
+            "EVAL_RESPONSE_NOT_OK" | "RESPONSE_NOT_OK" => Some(EvalErrorCode::ResponseNotOk),
+            "EVAL_TIMEOUT" | "TIMEOUT" => Some(EvalErrorCode::Timeout),
+            _ => None,
+        }
+    }
+
+    fn code(self) -> &'static str {
+        match self {
+            EvalErrorCode::RuntimeError => "EVAL_RUNTIME_ERROR",
+            EvalErrorCode::CrossOrigin => "EVAL_CROSS_ORIGIN",
+            EvalErrorCode::ResponseNotJson => "EVAL_RESPONSE_NOT_JSON",
+            EvalErrorCode::ResponseNotOk => "EVAL_RESPONSE_NOT_OK",
+            EvalErrorCode::Timeout => "EVAL_TIMEOUT",
+        }
+    }
+
+    fn default_hint(self) -> &'static str {
+        match self {
+            EvalErrorCode::RuntimeError => {
+                "Inspect the expression and referenced variables before retrying"
+            }
+            EvalErrorCode::CrossOrigin => "Use same-origin fetch or proxy the request server-side",
+            EvalErrorCode::ResponseNotJson => "Check content-type before parsing JSON",
+            EvalErrorCode::ResponseNotOk => "Handle non-2xx responses before decoding the body",
+            EvalErrorCode::Timeout => "Reduce work or raise --timeout",
+        }
+    }
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn truncate_body_head(text: &str) -> String {
+    text.chars().take(BODY_HEAD_LIMIT_CHARS).collect()
+}
+
+fn string_property<'a>(properties: &'a Map<String, Value>, key: &str) -> Option<&'a str> {
+    properties.get(key).and_then(|value| value.as_str())
+}
+
+fn normalize_detail_key(name: &str) -> String {
+    match name {
+        "contentType" => "content_type".to_string(),
+        "bodyHead" => "body_head".to_string(),
+        other => other.to_string(),
+    }
+}
+
+fn remote_object_to_json(remote: &Value) -> Value {
+    if let Some(value) = remote.get("value") {
+        return value.clone();
+    }
+    if let Some(value) = remote
+        .get("unserializableValue")
+        .and_then(|value| value.as_str())
+    {
+        return Value::String(value.to_string());
+    }
+    if let Some(value) = remote.get("description").and_then(|value| value.as_str()) {
+        return Value::String(value.to_string());
+    }
+    Value::Null
+}
+
+async fn read_exception_properties(
+    cdp: &CdpSession,
+    target_id: &str,
+    object_id: &str,
+) -> Map<String, Value> {
+    let Ok(resp) = cdp
+        .execute_on_tab(
+            target_id,
+            "Runtime.getProperties",
+            json!({
+                "objectId": object_id,
+                "ownProperties": true,
+            }),
+        )
+        .await
+    else {
+        return Map::new();
+    };
+
+    let mut properties = Map::new();
+    let Some(entries) = resp
+        .pointer("/result/result")
+        .and_then(|value| value.as_array())
+    else {
+        return properties;
+    };
+
+    for entry in entries {
+        let Some(name) = entry.get("name").and_then(|value| value.as_str()) else {
+            continue;
+        };
+        if entry.get("get").is_some() || entry.get("set").is_some() {
+            continue;
+        }
+        let Some(remote_value) = entry.get("value") else {
+            continue;
+        };
+        properties.insert(
+            normalize_detail_key(name),
+            remote_object_to_json(remote_value),
+        );
+    }
+
+    properties
+}
+
+fn classify_eval_error(
+    description: &str,
+    error_type: &str,
+    properties: &Map<String, Value>,
+) -> EvalErrorCode {
+    if let Some(code) = string_property(properties, "code").and_then(EvalErrorCode::from_wire_code)
+    {
+        return code;
+    }
+
+    let mut haystack = String::new();
+    haystack.push_str(description);
+    haystack.push(' ');
+    haystack.push_str(error_type);
+    if let Some(reason) = string_property(properties, "reason") {
+        haystack.push(' ');
+        haystack.push_str(reason);
+    }
+    if let Some(message) = string_property(properties, "message") {
+        haystack.push(' ');
+        haystack.push_str(message);
+    }
+    let haystack = haystack.to_ascii_lowercase();
+
+    if haystack.contains("failed to fetch")
+        || haystack.contains("securityerror")
+        || haystack.contains("cross-origin")
+        || haystack.contains("cross origin")
+        || haystack.contains("same origin policy")
+        || haystack.contains("blocked a frame with origin")
+        || haystack.contains("content security policy")
+    {
+        EvalErrorCode::CrossOrigin
+    } else {
+        EvalErrorCode::RuntimeError
+    }
+}
+
+struct EvalFailureContext<'a> {
+    pre_url: &'a str,
+    pre_origin: &'a str,
+    pre_ready_state: &'a str,
+    error_type: &'a str,
+}
+
+fn build_eval_error_result(
+    code: EvalErrorCode,
+    reason: String,
+    hint: Option<String>,
+    context: EvalFailureContext<'_>,
+    mut properties: Map<String, Value>,
+) -> ActionResult {
+    properties.remove("code");
+    properties.remove("hint");
+
+    let body_head = string_property(&properties, "body_head").map(truncate_body_head);
+    let message = properties
+        .get("reason")
+        .and_then(|value| value.as_str())
+        .unwrap_or(&reason)
+        .to_string();
+    let hint = hint.unwrap_or_else(|| code.default_hint().to_string());
+
+    let mut details = Map::new();
+    details.insert("stage".to_string(), json!("eval"));
+    details.insert("pre_url".to_string(), json!(context.pre_url));
+    details.insert("pre_origin".to_string(), json!(context.pre_origin));
+    details.insert("pre_readyState".to_string(), json!(context.pre_ready_state));
+    details.insert("error_type".to_string(), json!(context.error_type));
+    details.insert("reason".to_string(), json!(reason));
+
+    for (key, value) in properties {
+        details.insert(key, value);
+    }
+
+    if let Some(body_head) = body_head {
+        details.insert("body_head".to_string(), json!(body_head));
+    }
+
+    ActionResult::fatal_with_details(code.code(), message, hint, Value::Object(details))
+}
+
+fn eval_timeout_result(timeout_ms: u64) -> ActionResult {
+    let reason = format!("browser eval timed out after {timeout_ms}ms");
+    ActionResult::fatal_with_details(
+        EvalErrorCode::Timeout.code(),
+        reason.clone(),
+        EvalErrorCode::Timeout.default_hint(),
+        json!({ "reason": reason }),
+    )
+}
+
+pub fn timeout_result(timeout_ms: u64) -> ActionResult {
+    eval_timeout_result(timeout_ms)
+}
 
 /// Evaluate JavaScript
 #[derive(Args, Debug, Clone, Serialize, Deserialize)]
@@ -134,14 +360,28 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     {
         Ok(v) => v,
         Err(e) => {
-            let details = json!({
-                "stage": "eval",
-                "pre_url": pre_url,
-                "pre_origin": pre_origin,
-                "pre_readyState": pre_ready_state,
-                "error_type": "CdpError",
-            });
-            return ActionResult::fatal_with_details("EVAL_FAILED", e.to_string(), "", details);
+            return match e {
+                CliError::Timeout => eval_timeout_result(60_000),
+                CliError::CloudConnectionLost(_) | CliError::SessionClosed(_) => {
+                    cdp_error_to_result(e, EvalErrorCode::RuntimeError.code())
+                }
+                other => {
+                    let reason = other.to_string();
+                    let code = classify_eval_error(&reason, "CdpError", &Map::new());
+                    build_eval_error_result(
+                        code,
+                        reason,
+                        None,
+                        EvalFailureContext {
+                            pre_url: &pre_url,
+                            pre_origin: &pre_origin,
+                            pre_ready_state: &pre_ready_state,
+                            error_type: "CdpError",
+                        },
+                        Map::new(),
+                    )
+                }
+            };
         }
     };
 
@@ -161,15 +401,32 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 .unwrap_or("Error")
                 .to_string();
 
-            let details = json!({
-                "stage": "eval",
-                "pre_url": pre_url,
-                "pre_origin": pre_origin,
-                "pre_readyState": pre_ready_state,
-                "error_type": error_type,
-            });
+            let properties = if let Some(object_id) = exc
+                .pointer("/exception/objectId")
+                .and_then(|value| value.as_str())
+            {
+                read_exception_properties(&cdp, &target_id, object_id).await
+            } else {
+                Map::new()
+            };
+            let code = classify_eval_error(emsg, &error_type, &properties);
+            let reason = string_property(&properties, "reason")
+                .unwrap_or(emsg)
+                .to_string();
+            let hint = string_property(&properties, "hint").map(ToOwned::to_owned);
 
-            return ActionResult::fatal_with_details("EVAL_FAILED", emsg.to_string(), "", details);
+            return build_eval_error_result(
+                code,
+                reason,
+                hint,
+                EvalFailureContext {
+                    pre_url: &pre_url,
+                    pre_origin: &pre_origin,
+                    pre_ready_state: &pre_ready_state,
+                    error_type: &error_type,
+                },
+                properties,
+            );
         }
 
         let js_type = result
@@ -207,13 +464,80 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             "post_title": post_title,
         }))
     } else {
-        let details = json!({
-            "stage": "eval",
-            "pre_url": pre_url,
-            "pre_origin": pre_origin,
-            "pre_readyState": pre_ready_state,
-            "error_type": "CdpError",
-        });
-        ActionResult::fatal_with_details("EVAL_FAILED", "no result in CDP response", "", details)
+        build_eval_error_result(
+            EvalErrorCode::RuntimeError,
+            "no result in CDP response".to_string(),
+            None,
+            EvalFailureContext {
+                pre_url: &pre_url,
+                pre_origin: &pre_origin,
+                pre_ready_state: &pre_ready_state,
+                error_type: "CdpError",
+            },
+            Map::new(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BODY_HEAD_LIMIT_CHARS, EvalErrorCode, classify_eval_error, truncate_body_head};
+    use serde_json::{Map, json};
+
+    #[test]
+    fn eval_error_code_mappings_are_stable() {
+        assert_eq!(EvalErrorCode::RuntimeError.code(), "EVAL_RUNTIME_ERROR");
+        assert_eq!(EvalErrorCode::CrossOrigin.code(), "EVAL_CROSS_ORIGIN");
+        assert_eq!(
+            EvalErrorCode::ResponseNotJson.code(),
+            "EVAL_RESPONSE_NOT_JSON"
+        );
+        assert_eq!(EvalErrorCode::ResponseNotOk.code(), "EVAL_RESPONSE_NOT_OK");
+        assert_eq!(EvalErrorCode::Timeout.code(), "EVAL_TIMEOUT");
+    }
+
+    #[test]
+    fn eval_error_default_hints_are_non_empty() {
+        let hints = [
+            EvalErrorCode::RuntimeError.default_hint(),
+            EvalErrorCode::CrossOrigin.default_hint(),
+            EvalErrorCode::ResponseNotJson.default_hint(),
+            EvalErrorCode::ResponseNotOk.default_hint(),
+            EvalErrorCode::Timeout.default_hint(),
+        ];
+
+        assert!(hints.iter().all(|hint| !hint.is_empty()));
+    }
+
+    #[test]
+    fn truncate_body_head_respects_char_boundary() {
+        let input = "中".repeat(BODY_HEAD_LIMIT_CHARS + 8);
+        let truncated = truncate_body_head(&input);
+
+        assert_eq!(truncated.chars().count(), BODY_HEAD_LIMIT_CHARS);
+        assert!(truncated.chars().all(|ch| ch == '中'));
+    }
+
+    #[test]
+    fn classify_eval_error_uses_wire_code_first() {
+        let mut properties = Map::new();
+        properties.insert("code".to_string(), json!("EVAL_RESPONSE_NOT_JSON"));
+
+        assert_eq!(
+            classify_eval_error("ignored", "Object", &properties),
+            EvalErrorCode::ResponseNotJson
+        );
+    }
+
+    #[test]
+    fn classify_eval_error_detects_cross_origin_fallbacks() {
+        assert_eq!(
+            classify_eval_error("TypeError: Failed to fetch", "TypeError", &Map::new()),
+            EvalErrorCode::CrossOrigin
+        );
+        assert_eq!(
+            classify_eval_error("SecurityError: Blocked", "DOMException", &Map::new()),
+            EvalErrorCode::CrossOrigin
+        );
     }
 }

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -1152,6 +1152,24 @@ mod tests {
     }
 
     #[test]
+    fn try_parse_from_accepts_browser_eval_timeout_flag() {
+        let cli = Cli::try_parse_from([
+            "actionbook",
+            "browser",
+            "eval",
+            "await Promise.resolve(1)",
+            "--session",
+            "session-1",
+            "--tab",
+            "tab-1",
+            "--timeout",
+            "250",
+        ]);
+
+        assert!(cli.is_ok(), "browser eval should accept --timeout");
+    }
+
+    #[test]
     fn try_parse_from_accepts_browser_mouse_move_command() {
         let cli = Cli::try_parse_from([
             "actionbook",

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -6,6 +6,7 @@ use serde_json::json;
 
 use actionbook_cli::action::Action;
 use actionbook_cli::action_result::ActionResult;
+use actionbook_cli::browser::interaction;
 use actionbook_cli::cli::{BrowserCommands, Cli, Commands, DaemonCommands, ExtensionCommands};
 use actionbook_cli::config;
 use actionbook_cli::output::{self, JsonEnvelope};
@@ -280,11 +281,15 @@ async fn handle_browser(
         match tokio::time::timeout(Duration::from_millis(timeout_ms), execution).await {
             Ok(result) => result?,
             Err(_) => {
-                let result = ActionResult::fatal_with_hint(
-                    "TIMEOUT",
-                    format!("{command_name} timed out after {timeout_ms}ms"),
-                    "increase --timeout or retry the command",
-                );
+                let result = if command_name == interaction::eval::COMMAND_NAME {
+                    interaction::eval::timeout_result(timeout_ms)
+                } else {
+                    ActionResult::fatal_with_hint(
+                        "TIMEOUT",
+                        format!("{command_name} timed out after {timeout_ms}ms"),
+                        "increase --timeout or retry the command",
+                    )
+                };
                 let duration = start.elapsed();
                 let context = command.context(&result);
                 if json_mode {

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -711,9 +711,31 @@ setTimeout(() => {{
         return;
     }
 
+    if path == "/api/eval-json-403" {
+        let body = r#"{"error":"forbidden","provider":"fixture"}"#;
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Type: application/json; charset=utf-8\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
+        return;
+    }
+
     if path == "/api/fail-reset" {
         // Drop the TCP connection without sending an HTTP response so the browser
         // reports a network failure (`loadingFailed`) instead of a completed response.
+        return;
+    }
+
+    if path == "/api/eval-html-403" {
+        let body = "<!DOCTYPE html><html><head><title>Denied</title></head><body><h1>Access denied</h1><p>challenge</p></body></html>";
+        let response = format!(
+            "HTTP/1.1 403 Forbidden\r\nContent-Type: text/html; charset=utf-8\r\nCache-Control: no-store\r\nConnection: close\r\nContent-Length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let _ = stream.write_all(response.as_bytes());
         return;
     }
 

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -1152,11 +1152,6 @@ pub fn api_base_url() -> String {
 }
 
 /// URL for page A (primary test page).
-pub fn api_base_url() -> String {
-    format!("http://127.0.0.1:{}", local_server().port)
-}
-
-/// URL for page A (primary test page).
 pub fn url_a() -> String {
     format!("http://127.0.0.1:{}/page-a", local_server().port)
 }

--- a/packages/cli/tests/e2e/harness.rs
+++ b/packages/cli/tests/e2e/harness.rs
@@ -1152,6 +1152,11 @@ pub fn api_base_url() -> String {
 }
 
 /// URL for page A (primary test page).
+pub fn api_base_url() -> String {
+    format!("http://127.0.0.1:{}", local_server().port)
+}
+
+/// URL for page A (primary test page).
 pub fn url_a() -> String {
     format!("http://127.0.0.1:{}/page-a", local_server().port)
 }

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -6,8 +6,8 @@
 //! per api-reference.md §11.
 
 use crate::harness::{
-    SessionGuard, assert_failure, assert_success, headless, headless_json, parse_json, skip,
-    stderr_str, stdout_str, unique_session, wait_page_ready,
+    SessionGuard, api_base_url, assert_failure, assert_success, headless, headless_json,
+    parse_json, skip, stderr_str, stdout_str, unique_session, wait_page_ready,
 };
 
 const TEST_URL: &str = "https://example.com";
@@ -581,6 +581,15 @@ fn eval_failure_json_with_flags(
 fn eval_value(session_id: &str, tab_id: &str, expression: &str) -> String {
     let v = eval_json_with_flags(session_id, tab_id, expression, &[]);
     v["data"]["value"].as_str().unwrap_or("").to_string()
+}
+
+fn assert_browser_eval_structured_failure(v: &serde_json::Value, expected_code: &str) {
+    assert_eq!(v["command"], "browser eval");
+    assert_error_envelope(v, expected_code);
+    assert!(
+        v["error"]["details"]["reason"].is_string(),
+        "structured eval failures must expose details.reason"
+    );
 }
 
 fn install_click_fixture(session_id: &str, tab_id: &str) {
@@ -5853,6 +5862,221 @@ fn eval_async_trailing_line_comment() {
         v["data"]["value"],
         serde_json::json!(1),
         "async expression with trailing line comment should resolve to 1"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_runtime_error_reference_error_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "(() => { throw new ReferenceError('x'); })()",
+        &[],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_RUNTIME_ERROR");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("ReferenceError"),
+        "reason must preserve the runtime error class"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_runtime_error_type_error_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "(() => { let x = null; return x.map(() => 1); })()",
+        &[],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_RUNTIME_ERROR");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("TypeError"),
+        "reason must preserve the runtime type error"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_cross_origin_fetch_failure_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session(TEST_URL);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  try {{
+    await fetch("{}/api/data?source=cors").then(r => r.json());
+    return "unexpected-success";
+  }} catch (e) {{
+    throw {{
+      code: "EVAL_CROSS_ORIGIN",
+      reason: String(e),
+      hint: "Use same-origin fetch or proxy the request server-side"
+    }};
+  }}
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_CROSS_ORIGIN");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("fetch"),
+        "reason must preserve the blocked fetch details"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_non_json_html_response_is_guarded() {
+    if skip() {
+        return;
+    }
+    let local_page = format!("{}/page-a", api_base_url());
+    let (sid, tid) = start_session(&local_page);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  const response = await fetch("{}/api/eval-html-403");
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  if (!contentType.includes("application/json")) {{
+    throw {{
+      code: "EVAL_RESPONSE_NOT_JSON",
+      reason: "Expected JSON but got " + contentType,
+      hint: "Check response.headers.get('content-type') before parsing JSON",
+      status: response.status,
+      content_type: contentType,
+      body_head: body.slice(0, 64)
+    }};
+  }}
+  return JSON.parse(body);
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_RESPONSE_NOT_JSON");
+    assert_eq!(v["error"]["details"]["status"], 403);
+    assert!(
+        v["error"]["details"]["content_type"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("text/html"),
+        "content_type must preserve the HTML response type"
+    );
+    assert!(
+        v["error"]["details"]["body_head"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("<!DOCTYPE html>"),
+        "body_head must capture the leading HTML body snippet"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_non_ok_json_response_is_guarded() {
+    if skip() {
+        return;
+    }
+    let local_page = format!("{}/page-a", api_base_url());
+    let (sid, tid) = start_session(&local_page);
+    let _guard = SessionGuard::new(&sid);
+
+    let expression = format!(
+        r#"(async () => {{
+  const response = await fetch("{}/api/eval-json-403");
+  const contentType = response.headers.get("content-type") || "";
+  const body = await response.text();
+  if (!response.ok) {{
+    throw {{
+      code: "EVAL_RESPONSE_NOT_OK",
+      reason: "HTTP " + response.status,
+      hint: "Handle non-2xx fetch responses before decoding the body",
+      status: response.status,
+      content_type: contentType,
+      body_head: body.slice(0, 64)
+    }};
+  }}
+  return JSON.parse(body);
+}})()"#,
+        api_base_url()
+    );
+
+    let v = eval_failure_json_with_flags(&sid, &tid, &expression, &[]);
+    assert_browser_eval_structured_failure(&v, "EVAL_RESPONSE_NOT_OK");
+    assert_eq!(v["error"]["details"]["status"], 403);
+    assert!(
+        v["error"]["details"]["content_type"]
+            .as_str()
+            .unwrap_or("")
+            .starts_with("application/json"),
+        "content_type must preserve the JSON response type"
+    );
+    assert!(
+        v["error"]["details"]["body_head"]
+            .as_str()
+            .unwrap_or("")
+            .contains("forbidden"),
+        "body_head must capture the leading response body"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_timeout_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        "await new Promise(() => {})",
+        &["--timeout", "100"],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_TIMEOUT");
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .unwrap_or("")
+            .contains("timed out"),
+        "timeout reason must preserve the timeout failure"
     );
 
     close_session(&sid);

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -587,8 +587,16 @@ fn assert_browser_eval_structured_failure(v: &serde_json::Value, expected_code: 
     assert_eq!(v["command"], "browser eval");
     assert_error_envelope(v, expected_code);
     assert!(
-        v["error"]["details"]["reason"].is_string(),
-        "structured eval failures must expose details.reason"
+        v["error"]["hint"]
+            .as_str()
+            .is_some_and(|hint| !hint.is_empty()),
+        "structured eval failures must expose a non-empty error.hint"
+    );
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .is_some_and(|reason| !reason.is_empty()),
+        "structured eval failures must expose a non-empty details.reason"
     );
 }
 
@@ -5574,7 +5582,7 @@ fn eval_exception_json() {
     assert!(v["context"].is_object(), "context must be present on error");
     assert_eq!(v["context"]["session_id"], sid);
     assert_eq!(v["context"]["tab_id"], tid);
-    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_error_envelope(&v, "EVAL_RUNTIME_ERROR");
     assert!(
         v["error"]["message"]
             .as_str()
@@ -5618,8 +5626,8 @@ fn eval_exception_text() {
         "header must contain [session_id tab_id]: got {text}"
     );
     assert!(
-        text.contains("error EVAL_FAILED:"),
-        "text must contain error EVAL_FAILED: got {text}"
+        text.contains("error EVAL_RUNTIME_ERROR:"),
+        "text must contain error EVAL_RUNTIME_ERROR: got {text}"
     );
 
     close_session(&sid);
@@ -5709,7 +5717,7 @@ fn eval_no_isolate_flag() {
 
     let third = eval_failure_json_with_flags(&sid, &tid, "let x = 1", &["--no-isolate"]);
     assert_eq!(third["command"], "browser eval");
-    assert_error_envelope(&third, "EVAL_FAILED");
+    assert_error_envelope(&third, "EVAL_RUNTIME_ERROR");
     assert!(
         third["error"]["message"]
             .as_str()
@@ -5776,7 +5784,7 @@ fn eval_error_details_syntax() {
 
     let v = eval_failure_json_with_flags(&sid, &tid, "{{{invalid", &[]);
     assert_eq!(v["command"], "browser eval");
-    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_error_envelope(&v, "EVAL_RUNTIME_ERROR");
     assert_eq!(v["error"]["details"]["stage"], "eval");
     assert_eq!(v["error"]["details"]["pre_url"], "about:blank");
     assert_eq!(v["error"]["details"]["pre_origin"], "null");
@@ -5802,7 +5810,7 @@ fn eval_error_details_runtime() {
 
     let v = eval_failure_json_with_flags(&sid, &tid, "nonExistentVariable.foo", &[]);
     assert_eq!(v["command"], "browser eval");
-    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_error_envelope(&v, "EVAL_RUNTIME_ERROR");
     assert_eq!(v["error"]["details"]["stage"], "eval");
     assert!(
         v["error"]["details"]["pre_url"]
@@ -5830,7 +5838,7 @@ fn eval_error_details_has_context() {
 
     let v = eval_failure_json_with_flags(&sid, &tid, "{{{invalid", &[]);
     assert_eq!(v["command"], "browser eval");
-    assert_error_envelope(&v, "EVAL_FAILED");
+    assert_error_envelope(&v, "EVAL_RUNTIME_ERROR");
     assert!(
         v["error"]["details"]["pre_url"]
             .as_str()
@@ -5934,9 +5942,7 @@ fn browser_eval_cross_origin_fetch_failure_is_structured() {
     return "unexpected-success";
   }} catch (e) {{
     throw {{
-      code: "EVAL_CROSS_ORIGIN",
-      reason: String(e),
-      hint: "Use same-origin fetch or proxy the request server-side"
+      reason: String(e)
     }};
   }}
 }})()"#,
@@ -5952,6 +5958,38 @@ fn browser_eval_cross_origin_fetch_failure_is_structured() {
             .contains("fetch"),
         "reason must preserve the blocked fetch details"
     );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_body_head_is_truncated_at_utf8_boundary() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_failure_json_with_flags(
+        &sid,
+        &tid,
+        r#"(() => {
+  throw {
+    code: "EVAL_RESPONSE_NOT_JSON",
+    reason: "Expected JSON but got text/plain; charset=utf-8",
+    status: 200,
+    content_type: "text/plain; charset=utf-8",
+    body_head: "中".repeat(300)
+  };
+})()"#,
+        &[],
+    );
+    assert_browser_eval_structured_failure(&v, "EVAL_RESPONSE_NOT_JSON");
+    let body_head = v["error"]["details"]["body_head"]
+        .as_str()
+        .expect("body_head must be a string");
+    assert_eq!(body_head.chars().count(), 256);
+    assert!(body_head.chars().all(|ch| ch == '中'));
 
     close_session(&sid);
 }


### PR DESCRIPTION
## Background
- ACT-967 requires `browser eval` to return structured errors on runtime failures instead of collapsing everything into `EVAL_FAILED`
- ACT-973 requires the `status` / `content_type` / `body_head` fields thrown by the fetch guard on the JS side to be stably passed through the existing envelope
- Legacy `interaction` e2e still asserts `EVAL_FAILED`, which conflicts with the new error contract

## Changes
- Introduce `EvalErrorCode` in `packages/cli/src/browser/interaction/eval.rs`, covering `RuntimeError` / `CrossOrigin` / `ResponseNotJson` / `ResponseNotOk` / `Timeout`
- Failure path reads the thrown object via `Runtime.getProperties` and funnels structured fields into the existing envelope's `error.details`
- Wire a dedicated timeout result for `browser eval` so `--timeout` honors millisecond semantics and returns `EVAL_TIMEOUT`
- Add CLI-side cross-origin fallback so cross-origin failures surface as `EVAL_CROSS_ORIGIN` instead of raw CDP errors
- Upgrade legacy `interaction` e2e assertions from `EVAL_FAILED` to the new `EvalErrorCode`
- Add `body_head` 256-char UTF-8 boundary smoke test to validate truncation at the e2e layer

## Envelope contract
\`\`\`json
{
  "ok": false,
  "data": null,
  "error": {
    "code": "EVAL_*",
    "message": "<string>",
    "retryable": false,
    "hint": "<string>",
    "details": {
      "reason": "<string>",
      "status": "<optional>",
      "content_type": "<optional>",
      "body_head": "<optional, <=256 chars>"
    }
  }
}
\`\`\`

## Verification
- `cargo test --manifest-path packages/cli/Cargo.toml browser::interaction::eval::tests -- --nocapture`
- `RUN_E2E_TESTS=true cargo test --manifest-path packages/cli/Cargo.toml --test e2e eval_ -- --nocapture --test-threads=1`
- `cargo clippy --manifest-path packages/cli/Cargo.toml --all-targets -- -D warnings`

## Impact
- `browser eval` failures keep the existing envelope, but `error.code` / `error.hint` / `error.details` now carry structured classification info
- Callers can branch directly on `EVAL_RUNTIME_ERROR` / `EVAL_CROSS_ORIGIN` / `EVAL_RESPONSE_NOT_JSON` / `EVAL_RESPONSE_NOT_OK` / `EVAL_TIMEOUT`