### PR TITLE
docs(eval): document structured EvalErrorCode error envelope

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -266,6 +266,17 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
   `eval` isolates `let`/`const` scope by default. Use `--no-isolate` for multi-statement async expressions or when you need shared scope across calls.
 </Tip>
 
+<Note>
+  On failure, `eval` returns a structured error envelope with `error.code` set to one of:
+  - `EVAL_RUNTIME_ERROR` — JS exception (ReferenceError, TypeError, etc.)
+  - `EVAL_CROSS_ORIGIN` — cross-origin fetch or SecurityError
+  - `EVAL_RESPONSE_NOT_JSON` — response Content-Type is not JSON
+  - `EVAL_RESPONSE_NOT_OK` — HTTP status is not 2xx
+  - `EVAL_TIMEOUT` — expression did not resolve within `--timeout`
+
+  Each error includes `error.hint` and `error.details` with diagnostic fields (`reason`, and for fetch errors: `status`, `content_type`, `body_head`). Read `error.code` to branch on the failure class instead of parsing the message string.
+</Note>
+
 ### Wait
 
 ```bash

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -275,7 +275,7 @@ actionbook browser snapshot --interactive --session s1 --tab t1     # only inter
 actionbook browser screenshot output.png --session s1 --tab t1
 actionbook browser screenshot output.png --full --session s1 --tab t1
 actionbook browser pdf report.pdf --session s1 --tab t1
-actionbook browser eval "document.title" --session s1 --tab t1
+actionbook browser eval "document.title" --session s1 --tab t1      # JS eval (structured errors)
 actionbook browser html --session s1 --tab t1
 actionbook browser text --session s1 --tab t1
 actionbook browser title --session s1 --tab t1
@@ -440,6 +440,22 @@ Extension mode connects via a local WebSocket bridge with the following guarante
 - No token or pairing is required; local origin is sufficient for authentication
 - The extension identifies itself via a WebSocket handshake with role and version fields
 - The bridge validates the connection source (origin + extension ID) before accepting commands
+
+## Eval Error Handling
+
+`browser eval` returns structured error codes on failure. Branch on `error.code` instead of parsing the message string:
+
+| Code | Meaning | Best practice |
+|------|---------|---------------|
+| `EVAL_RUNTIME_ERROR` | JS exception | Check expression syntax and referenced variables |
+| `EVAL_CROSS_ORIGIN` | Cross-origin or CSP block | Use same-origin fetch or proxy server-side |
+| `EVAL_RESPONSE_NOT_JSON` | Non-JSON response body | Read `error.details.content_type` and `body_head` before retrying |
+| `EVAL_RESPONSE_NOT_OK` | Non-2xx HTTP status | Read `error.details.status` and `body_head` to distinguish 403 / challenge / CORS |
+| `EVAL_TIMEOUT` | Expression exceeded `--timeout` | Reduce work or increase timeout |
+
+<Tip>
+  For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` (first ≤256 chars of the response body) to decide whether to retry — a 403 challenge page is not worth retrying blindly.
+</Tip>
 
 ## Troubleshooting
 

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -121,6 +121,15 @@ actionbook browser click @e7 --session s1 --tab t1
 actionbook browser wait navigation --session s1 --tab t1
 ```
 
+## Eval Error Handling
+
+`browser eval` returns structured error codes on failure — branch on `error.code` instead of parsing the message:
+
+- `EVAL_RUNTIME_ERROR` — JS exception. Inspect the expression before retrying.
+- `EVAL_CROSS_ORIGIN` — cross-origin fetch or CSP block. Proxy the request server-side.
+- `EVAL_RESPONSE_NOT_JSON` / `EVAL_RESPONSE_NOT_OK` — read `error.details.body_head` (first ≤256 chars of the response body) to distinguish 403 / challenge pages / CORS errors. Do not blindly retry.
+- `EVAL_TIMEOUT` — expression exceeded `--timeout`. Reduce work or raise the timeout.
+
 ## Selectors
 
 Selectors should come from `actionbook browser snapshot` — not from prior knowledge or memory. Always snapshot first to get current refs, then use those refs to interact with the page.

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -136,7 +136,19 @@ actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isol
 
 **eval scope isolation:** By default, `eval` wraps `let`/`const` declarations in an isolated scope so they don't leak across calls. Use `--no-isolate` to disable this — needed for multi-statement async expressions or when you want shared scope.
 
-**eval response fields:** Success includes `pre_url`, `pre_origin`, `pre_readyState` (page state before execution) and `post_url`, `post_title` (page state after). On failure, `details` contains `{stage, pre_url, pre_origin, pre_readyState, error_type}` for diagnostics.
+**eval response fields:** Success includes `pre_url`, `pre_origin`, `pre_readyState` (page state before execution) and `post_url`, `post_title` (page state after). On failure, `error.details` contains `{stage, pre_url, pre_origin, pre_readyState, error_type, reason}` plus optional `status`, `content_type`, and `body_head` (≤256 chars, UTF-8 boundary safe) for fetch-related errors.
+
+**eval error codes:** On failure, `error.code` is one of:
+
+| Code | When | Hint | `error.details` extras |
+|------|------|------|------------------------|
+| `EVAL_RUNTIME_ERROR` | JS exception (ReferenceError, TypeError, etc.) | Inspect the expression and referenced variables before retrying | `reason` |
+| `EVAL_CROSS_ORIGIN` | Cross-origin fetch or SecurityError | Use same-origin fetch or proxy the request server-side | `reason` |
+| `EVAL_RESPONSE_NOT_JSON` | `Content-Type` is not JSON when JSON was expected | Check content-type before parsing JSON | `reason`, `status`, `content_type`, `body_head` |
+| `EVAL_RESPONSE_NOT_OK` | HTTP status is not 2xx | Handle non-2xx responses before decoding the body | `reason`, `status`, `content_type`, `body_head` |
+| `EVAL_TIMEOUT` | Expression did not resolve within `--timeout` | Reduce work or raise --timeout | `reason` |
+
+Read `error.code` to branch on the failure class. For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` to distinguish 403 / challenge pages / CORS errors before deciding whether to retry.
 
 **fill vs type:** `fill` clears the field and sets the value directly (like pasting). `type` simulates individual keystrokes and appends to existing content.
 


