### PR TITLE
feat(eval): support --file and stdin expression sources (ACT-975)

### DIFF
--- a/packages/cli/Cargo.lock
+++ b/packages/cli/Cargo.lock
@@ -17,6 +17,7 @@ dependencies = [
  "fs2",
  "futures-util",
  "indicatif",
+ "libc",
  "regex",
  "reqwest",
  "serde",

--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -76,6 +76,9 @@ serde_json = "1"
 tokio = { version = "1", features = ["test-util"] }
 wiremock = "0.6"
 
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"
+
 [[test]]
 name = "e2e"
 path = "tests/e2e/main.rs"

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -332,14 +332,28 @@ fn build_eval_args_error(code: EvalErrorCode, message: String, reason: &str) -> 
     )
 }
 
-fn build_file_not_found(path: &Path, io_reason: &str) -> ActionResult {
+/// Classify an `io::Error` from reading an eval script file into a bounded
+/// `details.reason` vocabulary. The wire code stays `EVAL_FILE_NOT_FOUND`
+/// for both missing and permission-denied paths because the remediation
+/// ("verify the path resolves and is readable") is identical across the
+/// sub-cases; the reason field carries the observability signal.
+fn io_kind_to_reason(kind: std::io::ErrorKind) -> &'static str {
+    match kind {
+        std::io::ErrorKind::NotFound => "not_found",
+        std::io::ErrorKind::PermissionDenied => "permission_denied",
+        std::io::ErrorKind::InvalidData => "invalid_data",
+        _ => "other",
+    }
+}
+
+fn build_file_unreadable(path: &Path, err: &std::io::Error) -> ActionResult {
     ActionResult::fatal_with_details(
         EvalErrorCode::FileNotFound.code(),
-        format!("eval script file not found: {}", path.display()),
+        format!("failed to read eval script file: {}", path.display()),
         EvalErrorCode::FileNotFound.default_hint(),
         json!({
             "stage": "eval",
-            "reason": io_reason,
+            "reason": io_kind_to_reason(err.kind()),
             "path": path.display().to_string(),
         }),
     )
@@ -350,9 +364,11 @@ fn build_file_not_found(path: &Path, io_reason: &str) -> ActionResult {
 /// All failure envelopes are arg-layer — no CDP round-trip has happened yet,
 /// so no pre-page context (pre_url, pre_origin, pre_readyState) is attached.
 ///
-/// Must be called on the CLI side before the command is forwarded to the
-/// daemon, because stdin and the file's relative path belong to the CLI
-/// process, not the daemon's.
+/// CLI pre-flight only. Must not be called on the daemon side: after the CLI
+/// has resolved stdin, `cmd.expression` can be `Some("-")` (the user piped a
+/// literal dash) and re-invoking this resolver would misclassify it as the
+/// stdin sentinel and read the daemon's own stdin. The daemon consumes
+/// `cmd.expression` directly.
 pub fn resolve_eval_source(cmd: &Cmd) -> Result<String, ActionResult> {
     let positional_is_stdin = matches!(cmd.expression.as_deref(), Some("-"));
     let has_stdin = positional_is_stdin;
@@ -407,8 +423,7 @@ pub fn resolve_eval_source(cmd: &Cmd) -> Result<String, ActionResult> {
     }
 
     if let Some(path) = &cmd.file {
-        return std::fs::read_to_string(path)
-            .map_err(|err| build_file_not_found(path, &err.to_string()));
+        return std::fs::read_to_string(path).map_err(|err| build_file_unreadable(path, &err));
     }
 
     match &cmd.expression {
@@ -496,9 +511,19 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
-    let source_expression = match resolve_eval_source(cmd) {
-        Ok(s) => s,
-        Err(err) => return err,
+    // cmd.expression has already been resolved on the CLI side (see
+    // `resolve_eval_source`). Do NOT re-invoke the resolver here — after
+    // resolution the expression can legitimately be the literal `-`, which
+    // the resolver would misread as the stdin sentinel.
+    let source_expression = match &cmd.expression {
+        Some(expr) => expr.clone(),
+        None => {
+            return build_eval_args_error(
+                EvalErrorCode::ArgsConflict,
+                "no eval input provided".to_string(),
+                "no_source",
+            );
+        }
     };
 
     let (cdp, target_id) = match get_cdp_and_target(registry, &cmd.session, &cmd.tab).await {

--- a/packages/cli/src/browser/interaction/eval.rs
+++ b/packages/cli/src/browser/interaction/eval.rs
@@ -1,3 +1,6 @@
+use std::io::{IsTerminal, Read};
+use std::path::{Path, PathBuf};
+
 use clap::Args;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -22,10 +25,16 @@ enum EvalErrorCode {
     ResponseNotJson,
     ResponseNotOk,
     Timeout,
+    ArgsConflict,
+    FileNotFound,
+    StdinTty,
+    StdinEmpty,
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
 impl EvalErrorCode {
+    // Client-layer codes (ArgsConflict, FileNotFound, StdinTty, StdinEmpty) are
+    // never emitted by CDP, so they are intentionally absent here.
     fn from_wire_code(raw: &str) -> Option<Self> {
         match raw {
             "EVAL_RUNTIME_ERROR" | "RUNTIME_ERROR" => Some(EvalErrorCode::RuntimeError),
@@ -44,6 +53,10 @@ impl EvalErrorCode {
             EvalErrorCode::ResponseNotJson => "EVAL_RESPONSE_NOT_JSON",
             EvalErrorCode::ResponseNotOk => "EVAL_RESPONSE_NOT_OK",
             EvalErrorCode::Timeout => "EVAL_TIMEOUT",
+            EvalErrorCode::ArgsConflict => "EVAL_ARGS_CONFLICT",
+            EvalErrorCode::FileNotFound => "EVAL_FILE_NOT_FOUND",
+            EvalErrorCode::StdinTty => "EVAL_STDIN_TTY",
+            EvalErrorCode::StdinEmpty => "EVAL_STDIN_EMPTY",
         }
     }
 
@@ -56,6 +69,16 @@ impl EvalErrorCode {
             EvalErrorCode::ResponseNotJson => "Check content-type before parsing JSON",
             EvalErrorCode::ResponseNotOk => "Handle non-2xx responses before decoding the body",
             EvalErrorCode::Timeout => "Reduce work or raise --timeout",
+            EvalErrorCode::ArgsConflict => {
+                "Provide exactly one of: positional expression, --file, or stdin (`-`)"
+            }
+            EvalErrorCode::FileNotFound => "Verify --file points to a readable script path",
+            EvalErrorCode::StdinTty => {
+                "Pipe the expression via stdin, e.g. echo 'expr' | actionbook browser eval -"
+            }
+            EvalErrorCode::StdinEmpty => {
+                "stdin was read but produced no expression; verify the upstream command or pipeline"
+            }
         }
     }
 }
@@ -300,6 +323,104 @@ fn eval_timeout_result(timeout_ms: u64) -> ActionResult {
     )
 }
 
+fn build_eval_args_error(code: EvalErrorCode, message: String, reason: &str) -> ActionResult {
+    ActionResult::fatal_with_details(
+        code.code(),
+        message,
+        code.default_hint(),
+        json!({ "stage": "eval", "reason": reason }),
+    )
+}
+
+fn build_file_not_found(path: &Path, io_reason: &str) -> ActionResult {
+    ActionResult::fatal_with_details(
+        EvalErrorCode::FileNotFound.code(),
+        format!("eval script file not found: {}", path.display()),
+        EvalErrorCode::FileNotFound.default_hint(),
+        json!({
+            "stage": "eval",
+            "reason": io_reason,
+            "path": path.display().to_string(),
+        }),
+    )
+}
+
+/// Resolve the eval expression from one of three mutually-exclusive sources:
+/// a positional expression, `--file <path>`, or stdin (positional `-`).
+/// All failure envelopes are arg-layer — no CDP round-trip has happened yet,
+/// so no pre-page context (pre_url, pre_origin, pre_readyState) is attached.
+///
+/// Must be called on the CLI side before the command is forwarded to the
+/// daemon, because stdin and the file's relative path belong to the CLI
+/// process, not the daemon's.
+pub fn resolve_eval_source(cmd: &Cmd) -> Result<String, ActionResult> {
+    let positional_is_stdin = matches!(cmd.expression.as_deref(), Some("-"));
+    let has_stdin = positional_is_stdin;
+    let has_inline = cmd.expression.is_some() && !positional_is_stdin;
+    let has_file = cmd.file.is_some();
+
+    let source_count = u8::from(has_inline) + u8::from(has_file) + u8::from(has_stdin);
+    if source_count > 1 {
+        let reason = match (has_inline, has_file, has_stdin) {
+            (true, true, false) => "positional+file",
+            (true, false, true) => "positional+stdin",
+            (false, true, true) => "file+stdin",
+            (true, true, true) => "positional+file+stdin",
+            _ => "multiple_sources",
+        };
+        return Err(build_eval_args_error(
+            EvalErrorCode::ArgsConflict,
+            "multiple eval input sources provided".to_string(),
+            reason,
+        ));
+    }
+
+    if has_stdin {
+        if std::io::stdin().is_terminal() {
+            return Err(build_eval_args_error(
+                EvalErrorCode::StdinTty,
+                "stdin is a terminal; no expression piped".to_string(),
+                "stdin_is_tty",
+            ));
+        }
+        let mut buf = String::new();
+        if let Err(err) = std::io::stdin().read_to_string(&mut buf) {
+            return Err(build_eval_args_error(
+                EvalErrorCode::StdinEmpty,
+                format!("failed to read stdin: {err}"),
+                "read_error",
+            ));
+        }
+        if buf.trim().is_empty() {
+            let reason = if buf.is_empty() {
+                "pipe_closed"
+            } else {
+                "whitespace_only"
+            };
+            return Err(build_eval_args_error(
+                EvalErrorCode::StdinEmpty,
+                "stdin expression is empty".to_string(),
+                reason,
+            ));
+        }
+        return Ok(buf);
+    }
+
+    if let Some(path) = &cmd.file {
+        return std::fs::read_to_string(path)
+            .map_err(|err| build_file_not_found(path, &err.to_string()));
+    }
+
+    match &cmd.expression {
+        Some(expr) => Ok(expr.clone()),
+        None => Err(build_eval_args_error(
+            EvalErrorCode::ArgsConflict,
+            "no eval input provided".to_string(),
+            "no_source",
+        )),
+    }
+}
+
 pub fn timeout_result(timeout_ms: u64) -> ActionResult {
     eval_timeout_result(timeout_ms)
 }
@@ -324,8 +445,12 @@ Note: Multi-statement expressions that contain 'await' (e.g.
 isolated mode — use --no-isolate or wrap the body in an explicit async arrow:
   actionbook browser eval \"(async () => { let x = await f(); return x + 1; })()\" ...")]
 pub struct Cmd {
-    /// JavaScript expression
-    pub expression: String,
+    /// JavaScript expression, or `-` to read the expression from stdin
+    pub expression: Option<String>,
+    /// Read the JavaScript expression from a file
+    #[arg(long)]
+    #[serde(default)]
+    pub file: Option<PathBuf>,
     /// Session ID
     #[arg(long)]
     #[serde(rename = "session_id")]
@@ -371,6 +496,11 @@ pub fn context(cmd: &Cmd, result: &ActionResult) -> Option<ResponseContext> {
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
+    let source_expression = match resolve_eval_source(cmd) {
+        Ok(s) => s,
+        Err(err) => return err,
+    };
+
     let (cdp, target_id) = match get_cdp_and_target(registry, &cmd.session, &cmd.tab).await {
         Ok(v) => v,
         Err(e) => return e,
@@ -405,16 +535,20 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     //
     // With --no-isolate, pass the expression directly (old behavior).
     let expression = if cmd.no_isolate {
-        cmd.expression.clone()
+        source_expression.clone()
     } else {
         // Detect top-level `await` anywhere in the expression (not just at start).
         // e.g. `(await Promise.resolve(42)) + 1` has await after `(`.
         // Sync expressions work fine inside async functions too (awaitPromise unwraps).
-        let has_await = cmd.expression.contains("await ") || cmd.expression.contains("await(");
+        let has_await =
+            source_expression.contains("await ") || source_expression.contains("await(");
         if has_await {
-            format!("(async function(){{ return (\n{}\n); }})()", cmd.expression)
+            format!(
+                "(async function(){{ return (\n{}\n); }})()",
+                source_expression
+            )
         } else {
-            let escaped = serde_json::to_string(&cmd.expression).unwrap_or_default();
+            let escaped = serde_json::to_string(&source_expression).unwrap_or_default();
             format!("(function(){{ return eval({}); }})()", escaped)
         }
     };
@@ -440,7 +574,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                         &reason,
                         "CdpError",
                         &Map::new(),
-                        &cmd.expression,
+                        &source_expression,
                         &pre_origin,
                     );
                     build_eval_error_result(
@@ -484,8 +618,13 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
             } else {
                 Map::new()
             };
-            let code =
-                classify_eval_error(emsg, &error_type, &properties, &cmd.expression, &pre_origin);
+            let code = classify_eval_error(
+                emsg,
+                &error_type,
+                &properties,
+                &source_expression,
+                &pre_origin,
+            );
             let reason = string_property(&properties, "reason")
                 .unwrap_or(emsg)
                 .to_string();

--- a/packages/cli/src/cli.rs
+++ b/packages/cli/src/cli.rs
@@ -1170,6 +1170,23 @@ mod tests {
     }
 
     #[test]
+    fn try_parse_from_accepts_browser_eval_file_flag() {
+        let cli = Cli::try_parse_from([
+            "actionbook",
+            "browser",
+            "eval",
+            "--file",
+            "/tmp/script.js",
+            "--session",
+            "session-1",
+            "--tab",
+            "tab-1",
+        ]);
+
+        assert!(cli.is_ok(), "browser eval should accept --file");
+    }
+
+    #[test]
     fn try_parse_from_accepts_browser_mouse_move_command() {
         let cli = Cli::try_parse_from([
             "actionbook",

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -246,6 +246,33 @@ async fn handle_browser(
                 actionbook_cli::browser::session::provider::collect_provider_env_from_process();
             BrowserCommands::Restart(cmd)
         }
+        BrowserCommands::Eval(mut cmd) => {
+            // stdin and the file's relative path belong to the CLI process,
+            // not the daemon's — resolve here so that positional `-` reads
+            // the user's pipe and --file is opened against the user's cwd.
+            match interaction::eval::resolve_eval_source(&cmd) {
+                Ok(expr) => {
+                    cmd.expression = Some(expr);
+                    cmd.file = None;
+                    BrowserCommands::Eval(cmd)
+                }
+                Err(result) => {
+                    let failed_command = BrowserCommands::Eval(cmd);
+                    let duration = start.elapsed();
+                    let context = failed_command.context(&result);
+                    let command_name = failed_command.command_name().to_string();
+                    if json_mode {
+                        let envelope =
+                            JsonEnvelope::from_result(&command_name, context, &result, duration);
+                        println!("{}", serde_json::to_string(&envelope)?);
+                    } else {
+                        let text = output::format_text(&command_name, &context, &result);
+                        eprintln!("{text}");
+                    }
+                    flush_and_exit(1);
+                }
+            }
+        }
         other => other,
     };
 

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -6296,6 +6296,151 @@ fn browser_eval_file_and_expression_conflict_is_structured() {
     close_session(&sid);
 }
 
+#[cfg(unix)]
+#[test]
+fn browser_eval_stdin_dash_on_tty_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    // openpty gives us a master/slave pair whose slave fd reports
+    // is_terminal() == true.  Hand the slave as the child's stdin so the
+    // TTY fast-path fires before any read would block on the un-driven
+    // master.  Closing master after the child exits releases the pair.
+    use std::os::unix::io::FromRawFd;
+    let (master_fd, slave_fd) = unsafe {
+        let mut master: libc::c_int = 0;
+        let mut slave: libc::c_int = 0;
+        let rc = libc::openpty(
+            &mut master as *mut _,
+            &mut slave as *mut _,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+        assert_eq!(rc, 0, "openpty must succeed");
+        (master, slave)
+    };
+
+    let slave_stdin = unsafe { Stdio::from_raw_fd(slave_fd) };
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let out = std::process::Command::new(&bin)
+        .env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(&sid)
+        .arg("--tab")
+        .arg(&tid)
+        .stdin(slave_stdin)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run browser eval with pty stdin");
+
+    unsafe {
+        libc::close(master_fd);
+    }
+
+    assert_failure(&out, "browser eval stdin on tty");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_STDIN_TTY");
+    assert!(
+        v["error"]["details"]["reason"].as_str().is_some(),
+        "details.reason must exist for EVAL_STDIN_TTY"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_stdin_empty_pipe_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let out = std::process::Command::new(&bin)
+        .env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(&sid)
+        .arg("--tab")
+        .arg(&tid)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run browser eval with null stdin");
+
+    assert_failure(&out, "browser eval stdin empty pipe");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_STDIN_EMPTY");
+    assert!(
+        v["error"]["details"]["reason"].as_str().is_some(),
+        "details.reason must exist for EVAL_STDIN_EMPTY"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_stdin_whitespace_only_pipe_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(&sid)
+        .arg("--tab")
+        .arg(&tid)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn browser eval stdin command");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin pipe");
+        stdin
+            .write_all(b"   \n\t\n")
+            .expect("write whitespace-only stdin");
+    }
+    let out = child
+        .wait_with_output()
+        .expect("wait for browser eval stdin command");
+
+    assert_failure(&out, "browser eval stdin whitespace only");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_STDIN_EMPTY");
+    assert!(
+        v["error"]["details"]["reason"].as_str().is_some(),
+        "details.reason must exist for EVAL_STDIN_EMPTY"
+    );
+
+    close_session(&sid);
+}
+
 // ========================================================================
 // Group 20: mouse-move — command wiring, success path, and error path
 // ========================================================================

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -5,9 +5,14 @@
 //! `browser fill`, and `browser select`,
 //! per api-reference.md §11.
 
+use std::io::Write;
+use std::process::Stdio;
+
+use assert_cmd::cargo::cargo_bin;
+
 use crate::harness::{
     SessionGuard, api_base_url, assert_failure, assert_success, headless, headless_json,
-    parse_json, skip, stderr_str, stdout_str, unique_session, wait_page_ready,
+    parse_json, shared_env, skip, stderr_str, stdout_str, unique_session, wait_page_ready,
 };
 
 const TEST_URL: &str = "https://example.com";
@@ -598,6 +603,37 @@ fn assert_browser_eval_structured_failure(v: &serde_json::Value, expected_code: 
             .is_some_and(|reason| !reason.is_empty()),
         "structured eval failures must expose a non-empty details.reason"
     );
+}
+
+fn eval_json_with_stdin(session_id: &str, tab_id: &str, stdin_expr: &str) -> serde_json::Value {
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(session_id)
+        .arg("--tab")
+        .arg(tab_id)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn browser eval stdin command");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin pipe");
+        stdin
+            .write_all(stdin_expr.as_bytes())
+            .expect("write stdin expression");
+    }
+    let out = child
+        .wait_with_output()
+        .expect("wait for browser eval stdin command");
+    assert_success(&out, "browser eval stdin");
+    parse_json(&out)
 }
 
 fn install_click_fixture(session_id: &str, tab_id: &str) {
@@ -5967,7 +6003,7 @@ fn browser_eval_body_head_is_truncated_at_utf8_boundary() {
     if skip() {
         return;
     }
-    let (sid, tid) = start_session("about:blank");
+    let (sid, tid) = start_session(TEST_URL);
     let _guard = SessionGuard::new(&sid);
 
     let v = eval_failure_json_with_flags(
@@ -6116,6 +6152,146 @@ fn browser_eval_timeout_is_structured() {
             .contains("timed out"),
         "timeout reason must preserve the timeout failure"
     );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_basic_executes_expression() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(script.path(), "(() => ({ a: 1, ok: true }))()").expect("write eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "browser eval --file basic");
+    let v = parse_json(&out);
+    assert_eq!(v["data"]["value"]["a"], 1);
+    assert_eq!(v["data"]["value"]["ok"], true);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_preserves_complex_javascript() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(
+        script.path(),
+        r#"(() => ({ regex: /\w+/.toString(), text: "quote:\" slash:\\" }))()"#,
+    )
+    .expect("write complex eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&out, "browser eval --file complex");
+    let v = parse_json(&out);
+    assert_eq!(v["data"]["value"]["regex"], "/\\w+/");
+    assert_eq!(v["data"]["value"]["text"], r#"quote:" slash:\"#);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_stdin_dash_reads_expression() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let v = eval_json_with_stdin(&sid, &tid, "(() => ({ via: 'stdin', value: 1 }))()");
+    assert_eq!(v["data"]["value"]["via"], "stdin");
+    assert_eq!(v["data"]["value"]["value"], 1);
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_missing_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            "/tmp/actionbook-eval-file-missing.js",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_failure(&out, "browser eval --file missing");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_FILE_NOT_FOUND");
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_and_expression_conflict_is_structured() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(script.path(), "(() => 1)()").expect("write eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "(() => 2)()",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_failure(&out, "browser eval positional + file conflict");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_ARGS_CONFLICT");
 
     close_session(&sid);
 }

--- a/packages/cli/tests/e2e/interaction.rs
+++ b/packages/cli/tests/e2e/interaction.rs
@@ -6441,6 +6441,138 @@ fn browser_eval_stdin_whitespace_only_pipe_is_structured() {
     close_session(&sid);
 }
 
+// Piping the literal `-` character via stdin must NOT cause the daemon to
+// re-read its own stdin. CLI pre-flight resolves stdin to Some("-"); if the
+// daemon re-invokes the same resolver it would re-interpret the expression
+// as the stdin sentinel and either hang or produce a spurious EVAL_STDIN_*
+// envelope instead of forwarding `-` to CDP as a JavaScript expression.
+#[test]
+fn browser_eval_stdin_dash_literal_does_not_retry_stdin_on_daemon() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let env = shared_env();
+    let bin = cargo_bin("actionbook");
+    let mut cmd = std::process::Command::new(&bin);
+    cmd.env("ACTIONBOOK_HOME", &env.actionbook_home)
+        .arg("--json")
+        .arg("browser")
+        .arg("eval")
+        .arg("-")
+        .arg("--session")
+        .arg(&sid)
+        .arg("--tab")
+        .arg(&tid)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn browser eval stdin command");
+    {
+        let stdin = child.stdin.as_mut().expect("stdin pipe");
+        stdin.write_all(b"-").expect("write literal dash to stdin");
+    }
+    let out = child
+        .wait_with_output()
+        .expect("wait for browser eval stdin command");
+
+    let v = parse_json(&out);
+    let code = v["error"]["code"].as_str().unwrap_or("");
+    assert_ne!(
+        code, "EVAL_STDIN_TTY",
+        "daemon must not re-resolve literal `-` as stdin sentinel: got EVAL_STDIN_TTY"
+    );
+    assert_ne!(
+        code, "EVAL_STDIN_EMPTY",
+        "daemon must not re-resolve literal `-` as stdin sentinel: got EVAL_STDIN_EMPTY (envelope={v})"
+    );
+
+    close_session(&sid);
+}
+
+#[cfg(unix)]
+#[test]
+fn browser_eval_file_permission_denied_is_structured_with_reason() {
+    if skip() {
+        return;
+    }
+    use std::os::unix::fs::PermissionsExt;
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    std::fs::write(script.path(), "(() => 1)()").expect("write eval file");
+    std::fs::set_permissions(script.path(), std::fs::Permissions::from_mode(0o000))
+        .expect("chmod 000 the eval file");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+
+    // Restore perms so TempFile drop can clean up.
+    let _ = std::fs::set_permissions(script.path(), std::fs::Permissions::from_mode(0o600));
+
+    assert_failure(&out, "browser eval --file permission denied");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_FILE_NOT_FOUND");
+    assert_eq!(
+        v["error"]["details"]["reason"].as_str(),
+        Some("permission_denied"),
+        "details.reason must map io::ErrorKind::PermissionDenied to 'permission_denied' (envelope={v})"
+    );
+
+    close_session(&sid);
+}
+
+#[test]
+fn browser_eval_file_invalid_utf8_is_structured_with_reason() {
+    if skip() {
+        return;
+    }
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let script = tempfile::NamedTempFile::new().expect("create eval temp file");
+    // Raw bytes that are not valid UTF-8: 0xff is never a valid start byte.
+    std::fs::write(script.path(), [0xff, 0xfe, 0xfd]).expect("write invalid utf-8");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "eval",
+            "--file",
+            script.path().to_str().expect("utf8 path"),
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+
+    assert_failure(&out, "browser eval --file invalid utf-8");
+    let v = parse_json(&out);
+    assert_error_envelope(&v, "EVAL_FILE_NOT_FOUND");
+    assert_eq!(
+        v["error"]["details"]["reason"].as_str(),
+        Some("invalid_data"),
+        "details.reason must map io::ErrorKind::InvalidData to 'invalid_data' (envelope={v})"
+    );
+
+    close_session(&sid);
+}
+
 // ========================================================================
 // Group 20: mouse-move — command wiring, success path, and error path
 // ========================================================================


### PR DESCRIPTION
## Summary

Extends `actionbook browser eval` to accept the JavaScript expression from three mutually-exclusive sources, built on top of the `EvalErrorCode` machinery landed in #573:

- **positional expression** (unchanged)
- **`--file <path>`** — read the expression from a script file
- **stdin (`-`)** — read the expression from a pipe, e.g. `echo 'expr' | actionbook browser eval -`

Resolution happens on the **CLI side** before the command is forwarded to the daemon, so stdin and the `--file` path both belong to the user's process, not the daemon's.

## Error codes added (client-only)

All four are arg-layer failures — no CDP round-trip, no pre-page context (`pre_url`, `pre_origin`, `pre_readyState`) attached. They are intentionally absent from `from_wire_code`.

| Code | When |
| --- | --- |
| `EVAL_ARGS_CONFLICT` | multiple sources provided, or no source at all |
| `EVAL_FILE_NOT_FOUND` | `--file` path unreadable (not-found / permission) |
| `EVAL_STDIN_TTY` | positional `-` but stdin is a terminal |
| `EVAL_STDIN_EMPTY` | stdin read produced an empty or whitespace-only buffer (`reason`: `pipe_closed` \| `whitespace_only`) |

Distinct messages and hints per code per the locked contract; `details.reason` is a loose discriminator (values documented in code but not contracted).

## Design note on flip-flops

The shape (one code vs. two codes for stdin failure) was debated in-thread and locked at **two codes** (`EVAL_STDIN_TTY` + `EVAL_STDIN_EMPTY`). Reviewers should not re-debate — resolved pre-landing.

## Test plan

- [x] 3 red tests landed first (separate TDD commits):
  - `browser_eval_stdin_dash_on_tty_is_structured` — uses `libc::openpty` (unix-only dev-dep) to simulate a TTY on stdin
  - `browser_eval_stdin_empty_pipe_is_structured` — `Stdio::null()` stdin
  - `browser_eval_stdin_whitespace_only_pipe_is_structured` — pipes `"   \n\t\n"`
- [x] All 38 eval e2e tests pass green locally with `RUN_E2E_TESTS=true`
- [x] 439 unit tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] CI: Lint, Unit Tests (Linux+Windows), Analyze (actions/js/python/rust), CodeQL all green
- [x] @cli-roger-test cross-review clear — no blockers, non-blocker nit on `EVAL_FILE_NOT_FOUND` message neutralization logged for follow-up ACT ticket
- [ ] Codex scan