### PR TITLE
docs(wait network-idle): update to edge-triggered semantics

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -278,7 +278,7 @@ actionbook browser wait condition "document.readyState === 'complete'" --session
 Default timeout: 30000ms. Override with `--timeout <ms>`.
 
 <Note>
-  `wait network-idle` automatically falls back from **strict** (zero in-flight requests for 500ms) to **relaxed** mode on pages with persistent background traffic. Relaxed mode requires fewer than 5 new requests in a 10s window with ≤5 pending, sustained for 3s. The response includes `mode` ("strict" or "relaxed") so callers know which condition was met.
+  `wait network-idle` is edge-triggered: it only tracks fetch/XHR requests started after the command begins. Pre-existing background connections (SSE, WebSocket, in-flight fetches) are ignored and do not block. This is an agent-friendly settle signal, not a guarantee of global network silence.
 </Note>
 
 ### Logs & Network

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -264,7 +264,7 @@ actionbook browser wait condition "document.readyState === 'complete'" --session
 ```
 
 <Tip>
-  `wait network-idle` automatically falls back to **relaxed** mode on pages with persistent background traffic (analytics pings, health-checks). Relaxed mode tolerates low-rate background requests instead of requiring absolute silence. The response includes `mode` ("strict" or "relaxed").
+  `wait network-idle` is edge-triggered: it only tracks fetch/XHR requests started after the command begins. Pre-existing background connections (SSE, WebSocket, analytics pings) are ignored and do not block. This is an agent-friendly settle signal, not a guarantee of global network silence.
 </Tip>
 
 ### Observation & Export

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -277,7 +277,7 @@ actionbook browser wait condition "document.readyState === 'complete'" --session
 
 Default timeout for all wait commands: 30000ms. Override with `--timeout <ms>`.
 
-`wait network-idle` uses two modes automatically. **Strict**: zero in-flight requests for 500ms. **Relaxed** (fallback): when pages have persistent background traffic (analytics pings, health-checks), relaxed mode kicks in — requires fewer than 5 new requests in a 10s sliding window with ≤5 pending, sustained for 3s. The response includes `mode` ("strict" or "relaxed") so callers know which condition was satisfied.
+`wait network-idle` is edge-triggered: it only tracks fetch/XHR requests started after the command begins. Pre-existing background connections (SSE, WebSocket, in-flight fetches, analytics pings) are ignored and do not block. This is an agent-friendly settle signal, not a guarantee of global network silence.
 
 ## Cookies
 


### PR DESCRIPTION
## Summary
- Update `wait network-idle` documentation across all three doc surfaces (`docs/api-reference/cli.mdx`, `docs/guides/browser.mdx`, `skills/actionbook/references/command-reference.md`) to reflect the edge-triggered semantics merged in #558
- Replace old relaxed/strict mode descriptions with: "edge-triggered: only tracks fetch/XHR requests started after the command begins. Pre-existing background connections are ignored."
- Framing aligned with `main.rs` help text: "agent-friendly settle signal, not a guarantee of global network silence"

## Context
PR #558 changed `wait network-idle` from a level-triggered (relaxed/strict dual-mode) approach to edge-triggered semantics using `network_pending_since()` with `Instant::now()` filtering. The docs still described the old relaxed/strict behavior.

## Test plan
- [ ] Verify docs site renders correctly (Mintlify)
- [ ] Confirm language consistency across all three files
- [ ] Confirm alignment with `main.rs` after_help text in `network_idle.rs`