### PR TITLE
feat(close): make browser close idempotent when the session is already gone (ACT-969)

### DIFF
--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -238,6 +238,7 @@ mod tests {
     use super::*;
     use crate::browser::session::provider::{ProviderEnv, ProviderSession};
     use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
+    use crate::output::JsonEnvelope;
     use crate::types::{Mode, SessionId};
 
     fn spawn_single_response_server(
@@ -320,6 +321,182 @@ mod tests {
         entry.provider = Some(provider_session.provider.clone());
         entry.provider_session = Some(provider_session);
         registry.lock().await.insert(entry);
+    }
+
+    async fn insert_running_session(
+        registry: &crate::daemon::registry::SharedRegistry,
+        session_id: &str,
+        status: SessionState,
+    ) {
+        let mut entry = SessionEntry::starting(
+            SessionId::new(session_id).expect("session id"),
+            Mode::Cloud,
+            true,
+            true,
+            "profile".to_string(),
+        );
+        entry.status = status;
+        registry.lock().await.insert(entry);
+    }
+
+    #[tokio::test]
+    async fn browser_close_unknown_session_returns_ok_with_warning() {
+        let registry = new_shared_registry();
+        let cmd = Cmd {
+            session: "missing-session".to_string(),
+        };
+
+        let result = execute(&cmd, &registry).await;
+        let envelope = JsonEnvelope::from_result(
+            COMMAND_NAME,
+            context(&cmd, &result),
+            &result,
+            Duration::from_millis(1),
+        );
+
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok result, got {other:?}"),
+        };
+
+        assert_eq!(data["status"], "closed");
+        assert_eq!(data["closed_tabs"], 0);
+        let warnings = data["__warnings"]
+            .as_array()
+            .expect("warnings array should exist on raw success data");
+        assert!(
+            warnings.iter().any(|w| {
+                w.as_str()
+                    .map(|s| s.contains("not found") || s.contains("already closed"))
+                    .unwrap_or(false)
+            }),
+            "raw warnings should describe missing/closed session: {warnings:?}",
+        );
+
+        assert!(envelope.ok);
+        assert_eq!(envelope.data["status"], "closed");
+        assert_eq!(envelope.data["closed_tabs"], 0);
+        assert!(
+            envelope.data.get("__warnings").is_none(),
+            "__warnings should be stripped from public data envelope"
+        );
+        assert!(
+            envelope
+                .meta
+                .warnings
+                .iter()
+                .any(|w| w.contains("not found") || w.contains("already closed")),
+            "meta warnings should carry missing-session warning: {:?}",
+            envelope.meta.warnings
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_close_active_session_still_works() {
+        let registry = new_shared_registry();
+        insert_running_session(&registry, "s1", SessionState::Running).await;
+
+        let result = execute(
+            &Cmd {
+                session: "s1".to_string(),
+            },
+            &registry,
+        )
+        .await;
+
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok result, got {other:?}"),
+        };
+        assert_eq!(data["status"], "closed");
+        assert_eq!(data["closed_tabs"], 0);
+        assert!(
+            data.get("__warnings").is_none(),
+            "active close should not emit warning"
+        );
+        assert!(
+            registry.lock().await.get("s1").is_none(),
+            "session should be removed after successful close"
+        );
+    }
+
+    #[tokio::test]
+    async fn browser_close_unknown_session_after_phase_two_returns_ok_with_warning() {
+        let (base_url, request_handle) = spawn_single_response_server_with_delay(
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n",
+            Duration::from_millis(300),
+        );
+        let registry = new_shared_registry();
+        insert_cloud_session(
+            &registry,
+            "hyp1",
+            make_provider_session(
+                "hyperbrowser",
+                "hb-session-1",
+                ProviderEnv::from([
+                    ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
+                    ("HYPERBROWSER_API_URL".to_string(), base_url.clone()),
+                ]),
+            ),
+        )
+        .await;
+
+        let reg_for_execute = registry.clone();
+        let handle = tokio::spawn(async move {
+            execute(
+                &Cmd {
+                    session: "hyp1".to_string(),
+                },
+                &reg_for_execute,
+            )
+            .await
+        });
+
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        let removed = registry.lock().await.remove("hyp1");
+        assert!(removed.is_some(), "test setup should evict session mid-close");
+
+        let result = handle.await.expect("close join");
+
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok result, got {other:?}"),
+        };
+        assert_eq!(data["status"], "closed");
+        assert_eq!(data["closed_tabs"], 0);
+        let warnings = data["__warnings"]
+            .as_array()
+            .expect("warnings array should exist on raw success data");
+        assert!(
+            warnings.iter().any(|w| {
+                w.as_str()
+                    .map(|s| s.contains("not found") || s.contains("already closed"))
+                    .unwrap_or(false)
+            }),
+            "phase-3 miss should warn instead of silently succeeding: {warnings:?}",
+        );
+
+        let request = request_handle.join().expect("request join");
+        assert!(request.starts_with("PUT /api/session/hb-session-1/stop HTTP/1.1"));
+    }
+
+    #[tokio::test]
+    async fn browser_close_midflight_second_caller_still_gets_closing_fatal() {
+        let registry = new_shared_registry();
+        insert_running_session(&registry, "s1", SessionState::Closing).await;
+
+        let result = execute(
+            &Cmd {
+                session: "s1".to_string(),
+            },
+            &registry,
+        )
+        .await;
+
+        match result {
+            ActionResult::Fatal { code, .. } => assert_eq!(code, "SESSION_CLOSING"),
+            other => panic!("expected SESSION_CLOSING fatal, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/packages/cli/src/browser/session/close.rs
+++ b/packages/cli/src/browser/session/close.rs
@@ -22,6 +22,8 @@ pub struct Cmd {
 }
 
 pub const COMMAND_NAME: &str = "browser close";
+const SESSION_NOT_FOUND_WARNING: &str =
+    "session not found in daemon — already closed or daemon restarted";
 
 pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
     Some(ResponseContext {
@@ -31,6 +33,15 @@ pub fn context(cmd: &Cmd, _result: &ActionResult) -> Option<ResponseContext> {
         url: None,
         title: None,
     })
+}
+
+fn already_closed_result(session_id: &str) -> ActionResult {
+    ActionResult::ok(json!({
+        "session_id": session_id,
+        "status": "closed",
+        "closed_tabs": 0,
+        "__warnings": [SESSION_NOT_FOUND_WARNING],
+    }))
 }
 
 pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
@@ -48,11 +59,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         let entry = match reg.get_mut(&cmd.session) {
             Some(e) => e,
             None => {
-                return ActionResult::fatal_with_hint(
-                    "SESSION_NOT_FOUND",
-                    format!("session '{}' not found", cmd.session),
-                    "run `actionbook browser list-sessions` to see available sessions",
-                );
+                return already_closed_result(&cmd.session);
             }
         };
         if entry.status == SessionState::Closing {
@@ -109,12 +116,9 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
                 // Phase 1 set status=Closing, so this should be unreachable
                 // under normal operation — another path would have to forcibly
                 // evict the entry while we were in Phase 2. Treat it as success
-                // from the caller's perspective: the remote is already stopped.
-                return ActionResult::ok(json!({
-                    "session_id": cmd.session,
-                    "status": "closed",
-                    "closed_tabs": 0,
-                }));
+                // from the caller's perspective and surface the same warning
+                // as the Phase 1 miss branch for idempotent close semantics.
+                return already_closed_result(&cmd.session);
             }
         };
         let tabs = entry.tabs_count();
@@ -454,7 +458,10 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(75)).await;
         let removed = registry.lock().await.remove("hyp1");
-        assert!(removed.is_some(), "test setup should evict session mid-close");
+        assert!(
+            removed.is_some(),
+            "test setup should evict session mid-close"
+        );
 
         let result = handle.await.expect("close join");
 

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -415,6 +415,11 @@ fn format_data_fields(command: &str, data: &Value, lines: &mut Vec<String>) {
             if let Some(tabs) = data.get("closed_tabs").and_then(|v| v.as_u64()) {
                 lines.push(format!("closed_tabs: {tabs}"));
             }
+            if let Some(warnings) = data.get("__warnings").and_then(|v| v.as_array()) {
+                for warning in warnings.iter().filter_map(|v| v.as_str()) {
+                    lines.push(format!("warning: {warning}"));
+                }
+            }
         }
         "browser restart" => {
             if let Some(status) = data
@@ -1274,6 +1279,26 @@ mod tests {
         assert_eq!(
             text,
             "path: /Users/test/.actionbook/extension\ninstalled: false\nrequired_version: >= 0.4.0\n  (check version at chrome://extensions/)"
+        );
+    }
+
+    #[test]
+    fn browser_close_text_renders_warning_lines() {
+        let result = ActionResult::ok(json!({
+            "session_id": "sid",
+            "status": "closed",
+            "closed_tabs": 0,
+            "__warnings": ["session 'sid' not found; treating as already closed"],
+        }));
+
+        let text = format_text("browser close", &None, &result);
+
+        assert!(text.contains("ok browser close"), "text: {text}");
+        assert!(text.contains("closed_tabs: 0"), "text: {text}");
+        assert!(text.contains("warning:"), "text: {text}");
+        assert!(
+            text.contains("not found") || text.contains("already closed"),
+            "text: {text}"
         );
     }
 }

--- a/packages/cli/tests/e2e/browser_lifecycle.rs
+++ b/packages/cli/tests/e2e/browser_lifecycle.rs
@@ -485,6 +485,11 @@ fn lifecycle_double_close_text() {
     let text = stdout_str(&out);
     assert!(text.contains("ok browser close"));
     assert!(text.contains("closed_tabs: 0"), "text: {text}");
+    assert!(text.contains("warning:"), "text: {text}");
+    assert!(
+        text.contains("not found") || text.contains("already closed"),
+        "text: {text}"
+    );
 }
 
 // ===========================================================================

--- a/packages/cli/tests/e2e/browser_lifecycle.rs
+++ b/packages/cli/tests/e2e/browser_lifecycle.rs
@@ -448,15 +448,24 @@ fn lifecycle_double_close_json() {
     assert_success(&out, "first close");
 
     let out = headless_json(&["browser", "close", "--session", &sid], 30);
-    assert_failure(&out, "second close should fail");
+    assert_success(&out, "second close idempotent");
     let v = parse_json(&out);
-    assert_eq!(v["ok"], false);
+    assert_eq!(v["ok"], true);
     assert_eq!(v["command"], "browser close");
-    assert!(v["data"].is_null());
-    assert_eq!(v["error"]["code"], "SESSION_NOT_FOUND");
-    assert!(v["error"]["message"].is_string());
-    assert!(v["error"]["retryable"].is_boolean());
-    assert!(v["error"]["details"].is_object() || v["error"]["details"].is_null());
+    assert_eq!(v["data"]["status"], "closed");
+    assert_eq!(v["data"]["closed_tabs"], 0);
+    let warnings = v["meta"]["warnings"]
+        .as_array()
+        .expect("meta warnings array should exist");
+    assert!(
+        warnings.iter().any(|w| {
+            w.as_str()
+                .map(|s| s.contains("not found") || s.contains("already closed"))
+                .unwrap_or(false)
+        }),
+        "expected idempotent close warning, got {warnings:?}"
+    );
+    assert!(v["error"].is_null());
     assert!(v["meta"]["duration_ms"].is_number());
 }
 
@@ -472,9 +481,10 @@ fn lifecycle_double_close_text() {
     assert_success(&out, "first close");
 
     let out = headless(&["browser", "close", "--session", &sid], 30);
-    assert_failure(&out, "second close text");
-    let text = stderr_str(&out);
-    assert!(text.contains("error SESSION_NOT_FOUND:"));
+    assert_success(&out, "second close idempotent text");
+    let text = stdout_str(&out);
+    assert!(text.contains("ok browser close"));
+    assert!(text.contains("closed_tabs: 0"), "text: {text}");
 }
 
 // ===========================================================================
@@ -1575,9 +1585,9 @@ fn restart_kills_old_chrome_and_spawns_new() {
     let _ = env.headless_json(&["browser", "close", "--session", "restart-leak"], 30);
 }
 
-/// Closing an already-closed session returns SESSION_NOT_FOUND (no panic/crash).
+/// Closing an already-closed session returns success with a warning (no panic/crash).
 #[test]
-fn double_close_returns_not_found() {
+fn double_close_returns_ok_with_warning() {
     if skip() {
         return;
     }
@@ -1601,11 +1611,25 @@ fn double_close_returns_not_found() {
     let out = env.headless_json(&["browser", "close", "--session", "double-close"], 30);
     assert_success(&out, "first close");
 
-    // Second close returns SESSION_NOT_FOUND
+    // Second close is idempotent and returns success with a warning
     let out = env.headless_json(&["browser", "close", "--session", "double-close"], 30);
-    assert_failure(&out, "second close should fail");
+    assert_success(&out, "second close should be idempotent");
     let v = parse_json(&out);
-    assert_eq!(v["error"]["code"], "SESSION_NOT_FOUND");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["status"], "closed");
+    assert_eq!(v["data"]["closed_tabs"], 0);
+    let warnings = v["meta"]["warnings"]
+        .as_array()
+        .expect("meta warnings array should exist");
+    assert!(
+        warnings.iter().any(|w| {
+            w.as_str()
+                .map(|s| s.contains("not found") || s.contains("already closed"))
+                .unwrap_or(false)
+        }),
+        "expected idempotent close warning, got {warnings:?}"
+    );
+    assert!(v["error"].is_null());
 }
 
 // ===========================================================================

--- a/packages/cli/tests/e2e/cloud_mode.rs
+++ b/packages/cli/tests/e2e/cloud_mode.rs
@@ -1589,9 +1589,23 @@ fn cloud_double_close_session_json() {
     assert_success(&out, "first close");
 
     let out = headless_json(&["browser", "close", "--session", &sid], 10);
-    assert_failure(&out, "double close");
+    assert_success(&out, "double close idempotent");
     let v = parse_json(&out);
-    assert_error_envelope(&v, "SESSION_NOT_FOUND");
+    assert_eq!(v["ok"], true);
+    assert_eq!(v["data"]["status"], "closed");
+    assert_eq!(v["data"]["closed_tabs"], 0);
+    let warnings = v["meta"]["warnings"]
+        .as_array()
+        .expect("meta warnings array should exist");
+    assert!(
+        warnings.iter().any(|w| {
+            w.as_str()
+                .map(|s| s.contains("not found") || s.contains("already closed"))
+                .unwrap_or(false)
+        }),
+        "expected idempotent close warning, got {warnings:?}"
+    );
+    assert!(v["error"].is_null());
 }
 
 // ═══════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- make `browser close` return success with a warning when the daemon no longer has the session entry
- keep the existing `SESSION_CLOSING` fatal path unchanged for genuine concurrent-close races
- add regression coverage for the phase-1 miss path, the phase-3 race-evict miss path, the active-session happy path, and the midflight closing guard

## Contract
ACT-969 fixes orchestrator false alarms when `actionbook browser close --session <sid>` reaches a daemon that has already lost the session (daemon restart, expired session id, etc.).

The locked behavior in this PR is:
- unknown session close is idempotent: `ok: true`, `status = "closed"`, `closed_tabs = 0`
- callers get `meta.warnings` explaining the session was already gone instead of a fatal `SESSION_NOT_FOUND`
- the phase-3 race-evict fallback returns the same warning so both miss paths are symmetric
- a second caller hitting an entry already marked `Closing` still gets fatal `SESSION_CLOSING`

## Validation
- `cargo test --manifest-path packages/cli/Cargo.toml browser_close_ -- --nocapture`
- `cargo clippy --manifest-path packages/cli/Cargo.toml --all-targets --all-features -- -D warnings`
- `cargo fmt --manifest-path packages/cli/Cargo.toml --check`
- attempted `cargo test --manifest-path packages/cli/Cargo.toml --package actionbook-cli`; clean `origin/main` currently reproduces two unrelated local failures in `tests/help_cli.rs::top_level_help_lists_setup_command` and `tests/setup_cli.rs::setup_json_with_env_api_key_does_not_persist_env_value`, so this PR stays scoped to ACT-969
