### PR TITLE
docs(eval): document --file/stdin input sources and CLI-layer error codes

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -284,7 +284,7 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
 
   **CLI-layer errors** (before any browser interaction):
   - `EVAL_ARGS_CONFLICT` — multiple input sources, or no source at all
-  - `EVAL_FILE_NOT_FOUND` — `--file` path unreadable (not found, permission denied)
+  - `EVAL_FILE_NOT_FOUND` — `--file` path unreadable (not found, permission denied, invalid data)
   - `EVAL_STDIN_TTY` — positional `-` but stdin is a terminal
   - `EVAL_STDIN_EMPTY` — stdin read produced empty or whitespace-only input
 

--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -253,6 +253,8 @@ actionbook browser scroll top --session s1 --tab t1
 actionbook browser eval "document.title" --session s1 --tab t1
 actionbook browser eval "document.querySelectorAll('a').length" --session s1 --tab t1
 actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isolate --session s1 --tab t1
+actionbook browser eval --file script.js --session s1 --tab t1
+echo 'document.title' | actionbook browser eval - --session s1 --tab t1
 
 # File upload
 actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
@@ -267,12 +269,24 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
 </Tip>
 
 <Note>
+  `eval` accepts the expression from three mutually-exclusive sources: a positional argument, `--file <path>`, or stdin (`-`). Providing more than one (or none) returns `EVAL_ARGS_CONFLICT`.
+</Note>
+
+<Note>
   On failure, `eval` returns a structured error envelope with `error.code` set to one of:
+
+  **Runtime errors** (after browser execution):
   - `EVAL_RUNTIME_ERROR` — JS exception (ReferenceError, TypeError, etc.)
   - `EVAL_CROSS_ORIGIN` — cross-origin fetch or SecurityError
   - `EVAL_RESPONSE_NOT_JSON` — response Content-Type is not JSON
   - `EVAL_RESPONSE_NOT_OK` — HTTP status is not 2xx
   - `EVAL_TIMEOUT` — expression did not resolve within `--timeout`
+
+  **CLI-layer errors** (before any browser interaction):
+  - `EVAL_ARGS_CONFLICT` — multiple input sources, or no source at all
+  - `EVAL_FILE_NOT_FOUND` — `--file` path unreadable (not found, permission denied)
+  - `EVAL_STDIN_TTY` — positional `-` but stdin is a terminal
+  - `EVAL_STDIN_EMPTY` — stdin read produced empty or whitespace-only input
 
   Each error includes `error.hint` and `error.details` with diagnostic fields (`reason`, and for fetch errors: `status`, `content_type`, `body_head`). Read `error.code` to branch on the failure class instead of parsing the message string.
 </Note>

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -443,7 +443,11 @@ Extension mode connects via a local WebSocket bridge with the following guarante
 
 ## Eval Error Handling
 
+`browser eval` accepts the expression from three mutually-exclusive sources: a positional argument, `--file <path>`, or stdin (`-`).
+
 `browser eval` returns structured error codes on failure. Branch on `error.code` instead of parsing the message string:
+
+**Runtime errors** (after browser execution):
 
 | Code | Meaning | Best practice |
 |------|---------|---------------|
@@ -452,6 +456,15 @@ Extension mode connects via a local WebSocket bridge with the following guarante
 | `EVAL_RESPONSE_NOT_JSON` | Non-JSON response body | Read `error.details.content_type` and `body_head` before retrying |
 | `EVAL_RESPONSE_NOT_OK` | Non-2xx HTTP status | Read `error.details.status` and `body_head` to distinguish 403 / challenge / CORS |
 | `EVAL_TIMEOUT` | Expression exceeded `--timeout` | Reduce work or increase timeout |
+
+**CLI-layer errors** (before any browser interaction):
+
+| Code | Meaning | Best practice |
+|------|---------|---------------|
+| `EVAL_ARGS_CONFLICT` | Multiple input sources or none | Provide exactly one of: positional, `--file`, or stdin `-` |
+| `EVAL_FILE_NOT_FOUND` | `--file` path unreadable | Verify the path resolves and is readable |
+| `EVAL_STDIN_TTY` | `-` but stdin is a terminal | Pipe the expression: `echo 'expr' \| actionbook browser eval -` |
+| `EVAL_STDIN_EMPTY` | Stdin produced empty input | Verify the upstream command or pipeline |
 
 <Tip>
   For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` (first ≤256 chars of the response body) to decide whether to retry — a 403 challenge page is not worth retrying blindly.

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -121,6 +121,13 @@ actionbook browser click @e7 --session s1 --tab t1
 actionbook browser wait navigation --session s1 --tab t1
 ```
 
+## Eval Input Sources
+
+`browser eval` accepts the expression from three mutually-exclusive sources:
+- **Positional**: `actionbook browser eval "expr" ...`
+- **`--file`**: `actionbook browser eval --file script.js ...`
+- **Stdin**: `echo 'expr' | actionbook browser eval - ...`
+
 ## Eval Error Handling
 
 `browser eval` returns structured error codes on failure — branch on `error.code` instead of parsing the message:
@@ -129,6 +136,10 @@ actionbook browser wait navigation --session s1 --tab t1
 - `EVAL_CROSS_ORIGIN` — cross-origin fetch or CSP block. Proxy the request server-side.
 - `EVAL_RESPONSE_NOT_JSON` / `EVAL_RESPONSE_NOT_OK` — read `error.details.body_head` (first ≤256 chars of the response body) to distinguish 403 / challenge pages / CORS errors. Do not blindly retry.
 - `EVAL_TIMEOUT` — expression exceeded `--timeout`. Reduce work or raise the timeout.
