### PR TITLE
docs(close): document browser close idempotent semantics

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -153,6 +153,13 @@ actionbook browser close --session s1                 # Close a session (alias: 
 actionbook browser restart --session s1               # Restart, preserving session_id
 ```
 
+<Note>
+  `browser close` is **idempotent**: closing an unknown or already-closed session returns `ok: true` with `meta.warnings` instead of a fatal error. This prevents false alarms in orchestrators that call close unconditionally during cleanup.
+
+  - Unknown/already-closed session: `ok: true`, `data: { status: "closed", closed_tabs: 0 }`, `meta.warnings: ["session not found in daemon — already closed or daemon restarted"]`
+  - Another close already in flight: `SESSION_CLOSING` fatal (unchanged)
+</Note>
+
 ### Tab Management
 
 ```bash

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -431,6 +431,10 @@ actionbook browser close --session s1       # close a session
 actionbook browser restart --session s1     # restart with same profile/mode
 ```
 
+<Tip>
+  `browser close` is idempotent — closing an unknown or already-closed session returns `ok: true` with a warning in `meta.warnings`, not an error. Safe to call unconditionally during cleanup without checking session existence first. Read `meta.warnings` to distinguish a fresh close from an already-gone session.
+</Tip>
+
 
 ## Extension Security
 

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -156,6 +156,14 @@ When you hit a login/auth wall (sign-in page, password prompt, MFA/OTP, CAPTCHA,
 
 Do not switch tools just because a login page appears.
 
+## Session Cleanup
+
+`browser close` is idempotent — closing an unknown or already-closed session returns `ok: true` with a warning in `meta.warnings`, not a fatal error. A typo in the session ID or a session that was already torn down is no longer an error condition.
+
+- Safe to call `browser close` unconditionally during cleanup without checking session existence first.
+- Read `meta.warnings` to distinguish a fresh close from an already-gone session. Do not treat a warning inside an `ok: true` response as a signal that the session is still alive.
+- If another close is already in flight for the same session, the command returns `SESSION_CLOSING` (fatal).
+
 ## References
 
 | Reference | Description |

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -49,9 +49,17 @@ actionbook browser start --max-tracked-requests 1000       # Custom network buff
 
 actionbook browser list-sessions                           # List all active sessions (includes max_tracked_requests)
 actionbook browser status --session s1                     # Show session status
-actionbook browser close --session s1                      # Close a session
+actionbook browser close --session s1                      # Close a session (idempotent)
 actionbook browser restart --session s1                    # Restart a session
 ```
+
+`browser close` is **idempotent**: closing an unknown or already-closed session returns `ok: true` with `meta.warnings` instead of a fatal error. Envelope shape for an already-gone session:
+
+- `ok: true`
+- `data: { status: "closed", closed_tabs: 0 }`
+- `meta.warnings: ["session not found in daemon — already closed or daemon restarted"]`
+
+If another close is already in flight for the same session, the command returns `SESSION_CLOSING` (fatal, unchanged). Safe to call unconditionally during cleanup without checking session existence first. Read `meta.warnings` to distinguish a fresh close from an already-gone session.
 
 Supported cloud providers: `driver` (`DRIVER_API_KEY`), `hyperbrowser` (`HYPERBROWSER_API_KEY`), `browseruse` (`BROWSER_USE_API_KEY`). `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
 


### PR DESCRIPTION
## Summary

- Syncs `browser close` idempotent behavior (ACT-969, PR #577) across all four doc surfaces
- Documents envelope shape for already-gone sessions: `ok: true`, `data: { status: "closed", closed_tabs: 0 }`, `meta.warnings`
- Documents `SESSION_CLOSING` fatal edge case (another close in flight)
- Adds best practice in SKILL.md: orchestrators should read `meta.warnings` to distinguish fresh close vs already-gone, and not treat ok-with-warning as a session-alive signal

## Surfaces updated

- `skills/actionbook/references/command-reference.md` — envelope shape + warning text after close command
- `docs/api-reference/cli.mdx` — Note block with envelope details
- `docs/guides/browser.mdx` — Tip in Shutdown section
- `skills/actionbook/SKILL.md` — Session Cleanup best practice section

## Test plan

- [ ] Verify command-reference.md renders correctly with envelope bullet list
- [ ] Verify cli.mdx Note block renders in docs site
- [ ] Verify browser.mdx Tip renders in docs site
- [ ] Verify SKILL.md Session Cleanup section parses correctly as skill context