### PR DESCRIPTION
## Summary

- Document the 5 structured `EvalErrorCode` variants (`EVAL_RUNTIME_ERROR`, `EVAL_CROSS_ORIGIN`, `EVAL_RESPONSE_NOT_JSON`, `EVAL_RESPONSE_NOT_OK`, `EVAL_TIMEOUT`) introduced in #573 (ACT-967/ACT-973)
- Update `error.details` field documentation to include `reason`, `status`, `content_type`, and `body_head` (≤256 chars, UTF-8 boundary safe)
- Add best-practice guidance: branch on `error.code`, inspect `body_head` for fetch errors before retrying

## Files changed

| File | What |
|------|------|
| `skills/actionbook/references/command-reference.md` | Full error code table with `When` / `Hint` / `details` extras columns |
| `docs/api-reference/cli.mdx` | Error code list + envelope description in Note block |
| `docs/guides/browser.mdx` | "Eval Error Handling" section with best-practice table + Tip |
| `skills/actionbook/SKILL.md` | Concise error handling guidance for agents |

## References

- Source: `packages/cli/src/browser/interaction/eval.rs` (`EvalErrorCode` enum, `default_hint()`, `BODY_HEAD_LIMIT_CHARS = 256`)
- PR: #573
- Linear: ACT-967, ACT-973

## Test plan

- [ ] Verify all 5 error codes match `EvalErrorCode::code()` in `eval.rs`
- [ ] Verify hints match `EvalErrorCode::default_hint()` in `eval.rs`
- [ ] Confirm `body_head` limit documented as ≤256 chars matches `BODY_HEAD_LIMIT_CHARS`
- [ ] Check docs site renders correctly (Note/Tip/table formatting)