+- `EVAL_ARGS_CONFLICT` — multiple input sources or none. Provide exactly one.
+- `EVAL_FILE_NOT_FOUND` — `--file` path unreadable. Verify the path.
+- `EVAL_STDIN_TTY` — `-` but stdin is a terminal. Pipe the expression.
+- `EVAL_STDIN_EMPTY` — stdin produced empty input. Verify the upstream pipeline.
 
 ## Selectors
 

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -132,7 +132,16 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
 actionbook browser eval "document.title" --session s1 --tab t1
 actionbook browser eval "document.querySelectorAll('a').length" --session s1 --tab t1
 actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isolate --session s1 --tab t1
+actionbook browser eval --file script.js --session s1 --tab t1
+echo 'document.title' | actionbook browser eval - --session s1 --tab t1
 ```
+
+**eval input sources:** The expression comes from exactly one of three mutually-exclusive sources:
+- **Positional argument** (default): `actionbook browser eval "expr" ...`
+- **`--file <path>`**: read expression from a local file: `actionbook browser eval --file script.js ...`
+- **Stdin (`-`)**: pipe the expression via stdin: `echo 'expr' | actionbook browser eval - ...`
+
+Providing more than one source (or none) returns `EVAL_ARGS_CONFLICT`.
 
 **eval scope isolation:** By default, `eval` wraps `let`/`const` declarations in an isolated scope so they don't leak across calls. Use `--no-isolate` to disable this — needed for multi-statement async expressions or when you want shared scope.
 
@@ -147,8 +156,14 @@ actionbook browser eval "await fetch('/api/data').then(r => r.json())" --no-isol
 | `EVAL_RESPONSE_NOT_JSON` | `Content-Type` is not JSON when JSON was expected | Check content-type before parsing JSON | `reason`, `status`, `content_type`, `body_head` |
 | `EVAL_RESPONSE_NOT_OK` | HTTP status is not 2xx | Handle non-2xx responses before decoding the body | `reason`, `status`, `content_type`, `body_head` |
 | `EVAL_TIMEOUT` | Expression did not resolve within `--timeout` | Reduce work or raise --timeout | `reason` |
+| `EVAL_ARGS_CONFLICT` | Multiple input sources, or no source at all | Provide exactly one of: positional expression, --file, or stdin (`-`) | `reason` |
+| `EVAL_FILE_NOT_FOUND` | `--file` path unreadable (not found, permission denied, invalid data) | Verify --file points to a readable script path | `reason`, `path` |
+| `EVAL_STDIN_TTY` | Positional `-` but stdin is a terminal (not piped) | Pipe the expression via stdin, e.g. `echo 'expr' \| actionbook browser eval -` | `reason` |
+| `EVAL_STDIN_EMPTY` | Stdin read produced empty or whitespace-only input | Verify the upstream command or pipeline produces output | `reason` |
 
-Read `error.code` to branch on the failure class. For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` to distinguish 403 / challenge pages / CORS errors before deciding whether to retry.
+The first 5 codes are **runtime errors** (after CDP execution). The last 4 are **CLI-layer errors** (before any browser interaction) — they carry `details.stage` and `details.reason` but no page context (`pre_url`, `pre_origin`, etc.).
+
+Read `error.code` to branch on the failure class. For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` to distinguish 403 / challenge pages / CORS errors before deciding whether to retry. The `details.reason` field is an observability signal — branch on `error.code`, not on `details.reason`.
 
 **fill vs type:** `fill` clears the field and sets the value directly (like pasting). `type` simulates individual keystrokes and appends to existing content.
 


### PR DESCRIPTION
## Summary

- Document three mutually-exclusive eval input sources: positional argument, `--file <path>`, stdin (`-`)
- Add 4 CLI-layer error codes: `EVAL_ARGS_CONFLICT`, `EVAL_FILE_NOT_FOUND`, `EVAL_STDIN_TTY`, `EVAL_STDIN_EMPTY`
- Clarify runtime vs CLI-layer error distinction and note that `details.reason` is observability, not stable contract

## Files changed

| File | What |
|------|------|
| `skills/actionbook/references/command-reference.md` | Input sources section + 4 new rows in error code table + runtime/CLI-layer distinction |
| `docs/api-reference/cli.mdx` | Input source Note + CLI-layer errors in error envelope Note + `--file`/stdin examples |
| `docs/guides/browser.mdx` | Input source intro + CLI-layer error table in Eval Error Handling section |
| `skills/actionbook/SKILL.md` | Eval Input Sources section + 4 CLI-layer error codes in error handling list |

## References

- Source: `packages/cli/src/browser/interaction/eval.rs` (`EvalErrorCode` enum variants, `default_hint()`, `resolve_eval_source()`, `io_kind_to_reason()`)
- PR: #576
- Linear: ACT-975

## Test plan

- [ ] Verify all 9 error codes match `EvalErrorCode::code()` in `eval.rs`
- [ ] Verify all hints match `EvalErrorCode::default_hint()` in `eval.rs`
- [ ] Verify `EVAL_FILE_NOT_FOUND` message matches neutral wording from `build_file_unreadable()`
- [ ] Verify `details.reason` bounded vocab documented for `EVAL_FILE_NOT_FOUND` matches `io_kind_to_reason()`
- [ ] Confirm 4 CLI-layer codes are absent from `from_wire_code` (client-only) as documented
- [ ] Check docs site renders correctly (Note/Tip/table formatting)