### PR TITLE
feat(cdp): structure CDP error taxonomy with classifier + envelope bridge (ACT-972)

### DIFF
--- a/packages/cli/src/browser/element.rs
+++ b/packages/cli/src/browser/element.rs
@@ -15,6 +15,7 @@
 use serde_json::{Value, json};
 
 use crate::action_result::ActionResult;
+use crate::daemon::cdp_error_classifier::CdpErrorCode;
 use crate::daemon::cdp_session::{CdpSession, cdp_error_to_result, get_cdp_and_target};
 use crate::daemon::registry::SharedRegistry;
 use crate::error::CliError;
@@ -372,7 +373,13 @@ async fn get_iframe_offset(
     let backend_node_id = owner
         .pointer("/result/backendNodeId")
         .and_then(|v| v.as_i64())
-        .ok_or_else(|| CliError::CdpError("DOM.getFrameOwner: no backendNodeId".to_string()))?;
+        .ok_or_else(|| {
+            CliError::cdp_with_code(
+                CdpErrorCode::NodeNotFound,
+                "DOM.getFrameOwner: no backendNodeId",
+                None,
+            )
+        })?;
 
     // Get the iframe's box model on the parent page (main tab session)
     let bm = cdp
@@ -386,7 +393,13 @@ async fn get_iframe_offset(
     let content = bm
         .pointer("/result/model/content")
         .and_then(|v| v.as_array())
-        .ok_or_else(|| CliError::CdpError("iframe box model: no content quad".to_string()))?;
+        .ok_or_else(|| {
+            CliError::cdp_with_code(
+                CdpErrorCode::NodeNotFound,
+                "iframe box model: no content quad",
+                None,
+            )
+        })?;
 
     // content quad: [x1,y1, x2,y2, x3,y3, x4,y4] — top-left is (x1, y1)
     let x = content[0].as_f64().unwrap_or(0.0);

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1672,8 +1672,10 @@ async fn create_tab_via_cdp(
         .pointer("/result/targetId")
         .and_then(|v| v.as_str())
         .ok_or_else(|| {
-            crate::error::CliError::CdpError(
-                "Target.createTarget did not return targetId".to_string(),
+            crate::error::CliError::cdp_with_code(
+                crate::daemon::cdp_error_classifier::CdpErrorCode::ProtocolError,
+                "Target.createTarget did not return targetId",
+                None,
             )
         })?
         .to_string();

--- a/packages/cli/src/daemon/cdp.rs
+++ b/packages/cli/src/daemon/cdp.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::Message;
 
+use crate::daemon::cdp_error_classifier::CdpErrorCode;
 use crate::error::CliError;
 
 fn ws_text(s: String) -> Message {
@@ -31,13 +32,13 @@ pub async fn cdp_runtime_evaluate(ws_url: &str, expression: &str) -> Result<Stri
     });
     ws.send(ws_text(msg.to_string()))
         .await
-        .map_err(|e| CliError::CdpError(e.to_string()))?;
+        .map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
 
     while let Some(raw) = ws.next().await {
-        let raw = raw.map_err(|e| CliError::CdpError(e.to_string()))?;
+        let raw = raw.map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
         if let Some(text) = msg_to_string(&raw) {
-            let resp: serde_json::Value =
-                serde_json::from_str(&text).map_err(|e| CliError::CdpError(e.to_string()))?;
+            let resp: serde_json::Value = serde_json::from_str(&text)
+                .map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
             if resp.get("id").and_then(|v| v.as_u64()) == Some(1) {
                 if let Some(result) = resp.get("result").and_then(|r| r.get("result")) {
                     let value = result
@@ -64,7 +65,13 @@ pub async fn cdp_runtime_evaluate(ws_url: &str, expression: &str) -> Result<Stri
             }
         }
     }
-    Err(CliError::CdpError("no response from CDP".to_string()))
+    // TODO(follow-up): promote pre-target-handshake transport faults to
+    // ConnectionFailed once site-layer disambiguation lands.
+    Err(CliError::cdp_with_code(
+        CdpErrorCode::Generic,
+        "no response from CDP",
+        None,
+    ))
 }
 
 /// CDP Page.navigate via WebSocket.
@@ -76,10 +83,10 @@ pub async fn cdp_navigate(ws_url: &str, url: &str) -> Result<(), CliError> {
     let msg = json!({ "id": 1, "method": "Page.navigate", "params": { "url": url } });
     ws.send(ws_text(msg.to_string()))
         .await
-        .map_err(|e| CliError::CdpError(e.to_string()))?;
+        .map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
 
     while let Some(raw) = ws.next().await {
-        let raw = raw.map_err(|e| CliError::CdpError(e.to_string()))?;
+        let raw = raw.map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
         if let Some(text) = msg_to_string(&raw) {
             let resp: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
             if resp.get("id").and_then(|v| v.as_u64()) == Some(1) {
@@ -103,7 +110,13 @@ pub async fn cdp_navigate(ws_url: &str, url: &str) -> Result<(), CliError> {
             }
         }
     }
-    Err(CliError::CdpError("no response from CDP".to_string()))
+    // TODO(follow-up): promote pre-target-handshake transport faults to
+    // ConnectionFailed once site-layer disambiguation lands.
+    Err(CliError::cdp_with_code(
+        CdpErrorCode::Generic,
+        "no response from CDP",
+        None,
+    ))
 }
 
 /// Get accessibility tree via CDP.
@@ -115,10 +128,10 @@ pub async fn cdp_get_ax_tree(ws_url: &str) -> Result<String, CliError> {
     let msg = json!({ "id": 1, "method": "Accessibility.getFullAXTree", "params": {} });
     ws.send(ws_text(msg.to_string()))
         .await
-        .map_err(|e| CliError::CdpError(e.to_string()))?;
+        .map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
 
     while let Some(raw) = ws.next().await {
-        let raw = raw.map_err(|e| CliError::CdpError(e.to_string()))?;
+        let raw = raw.map_err(|e| CliError::cdp_classified(e.to_string(), None))?;
         if let Some(text) = msg_to_string(&raw) {
             let resp: serde_json::Value = serde_json::from_str(&text).unwrap_or_default();
             if resp.get("id").and_then(|v| v.as_u64()) == Some(1) {
@@ -127,7 +140,13 @@ pub async fn cdp_get_ax_tree(ws_url: &str) -> Result<String, CliError> {
             }
         }
     }
-    Err(CliError::CdpError("no response".to_string()))
+    // TODO(follow-up): promote pre-target-handshake transport faults to
+    // ConnectionFailed once site-layer disambiguation lands.
+    Err(CliError::cdp_with_code(
+        CdpErrorCode::Generic,
+        "no response",
+        None,
+    ))
 }
 
 /// Ensure a URL has a scheme prefix. Rejects dangerous protocols.

--- a/packages/cli/src/daemon/cdp_error_classifier.rs
+++ b/packages/cli/src/daemon/cdp_error_classifier.rs
@@ -1,0 +1,194 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CdpErrorCode {
+    NodeNotFound,
+    NotInteractable,
+    NavTimeout,
+    TargetClosed,
+    ProtocolError,
+    Generic,
+}
+
+impl CdpErrorCode {
+    pub fn from_wire_code(_raw: &str) -> Option<Self> {
+        unimplemented!("not yet implemented")
+    }
+
+    pub fn code(self) -> &'static str {
+        unimplemented!("not yet implemented")
+    }
+
+    pub fn default_hint(self) -> &'static str {
+        unimplemented!("not yet implemented")
+    }
+
+    pub fn is_retryable(self) -> bool {
+        unimplemented!("not yet implemented")
+    }
+}
+
+pub fn classify(_raw: &str, _cdp_numeric_code: Option<i64>) -> CdpErrorCode {
+    unimplemented!("not yet implemented")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CdpErrorCode, classify};
+
+    #[test]
+    fn cdp_error_code_mappings_are_stable() {
+        assert_eq!(CdpErrorCode::NodeNotFound.code(), "CDP_NODE_NOT_FOUND");
+        assert_eq!(CdpErrorCode::NotInteractable.code(), "CDP_NOT_INTERACTABLE");
+        assert_eq!(CdpErrorCode::NavTimeout.code(), "CDP_NAV_TIMEOUT");
+        assert_eq!(CdpErrorCode::TargetClosed.code(), "CDP_TARGET_CLOSED");
+        assert_eq!(CdpErrorCode::ProtocolError.code(), "CDP_PROTOCOL_ERROR");
+        assert_eq!(CdpErrorCode::Generic.code(), "CDP_GENERIC");
+    }
+
+    #[test]
+    fn cdp_error_default_hints_match_contract() {
+        assert_eq!(
+            CdpErrorCode::NodeNotFound.default_hint(),
+            "the referenced node is stale — call `actionbook browser snapshot` to refresh node references then retry"
+        );
+        assert_eq!(
+            CdpErrorCode::NotInteractable.default_hint(),
+            "the element exists but isn't interactable — scroll it into view, wait for it to become visible, or dismiss any overlay covering it"
+        );
+        assert_eq!(
+            CdpErrorCode::NavTimeout.default_hint(),
+            "navigation exceeded the deadline — increase `--timeout` or verify the target URL is reachable"
+        );
+        assert_eq!(
+            CdpErrorCode::TargetClosed.default_hint(),
+            "the CDP target was closed mid-command (tab navigated away or session torn down) — start a fresh session or re-attach to the tab"
+        );
+        assert_eq!(
+            CdpErrorCode::ProtocolError.default_hint(),
+            "the browser rejected the command — inspect `details.reason` and `details.cdp_code` for the raw protocol error"
+        );
+        assert_eq!(CdpErrorCode::Generic.default_hint(), "");
+    }
+
+    #[test]
+    fn classify_node_not_found_by_message() {
+        assert_eq!(
+            classify("No node with given id found", Some(-32000)),
+            CdpErrorCode::NodeNotFound
+        );
+    }
+
+    #[test]
+    fn classify_node_not_found_case_insensitively() {
+        assert_eq!(
+            classify("NO NODE WITH GIVEN ID FOUND", Some(-32000)),
+            CdpErrorCode::NodeNotFound
+        );
+    }
+
+    #[test]
+    fn classify_not_interactable_by_message() {
+        assert_eq!(
+            classify(
+                "CDP error -32000: Could not compute box model.",
+                Some(-32000)
+            ),
+            CdpErrorCode::NotInteractable
+        );
+    }
+
+    #[test]
+    fn classify_nav_timeout_by_message() {
+        assert_eq!(
+            classify("Navigation timeout of 100 ms exceeded", Some(-32000)),
+            CdpErrorCode::NavTimeout
+        );
+    }
+
+    #[test]
+    fn classify_target_closed_by_message() {
+        assert_eq!(
+            classify("Target closed.", Some(-32000)),
+            CdpErrorCode::TargetClosed
+        );
+    }
+
+    #[test]
+    fn classify_response_channel_dropped_as_target_closed() {
+        assert_eq!(
+            classify("response channel dropped", None),
+            CdpErrorCode::TargetClosed
+        );
+    }
+
+    #[test]
+    fn classify_message_patterns_before_numeric_fallback() {
+        assert_eq!(
+            classify("Cannot find context with specified id", Some(-32602)),
+            CdpErrorCode::NodeNotFound
+        );
+    }
+
+    #[test]
+    fn classify_protocol_error_by_numeric_code() {
+        assert_eq!(
+            classify("CDP error -32602: invalid params", Some(-32602)),
+            CdpErrorCode::ProtocolError
+        );
+    }
+
+    #[test]
+    fn classify_pre_target_handshake_failure_as_generic() {
+        assert_eq!(
+            classify("no response from CDP", None),
+            CdpErrorCode::Generic
+        );
+    }
+
+    #[test]
+    fn classify_empty_message_as_generic() {
+        assert_eq!(classify("", None), CdpErrorCode::Generic);
+    }
+
+    #[test]
+    fn classify_non_cdp_garbage_as_generic() {
+        assert_eq!(
+            classify("socket parse exploded", None),
+            CdpErrorCode::Generic
+        );
+    }
+
+    #[test]
+    fn from_wire_code_round_trips_structured_codes_only() {
+        assert_eq!(
+            CdpErrorCode::from_wire_code("CDP_NODE_NOT_FOUND"),
+            Some(CdpErrorCode::NodeNotFound)
+        );
+        assert_eq!(
+            CdpErrorCode::from_wire_code("CDP_NOT_INTERACTABLE"),
+            Some(CdpErrorCode::NotInteractable)
+        );
+        assert_eq!(
+            CdpErrorCode::from_wire_code("CDP_NAV_TIMEOUT"),
+            Some(CdpErrorCode::NavTimeout)
+        );
+        assert_eq!(
+            CdpErrorCode::from_wire_code("CDP_TARGET_CLOSED"),
+            Some(CdpErrorCode::TargetClosed)
+        );
+        assert_eq!(
+            CdpErrorCode::from_wire_code("CDP_PROTOCOL_ERROR"),
+            Some(CdpErrorCode::ProtocolError)
+        );
+        assert_eq!(CdpErrorCode::from_wire_code("CDP_GENERIC"), None);
+    }
+
+    #[test]
+    fn cdp_error_retryability_matches_contract() {
+        assert!(!CdpErrorCode::NodeNotFound.is_retryable());
+        assert!(!CdpErrorCode::NotInteractable.is_retryable());
+        assert!(CdpErrorCode::NavTimeout.is_retryable());
+        assert!(CdpErrorCode::TargetClosed.is_retryable());
+        assert!(!CdpErrorCode::ProtocolError.is_retryable());
+        assert!(!CdpErrorCode::Generic.is_retryable());
+    }
+}

--- a/packages/cli/src/daemon/cdp_error_classifier.rs
+++ b/packages/cli/src/daemon/cdp_error_classifier.rs
@@ -9,25 +9,84 @@ pub enum CdpErrorCode {
 }
 
 impl CdpErrorCode {
-    pub fn from_wire_code(_raw: &str) -> Option<Self> {
-        unimplemented!("not yet implemented")
+    pub fn from_wire_code(raw: &str) -> Option<Self> {
+        match raw {
+            "CDP_NODE_NOT_FOUND" => Some(Self::NodeNotFound),
+            "CDP_NOT_INTERACTABLE" => Some(Self::NotInteractable),
+            "CDP_NAV_TIMEOUT" => Some(Self::NavTimeout),
+            "CDP_TARGET_CLOSED" => Some(Self::TargetClosed),
+            "CDP_PROTOCOL_ERROR" => Some(Self::ProtocolError),
+            _ => None,
+        }
     }
 
     pub fn code(self) -> &'static str {
-        unimplemented!("not yet implemented")
+        match self {
+            Self::NodeNotFound => "CDP_NODE_NOT_FOUND",
+            Self::NotInteractable => "CDP_NOT_INTERACTABLE",
+            Self::NavTimeout => "CDP_NAV_TIMEOUT",
+            Self::TargetClosed => "CDP_TARGET_CLOSED",
+            Self::ProtocolError => "CDP_PROTOCOL_ERROR",
+            Self::Generic => "CDP_GENERIC",
+        }
     }
 
     pub fn default_hint(self) -> &'static str {
-        unimplemented!("not yet implemented")
+        match self {
+            Self::NodeNotFound => {
+                "the referenced node is stale — call `actionbook browser snapshot` to refresh node references then retry"
+            }
+            Self::NotInteractable => {
+                "the element exists but isn't interactable — scroll it into view, wait for it to become visible, or dismiss any overlay covering it"
+            }
+            Self::NavTimeout => {
+                "navigation exceeded the deadline — increase `--timeout` or verify the target URL is reachable"
+            }
+            Self::TargetClosed => {
+                "the CDP target was closed mid-command (tab navigated away or session torn down) — start a fresh session or re-attach to the tab"
+            }
+            Self::ProtocolError => {
+                "the browser rejected the command — inspect `details.reason` and `details.cdp_code` for the raw protocol error"
+            }
+            Self::Generic => "",
+        }
     }
 
     pub fn is_retryable(self) -> bool {
-        unimplemented!("not yet implemented")
+        matches!(self, Self::NavTimeout | Self::TargetClosed)
     }
 }
 
-pub fn classify(_raw: &str, _cdp_numeric_code: Option<i64>) -> CdpErrorCode {
-    unimplemented!("not yet implemented")
+/// Classify a CDP error into a structured code.
+///
+/// Precedence: message pattern > numeric fallback > Generic. The classifier
+/// stays pure — no site knowledge (that lives in call-site overrides via
+/// `CliError::cdp_with_code`).
+pub fn classify(raw: &str, cdp_numeric_code: Option<i64>) -> CdpErrorCode {
+    let lower = raw.to_lowercase();
+
+    if lower.contains("no node with given id")
+        || lower.contains("cannot find context with specified id")
+    {
+        return CdpErrorCode::NodeNotFound;
+    }
+    if lower.contains("could not compute box model") {
+        return CdpErrorCode::NotInteractable;
+    }
+    if lower.contains("navigation timeout") {
+        return CdpErrorCode::NavTimeout;
+    }
+    if lower.contains("target closed") || lower.contains("response channel dropped") {
+        return CdpErrorCode::TargetClosed;
+    }
+
+    if let Some(n) = cdp_numeric_code
+        && (-32700..=-32000).contains(&n)
+    {
+        return CdpErrorCode::ProtocolError;
+    }
+
+    CdpErrorCode::Generic
 }
 
 #[cfg(test)]

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -18,6 +18,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::http;
 use tracing::warn;
 
+use crate::daemon::cdp_error_classifier::CdpErrorCode;
 use crate::error::CliError;
 
 type PendingResponseTx = oneshot::Sender<Result<Value, CliError>>;
@@ -403,7 +404,9 @@ async fn send_cdp_raw(
             });
             CliError::Timeout
         })?
-        .map_err(|_| CliError::CdpError("response channel dropped".to_string()))??;
+        .map_err(|_| {
+            CliError::cdp_with_code(CdpErrorCode::TargetClosed, "response channel dropped", None)
+        })??;
 
     if let Some(err) = resp.get("error") {
         let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -411,7 +414,10 @@ async fn send_cdp_raw(
             .get("message")
             .and_then(|v| v.as_str())
             .unwrap_or("unknown CDP error");
-        return Err(CliError::CdpError(format!("CDP error {code}: {message}")));
+        return Err(CliError::cdp_classified(
+            format!("CDP error {code}: {message}"),
+            Some(code),
+        ));
     }
 
     Ok(resp)
@@ -826,9 +832,11 @@ impl CdpSession {
             .and_then(|r| r.get("sessionId"))
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                CliError::CdpError(format!(
-                    "Target.attachToTarget did not return sessionId: {resp}"
-                ))
+                CliError::cdp_with_code(
+                    CdpErrorCode::ProtocolError,
+                    format!("Target.attachToTarget did not return sessionId: {resp}"),
+                    None,
+                )
             })?
             .to_string();
 
@@ -987,7 +995,14 @@ impl CdpSession {
             .lock()
             .await
             .remove(target_id)
-            .ok_or_else(|| CliError::CdpError(format!("no session for target '{target_id}'")))?;
+            .ok_or_else(|| {
+                CliError::cdp_with_code(
+                    CdpErrorCode::TargetClosed,
+                    format!("no session for target '{target_id}'"),
+                    None,
+                )
+                .with_detail("target_id", json!(target_id))
+            })?;
 
         self.execute(
             "Target.detachFromTarget",
@@ -1043,7 +1058,12 @@ impl CdpSession {
             .load(std::sync::atomic::Ordering::Acquire)
         {
             let tab_id: u64 = target_id.parse().map_err(|e| {
-                CliError::CdpError(format!("non-numeric extension tab id '{target_id}': {e}"))
+                CliError::cdp_with_code(
+                    CdpErrorCode::Generic,
+                    format!("non-numeric extension tab id '{target_id}': {e}"),
+                    None,
+                )
+                .with_detail("target_id", json!(target_id))
             })?;
 
             match self
@@ -1051,10 +1071,15 @@ impl CdpSession {
                 .await
             {
                 Ok(v) => Ok(v),
-                Err(CliError::CdpError(ref msg))
-                    // keep in sync with error messages in background.js
+                Err(CliError::CdpError { reason: ref msg, .. })
+                    // Substring guard is load-bearing: this branch opts in to
+                    // the extension self-heal retry only for these two exact
+                    // background.js-emitted messages. Widening to `code ==
+                    // TargetClosed` would enable the retry on unrelated target
+                    // closures (e.g. user-navigated-away tab) and cause an
+                    // unsafe re-attach loop. Keep in sync with background.js
                     // handleCdpCommand ("Tab N not attached") and the
-                    // chrome.debugger catch block ("Debugger detached from tab")
+                    // chrome.debugger catch block ("Debugger detached from tab").
                     if msg.contains(&format!("Tab {tab_id} not attached"))
                         || msg.contains("Debugger detached from tab") =>
                 {
@@ -1088,7 +1113,12 @@ impl CdpSession {
                 .get(target_id)
                 .cloned()
                 .ok_or_else(|| {
-                    CliError::CdpError(format!("no CDP session for target '{target_id}'"))
+                    CliError::cdp_with_code(
+                        CdpErrorCode::TargetClosed,
+                        format!("no CDP session for target '{target_id}'"),
+                        None,
+                    )
+                    .with_detail("target_id", json!(target_id))
                 })?;
             self.execute(method, params, Some(&session_id)).await
         }
@@ -1133,7 +1163,13 @@ impl CdpSession {
                 });
                 CliError::Timeout
             })?
-            .map_err(|_| CliError::CdpError("response channel dropped".to_string()))??;
+            .map_err(|_| {
+                CliError::cdp_with_code(
+                    CdpErrorCode::TargetClosed,
+                    "response channel dropped",
+                    None,
+                )
+            })??;
 
         if let Some(err) = resp.get("error") {
             let code = err.get("code").and_then(|v| v.as_i64()).unwrap_or(0);
@@ -1141,7 +1177,10 @@ impl CdpSession {
                 .get("message")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown CDP error");
-            return Err(CliError::CdpError(format!("CDP error {code}: {message}")));
+            return Err(CliError::cdp_classified(
+                format!("CDP error {code}: {message}"),
+                Some(code),
+            ));
         }
 
         Ok(resp)
@@ -1390,7 +1429,13 @@ impl CdpSession {
                 });
                 CliError::Timeout
             })?
-            .map_err(|_| CliError::CdpError("response channel dropped".to_string()))??;
+            .map_err(|_| {
+                CliError::cdp_with_code(
+                    CdpErrorCode::TargetClosed,
+                    "response channel dropped",
+                    None,
+                )
+            })??;
 
         // Surface CDP-level errors (e.g., method not found, target crashed)
         if let Some(err) = resp.get("error") {
@@ -1399,7 +1444,10 @@ impl CdpSession {
                 .get("message")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown CDP error");
-            return Err(CliError::CdpError(format!("CDP error {code}: {message}")));
+            return Err(CliError::cdp_classified(
+                format!("CDP error {code}: {message}"),
+                Some(code),
+            ));
         }
 
         Ok(resp)

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -1964,8 +1964,9 @@ pub async fn get_cdp_and_target(
 }
 
 /// Convert a CliError from CDP operations into an ActionResult.
-/// For cloud sessions, connection drops are surfaced as CLOUD_CONNECTION_LOST.
-/// For local sessions, they use the default_code.
+/// Structured `CliError::CdpError { .. }` keeps its classifier-assigned code,
+/// hint, and details (reason/cdp_code/site-specific fields) through the envelope;
+/// `default_code` is only used for genuinely unstructured/non-CDP errors.
 pub fn cdp_error_to_result(e: CliError, default_code: &str) -> crate::action_result::ActionResult {
     match &e {
         CliError::CloudConnectionLost(_) => crate::action_result::ActionResult::fatal_with_hint(
@@ -1978,6 +1979,12 @@ pub fn cdp_error_to_result(e: CliError, default_code: &str) -> crate::action_res
             e.to_string(),
             "the session was closed while a command was still in flight — start a new session",
         ),
+        CliError::CdpError { .. } => crate::action_result::ActionResult::fatal_with_details(
+            e.error_code(),
+            e.to_string(),
+            e.hint(),
+            e.envelope_details(),
+        ),
         _ => crate::action_result::ActionResult::fatal(default_code, e.to_string()),
     }
 }
@@ -1987,10 +1994,49 @@ pub fn cdp_error_to_result(e: CliError, default_code: &str) -> crate::action_res
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon::cdp_error_classifier::CdpErrorCode;
     use futures_util::stream::SplitSink;
     use std::net::SocketAddr;
     use tokio::net::TcpListener;
     use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn cdp_error_to_result_preserves_structured_code_over_default() {
+        let e = CliError::cdp_with_code(
+            CdpErrorCode::NotInteractable,
+            "CDP error -32000: Could not compute box model",
+            Some(-32000),
+        );
+        let r = cdp_error_to_result(e, "CDP_ERROR");
+        let crate::action_result::ActionResult::Fatal {
+            code,
+            hint,
+            details,
+            ..
+        } = r
+        else {
+            panic!("expected Fatal variant");
+        };
+        assert_eq!(code, "CDP_NOT_INTERACTABLE");
+        assert!(
+            !hint.is_empty(),
+            "expected structured hint from CdpErrorCode"
+        );
+        let details = details.expect("structured CdpError should carry envelope_details");
+        assert_eq!(details["cdp_code"], -32000);
+        assert!(details["reason"].is_string());
+    }
+
+    #[test]
+    fn cdp_error_to_result_uses_default_code_for_non_cdp_errors() {
+        let e = CliError::CdpConnectionFailed("handshake aborted".to_string());
+        let r = cdp_error_to_result(e, "CDP_CONNECTION_FAILED");
+        let crate::action_result::ActionResult::Fatal { code, details, .. } = r else {
+            panic!("expected Fatal variant");
+        };
+        assert_eq!(code, "CDP_CONNECTION_FAILED");
+        assert!(details.is_none());
+    }
 
     #[test]
     fn base64_decoded_len_matches_reference_for_sampled_inputs() {

--- a/packages/cli/src/daemon/mod.rs
+++ b/packages/cli/src/daemon/mod.rs
@@ -1,6 +1,7 @@
 pub mod bridge;
 pub mod browser;
 pub mod cdp;
+pub mod cdp_error_classifier;
 pub mod cdp_session;
 pub mod chrome_reaper;
 pub mod registry;

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -1,4 +1,7 @@
+use serde_json::{Map, Value};
 use thiserror::Error;
+
+use crate::daemon::cdp_error_classifier::{CdpErrorCode, classify};
 
 #[derive(Debug, Error)]
 pub enum CliError {
@@ -27,8 +30,13 @@ pub enum CliError {
     BrowserLaunchFailed(String),
     #[error("cdp connection failed: {0}")]
     CdpConnectionFailed(String),
-    #[error("cdp error: {0}")]
-    CdpError(String),
+    #[error("cdp error: {reason}")]
+    CdpError {
+        code: CdpErrorCode,
+        reason: String,
+        cdp_code: Option<i64>,
+        details: Map<String, Value>,
+    },
     #[error("session closed: {0}")]
     SessionClosed(String),
     #[error("timeout")]
@@ -64,6 +72,43 @@ pub enum CliError {
 }
 
 impl CliError {
+    /// Construct a CDP error whose code is derived from the raw message and
+    /// (optional) CDP numeric code via the classifier.
+    pub fn cdp_classified(reason: impl Into<String>, cdp_code: Option<i64>) -> Self {
+        let reason = reason.into();
+        let code = classify(&reason, cdp_code);
+        CliError::CdpError {
+            code,
+            reason,
+            cdp_code,
+            details: Map::new(),
+        }
+    }
+
+    /// Construct a CDP error with a caller-chosen code (bypasses the classifier).
+    /// Use this at call sites where the caller knows the code better than
+    /// message-pattern inference.
+    pub fn cdp_with_code(
+        code: CdpErrorCode,
+        reason: impl Into<String>,
+        cdp_code: Option<i64>,
+    ) -> Self {
+        CliError::CdpError {
+            code,
+            reason: reason.into(),
+            cdp_code,
+            details: Map::new(),
+        }
+    }
+
+    /// Chainable per-site detail injection; no-op on non-CdpError variants.
+    pub fn with_detail(mut self, key: &str, value: Value) -> Self {
+        if let CliError::CdpError { details, .. } = &mut self {
+            details.insert(key.to_string(), value);
+        }
+        self
+    }
+
     pub fn error_code(&self) -> &str {
         match self {
             CliError::DaemonNotRunning => "DAEMON_NOT_RUNNING",
@@ -78,7 +123,7 @@ impl CliError {
             CliError::BrowserNotFound => "BROWSER_NOT_FOUND",
             CliError::BrowserLaunchFailed(_) => "BROWSER_LAUNCH_FAILED",
             CliError::CdpConnectionFailed(_) => "CDP_CONNECTION_FAILED",
-            CliError::CdpError(_) => "CDP_ERROR",
+            CliError::CdpError { code, .. } => code.code(),
             CliError::SessionClosed(_) => "SESSION_CLOSED",
             CliError::Timeout => "TIMEOUT",
             CliError::NavigationFailed(_) => "NAVIGATION_FAILED",
@@ -134,27 +179,71 @@ impl CliError {
                 "the provider service returned a 5xx error — retry after a short delay or check the provider's status page"
                     .to_string()
             }
+            CliError::CdpError { code, .. } => code.default_hint().to_string(),
             _ => String::new(),
         }
     }
 
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
+        match self {
             CliError::DaemonNotRunning
-                | CliError::ConnectionFailed(_)
-                | CliError::CloudConnectionLost(_)
-                | CliError::Timeout
-                | CliError::Http(_)
-                | CliError::ApiRateLimited(_)
-                | CliError::ApiServerError(_)
-        )
+            | CliError::ConnectionFailed(_)
+            | CliError::CloudConnectionLost(_)
+            | CliError::Timeout
+            | CliError::Http(_)
+            | CliError::ApiRateLimited(_)
+            | CliError::ApiServerError(_) => true,
+            CliError::CdpError { code, .. } => code.is_retryable(),
+            _ => false,
+        }
     }
+
+    /// Extract per-variant details for the JSON envelope.
+    ///
+    /// For `CdpError`, the returned object always carries `reason` (the raw
+    /// CDP message), plus `cdp_code` when present and any site-specific fields
+    /// injected via `with_detail`. Other variants return `Value::Null`.
+    pub fn envelope_details(&self) -> Value {
+        match self {
+            CliError::CdpError {
+                reason,
+                cdp_code,
+                details,
+                ..
+            } => {
+                let mut out = details.clone();
+                out.insert("reason".to_string(), Value::String(reason.clone()));
+                if let Some(n) = cdp_code {
+                    out.insert("cdp_code".to_string(), Value::from(*n));
+                }
+                Value::Object(out)
+            }
+            _ => Value::Null,
+        }
+    }
+}
+
+/// Wire-layer counterpart of `CliError::is_retryable` — keyed on the `error.code`
+/// string so the envelope builder (which only has the code string, not a
+/// `CliError` instance) agrees with the method.
+pub fn is_retryable_code(code: &str) -> bool {
+    matches!(
+        code,
+        "CLOUD_CONNECTION_LOST"
+            | "TIMEOUT"
+            | "CDP_NAV_TIMEOUT"
+            | "CDP_TARGET_CLOSED"
+            | "API_RATE_LIMITED"
+            | "API_SERVER_ERROR"
+            | "CONNECTION_FAILED"
+            | "HTTP_ERROR"
+            | "DAEMON_NOT_RUNNING"
+    )
 }
 
 #[cfg(test)]
 mod tests {
-    use super::CliError;
+    use super::{CdpErrorCode, CliError, is_retryable_code};
 
     #[test]
     fn cdp_error_code_is_structured_for_stale_node_messages() {
@@ -174,7 +263,8 @@ mod tests {
 
     #[test]
     fn cdp_error_nav_timeout_is_retryable() {
-        let err = CliError::cdp_classified("Navigation timeout of 100 ms exceeded".to_string(), None);
+        let err =
+            CliError::cdp_classified("Navigation timeout of 100 ms exceeded".to_string(), None);
         assert_eq!(err.error_code(), "CDP_NAV_TIMEOUT");
         assert!(err.is_retryable(), "navigation timeout should be retryable");
     }
@@ -188,7 +278,8 @@ mod tests {
 
     #[test]
     fn cdp_error_protocol_errors_get_structured_code() {
-        let err = CliError::cdp_classified("CDP error -32602: invalid params".to_string(), Some(-32602));
+        let err =
+            CliError::cdp_classified("CDP error -32602: invalid params".to_string(), Some(-32602));
         assert_eq!(err.error_code(), "CDP_PROTOCOL_ERROR");
     }
 
@@ -200,8 +291,90 @@ mod tests {
 
     #[test]
     fn cdp_with_code_factory_bypasses_classifier() {
-        panic!(
-            "not yet implemented: add CliError::cdp_with_code factory and assert site override semantics"
+        // reason would classify as NodeNotFound, but caller override wins.
+        let err = CliError::cdp_with_code(
+            CdpErrorCode::ProtocolError,
+            "No node with given id found".to_string(),
+            Some(-32000),
         );
+        assert_eq!(err.error_code(), "CDP_PROTOCOL_ERROR");
+        let details = err.envelope_details();
+        assert_eq!(
+            details["reason"].as_str(),
+            Some("No node with given id found")
+        );
+        assert_eq!(details["cdp_code"].as_i64(), Some(-32000));
+    }
+
+    #[test]
+    fn with_detail_injects_site_specific_fields() {
+        let err = CliError::cdp_with_code(CdpErrorCode::NavTimeout, "timed out".to_string(), None)
+            .with_detail("timeout_ms", serde_json::json!(100));
+        let details = err.envelope_details();
+        assert_eq!(details["reason"].as_str(), Some("timed out"));
+        assert_eq!(details["timeout_ms"].as_i64(), Some(100));
+    }
+
+    #[test]
+    fn envelope_details_is_null_for_non_cdp_variants() {
+        assert!(CliError::Timeout.envelope_details().is_null());
+        assert!(CliError::DaemonNotRunning.envelope_details().is_null());
+    }
+
+    /// Fixture covering every distinct `error_code()` string returned by
+    /// `CliError`. The drift-guard test below walks this fixture to verify
+    /// `is_retryable()` (method) and `is_retryable_code()` (wire-level fn)
+    /// never disagree.
+    fn all_variants_fixture() -> Vec<CliError> {
+        vec![
+            CliError::DaemonNotRunning,
+            CliError::ConnectionFailed("x".to_string()),
+            CliError::SessionNotFound("x".to_string()),
+            CliError::SessionAlreadyExists {
+                profile: "p".to_string(),
+                existing_session: "s".to_string(),
+            },
+            CliError::SessionIdAlreadyExists("s".to_string()),
+            CliError::TabNotFound("t".to_string()),
+            CliError::InvalidArgument("x".to_string()),
+            CliError::InvalidSessionId("x".to_string()),
+            CliError::BrowserNotFound,
+            CliError::BrowserLaunchFailed("x".to_string()),
+            CliError::CdpConnectionFailed("x".to_string()),
+            CliError::cdp_with_code(CdpErrorCode::NodeNotFound, "r", None),
+            CliError::cdp_with_code(CdpErrorCode::NotInteractable, "r", None),
+            CliError::cdp_with_code(CdpErrorCode::NavTimeout, "r", None),
+            CliError::cdp_with_code(CdpErrorCode::TargetClosed, "r", None),
+            CliError::cdp_with_code(CdpErrorCode::ProtocolError, "r", None),
+            CliError::cdp_with_code(CdpErrorCode::Generic, "r", None),
+            CliError::SessionClosed("x".to_string()),
+            CliError::Timeout,
+            CliError::NavigationFailed("x".to_string()),
+            CliError::ElementNotFound("x".to_string()),
+            CliError::EvalFailed("x".to_string()),
+            CliError::MissingCdpEndpoint,
+            CliError::CloudConnectionLost("x".to_string()),
+            CliError::VersionMismatch {
+                cli: "1".to_string(),
+                daemon: "2".to_string(),
+            },
+            CliError::ApiError("x".to_string()),
+            CliError::ApiUnauthorized("x".to_string()),
+            CliError::ApiRateLimited("x".to_string()),
+            CliError::ApiServerError("x".to_string()),
+            CliError::Internal("x".to_string()),
+        ]
+    }
+
+    #[test]
+    fn is_retryable_code_matches_method_for_every_variant() {
+        for err in all_variants_fixture() {
+            let code = err.error_code().to_string();
+            assert_eq!(
+                err.is_retryable(),
+                is_retryable_code(&code),
+                "drift: {code} differs between method and code-string lookup"
+            );
+        }
     }
 }

--- a/packages/cli/src/error.rs
+++ b/packages/cli/src/error.rs
@@ -151,3 +151,57 @@ impl CliError {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::CliError;
+
+    #[test]
+    fn cdp_error_code_is_structured_for_stale_node_messages() {
+        let err = CliError::cdp_classified("No node with given id found".to_string(), None);
+        assert_eq!(err.error_code(), "CDP_NODE_NOT_FOUND");
+    }
+
+    #[test]
+    fn cdp_error_hint_is_actionable_for_not_interactable_messages() {
+        let err = CliError::cdp_classified("Could not compute box model.".to_string(), None);
+        assert!(
+            err.hint().contains("scroll"),
+            "expected actionable not-interactable hint, got {:?}",
+            err.hint()
+        );
+    }
+
+    #[test]
+    fn cdp_error_nav_timeout_is_retryable() {
+        let err = CliError::cdp_classified("Navigation timeout of 100 ms exceeded".to_string(), None);
+        assert_eq!(err.error_code(), "CDP_NAV_TIMEOUT");
+        assert!(err.is_retryable(), "navigation timeout should be retryable");
+    }
+
+    #[test]
+    fn cdp_error_target_closed_is_retryable() {
+        let err = CliError::cdp_classified("response channel dropped".to_string(), None);
+        assert_eq!(err.error_code(), "CDP_TARGET_CLOSED");
+        assert!(err.is_retryable(), "target closed should be retryable");
+    }
+
+    #[test]
+    fn cdp_error_protocol_errors_get_structured_code() {
+        let err = CliError::cdp_classified("CDP error -32602: invalid params".to_string(), Some(-32602));
+        assert_eq!(err.error_code(), "CDP_PROTOCOL_ERROR");
+    }
+
+    #[test]
+    fn cdp_error_generic_transport_failures_get_generic_code() {
+        let err = CliError::cdp_classified("socket parse exploded".to_string(), None);
+        assert_eq!(err.error_code(), "CDP_GENERIC");
+    }
+
+    #[test]
+    fn cdp_with_code_factory_bypasses_classifier() {
+        panic!(
+            "not yet implemented: add CliError::cdp_with_code factory and assert site override semantics"
+        );
+    }
+}

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -7,8 +7,10 @@ use serde_json::json;
 use actionbook_cli::action::Action;
 use actionbook_cli::action_result::ActionResult;
 use actionbook_cli::browser::interaction;
+use actionbook_cli::browser::navigation;
 use actionbook_cli::cli::{BrowserCommands, Cli, Commands, DaemonCommands, ExtensionCommands};
 use actionbook_cli::config;
+use actionbook_cli::daemon::cdp_error_classifier::CdpErrorCode;
 use actionbook_cli::output::{self, JsonEnvelope};
 use actionbook_cli::utils::client::DaemonClient;
 
@@ -18,6 +20,13 @@ use actionbook_cli::utils::client::DaemonClient;
 fn flush_and_exit(code: i32) -> ! {
     let _ = std::io::stdout().flush();
     std::process::exit(code);
+}
+
+fn is_navigation_command(command_name: &str) -> bool {
+    command_name == navigation::goto::COMMAND_NAME
+        || command_name == navigation::back::COMMAND_NAME
+        || command_name == navigation::forward::COMMAND_NAME
+        || command_name == navigation::reload::COMMAND_NAME
 }
 
 #[tokio::main]
@@ -112,18 +121,29 @@ async fn main() {
     match result {
         Ok(()) => {}
         Err(e) => {
-            let (code, hint) = match e.downcast_ref::<actionbook_cli::error::CliError>() {
-                Some(cli_err) => (cli_err.error_code().to_string(), cli_err.hint().to_string()),
-                None => ("INTERNAL_ERROR".to_string(), String::new()),
-            };
+            let (code, hint, retryable, details) =
+                match e.downcast_ref::<actionbook_cli::error::CliError>() {
+                    Some(cli_err) => (
+                        cli_err.error_code().to_string(),
+                        cli_err.hint().to_string(),
+                        cli_err.is_retryable(),
+                        cli_err.envelope_details(),
+                    ),
+                    None => (
+                        "INTERNAL_ERROR".to_string(),
+                        String::new(),
+                        false,
+                        serde_json::Value::Null,
+                    ),
+                };
             if json_output && !is_setup_command {
                 let envelope = JsonEnvelope::error(
                     "unknown",
                     None,
                     &code,
                     &e.to_string(),
-                    false,
-                    serde_json::Value::Null,
+                    retryable,
+                    details,
                     &hint,
                     std::time::Duration::ZERO,
                 );
@@ -310,6 +330,14 @@ async fn handle_browser(
             Err(_) => {
                 let result = if command_name == interaction::eval::COMMAND_NAME {
                     interaction::eval::timeout_result(timeout_ms)
+                } else if is_navigation_command(&command_name) {
+                    let reason = format!("{command_name} timed out after {timeout_ms}ms");
+                    ActionResult::fatal_with_details(
+                        CdpErrorCode::NavTimeout.code(),
+                        reason.clone(),
+                        CdpErrorCode::NavTimeout.default_hint(),
+                        json!({ "reason": reason, "timeout_ms": timeout_ms }),
+                    )
                 } else {
                     ActionResult::fatal_with_hint(
                         "TIMEOUT",

--- a/packages/cli/src/output.rs
+++ b/packages/cli/src/output.rs
@@ -125,8 +125,7 @@ impl JsonEnvelope {
                 hint,
                 details,
             } => {
-                // CloudConnectionLost is retryable despite being Fatal variant
-                let retryable = matches!(code.as_str(), "CLOUD_CONNECTION_LOST" | "TIMEOUT");
+                let retryable = crate::error::is_retryable_code(code);
                 Self::error(
                     command,
                     context,

--- a/packages/cli/tests/e2e/cdp_errors.rs
+++ b/packages/cli/tests/e2e/cdp_errors.rs
@@ -1,0 +1,128 @@
+use crate::harness::{
+    SessionGuard, assert_error_envelope, assert_failure, assert_success, headless_json, parse_json,
+    skip, start_session, url_slow,
+};
+
+#[test]
+fn cdp_not_interactable_returns_structured_code() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+
+    let setup = headless_json(
+        &[
+            "browser",
+            "eval",
+            "document.body.innerHTML = '<button id=\"hidden\" style=\"display:none\">Hidden</button>'",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+    assert_success(&setup, "install hidden button");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "click",
+            "#hidden",
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+
+    assert_failure(&out, "hidden click should return a structured CDP code");
+    let v = parse_json(&out);
+    assert_eq!(v["command"], "browser click");
+    assert_error_envelope(&v, "CDP_NOT_INTERACTABLE");
+    let hint = v["error"]["hint"].as_str().expect("hint string");
+    assert!(
+        hint.contains("scroll") || hint.contains("visible"),
+        "expected not-interactable hint, got {hint:?}"
+    );
+    assert_eq!(v["error"]["retryable"], false);
+    assert!(
+        v["error"]["details"]["reason"]
+            .as_str()
+            .map(|s| !s.is_empty())
+            .unwrap_or(false),
+        "expected non-empty details.reason"
+    );
+    assert!(
+        v["error"]["details"]["cdp_code"].is_i64(),
+        "expected integer details.cdp_code"
+    );
+}
+
+#[test]
+fn cdp_nav_timeout_returns_structured_code() {
+    if skip() {
+        return;
+    }
+
+    let (sid, tid) = start_session("about:blank");
+    let _guard = SessionGuard::new(&sid);
+    let slow_url = url_slow();
+
+    let out = headless_json(
+        &[
+            "--timeout",
+            "100",
+            "browser",
+            "goto",
+            &slow_url,
+            "--session",
+            &sid,
+            "--tab",
+            &tid,
+        ],
+        10,
+    );
+
+    assert_failure(
+        &out,
+        "slow goto should return a structured nav-timeout code",
+    );
+    let v = parse_json(&out);
+    assert_eq!(v["command"], "browser goto");
+    assert_error_envelope(&v, "CDP_NAV_TIMEOUT");
+    let hint = v["error"]["hint"].as_str().expect("hint string");
+    assert!(
+        hint.contains("--timeout") || hint.contains("reachable"),
+        "expected nav-timeout hint, got {hint:?}"
+    );
+    assert_eq!(v["error"]["retryable"], true);
+    assert_eq!(v["error"]["details"]["timeout_ms"], 100);
+}
+
+#[test]
+#[ignore = "TODO(ACT-972): direct-CDP stale-node repro bypassing REF_STALE short-circuit is not yet wired for deterministic E2E"]
+fn cdp_node_not_found_returns_structured_code() {
+    panic!(
+        "TODO(ACT-972): direct-CDP stale-node repro should assert CDP_NODE_NOT_FOUND + snapshot hint + retryable=false"
+    );
+}
+
+#[test]
+#[ignore = "TODO(ACT-972): deterministic target-closed repro needs a dedicated direct-CDP test hook"]
+fn cdp_target_closed_returns_structured_code() {
+    panic!(
+        "TODO(ACT-972): direct-CDP target-close repro should assert CDP_TARGET_CLOSED + retryable=true"
+    );
+}
+
+#[test]
+#[ignore = "TODO(ACT-972): need a deterministic user-facing non-matching CDP error to pin PROTOCOL_ERROR vs CDP_GENERIC in E2E"]
+fn cdp_unclassified_falls_back_to_generic() {
+    panic!(
+        "TODO(ACT-972): add a deterministic fallback E2E once a stable user-facing non-matching CDP error exists"
+    );
+}

--- a/packages/cli/tests/e2e/main.rs
+++ b/packages/cli/tests/e2e/main.rs
@@ -12,6 +12,7 @@
 mod batch_snapshot;
 mod bridge;
 mod browser_lifecycle;
+mod cdp_errors;
 mod cloud_mode;
 mod cookies;
 mod describe_state;


### PR DESCRIPTION
## Summary

Replace the flat `CliError::CdpError(String)` variant with a structured taxonomy backed by a pure message/numeric classifier, and wire it through the CLI output envelope so CDP failures surface actionable codes (`CDP_NODE_NOT_FOUND`, `CDP_NOT_INTERACTABLE`, `CDP_NAV_TIMEOUT`, `CDP_TARGET_CLOSED`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC`) with hints and structured details instead of a single opaque `CDP_ERROR`.

Linear: [ACT-972](https://linear.app/actionbook/issue/ACT-972)

## Commit graph

```
c1c1c4cca  test: add failing tests for CDP_* structured error codes (red)
27e47ee04  feat(cdp): structure CdpError with classifier + factories (A)
e83da863e  feat(cdp): bridge structured error into JSON envelope + nav-timeout detail (B)
7cb33e37a  fix(cdp): preserve structured CdpError through cdp_error_to_result (C)
```

## Behavior-change call-outs

The envelope `error.retryable` field is now driven by `is_retryable_code(code)` instead of a hardcoded `CLOUD_CONNECTION_LOST | TIMEOUT` whitelist, aligning it with the method-side `CliError::is_retryable()` via a drift guard. The following envelope-layer flips happen as a consequence — all are **explicit fixes to pre-existing drift**, not regressions:

| error.code | old envelope retryable | new envelope retryable | reason |
|---|---|---|---|
| `CDP_NAV_TIMEOUT` | `false` (was `CDP_ERROR`, not retryable) | `true` | navigation timeouts are inherently retryable per classifier |
| `CDP_TARGET_CLOSED` | `false` (was `CDP_ERROR`) | `true` | target-closed is transient, retryable per classifier |
| `API_RATE_LIMITED` | `false` (method said true, envelope lied) | `true` | drift fix — envelope now agrees with method |
| `API_SERVER_ERROR` | `false` (method said true) | `true` | drift fix |
| `CONNECTION_FAILED` | `false` (method said true) | `true` | drift fix |
| `HTTP_ERROR` | `false` (method said true) | `true` | drift fix |
| `DAEMON_NOT_RUNNING` | `false` (method said true) | `true` | drift fix |

All other codes (including `CDP_NODE_NOT_FOUND`, `CDP_NOT_INTERACTABLE`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC`) remain `retryable=false`.

**Downstream consumers that branch on `error.retryable`** (orchestrators, retry loops) will see newly-retryable outcomes for these codes. Aware reviewers should confirm this matches expected retry semantics.

## `is_retryable_code()` authoritative list

Defined in `packages/cli/src/error.rs:229-241`:

```rust
pub fn is_retryable_code(code: &str) -> bool {
    matches!(
        code,
        "CLOUD_CONNECTION_LOST"
            | "TIMEOUT"
            | "CDP_NAV_TIMEOUT"
            | "CDP_TARGET_CLOSED"
            | "API_RATE_LIMITED"
            | "API_SERVER_ERROR"
            | "CONNECTION_FAILED"
            | "HTTP_ERROR"
            | "DAEMON_NOT_RUNNING"
    )
}
```

Guarded by `is_retryable_code_matches_method_for_every_variant` drift test that walks every distinct `CliError::error_code()` string (30 codes, incl. all 6 `CdpErrorCode` sub-codes) and asserts `err.is_retryable() == is_retryable_code(err.error_code())`.

## Classifier contract (`packages/cli/src/daemon/cdp_error_classifier.rs`)

Pure precedence: **message pattern** > **numeric fallback** > `Generic`.

| Input trigger | Output `CdpErrorCode` | Wire code |
|---|---|---|
| message contains `"no node with given id"` or `"cannot find context with specified id"` | `NodeNotFound` | `CDP_NODE_NOT_FOUND` |
| message contains `"could not compute box model"` | `NotInteractable` | `CDP_NOT_INTERACTABLE` |
| message contains `"navigation timeout"` | `NavTimeout` | `CDP_NAV_TIMEOUT` |
| message contains `"target closed"` or `"response channel dropped"` | `TargetClosed` | `CDP_TARGET_CLOSED` |
| numeric code in JSON-RPC reserved range `-32700..=-32000` | `ProtocolError` | `CDP_PROTOCOL_ERROR` |
| anything else | `Generic` | `CDP_GENERIC` |

`from_wire_code()` round-trips the 5 structured codes only (not `CDP_GENERIC`), matching the precedent set by `EVAL_ARGS_CONFLICT` in the eval error system — the CLI is an emitter of `_GENERIC` but does not treat it as an ingestible classification target.

## Factory API

```rust
// Classifier-driven (most common)
CliError::cdp_classified(reason, cdp_code) -> Self

// Site-override (caller knows the code better than the classifier)
CliError::cdp_with_code(code, reason, cdp_code) -> Self

// Builder for site-specific details (chainable, no-op on non-CdpError)
impl CliError { fn with_detail(self, key: &str, value: Value) -> Self }
```

## 24-site migration (commit A)

| File:line | Pattern | Factory used |
|---|---|---|
| `cdp.rs:149/172/216/271/303/342` (×6) | `.map_err(\|e\| CliError::CdpError(e.to_string()))` handshake | `cdp_classified(e.to_string(), None)` |
| `cdp.rs:161/286/359` (×3) | `CliError::CdpError("no response from CDP".to_string())` | `cdp_with_code(Generic, "no response from CDP", None)` |
| `cdp_session.rs:407/1140/1399` (×3) | `"response channel dropped"` | `cdp_with_code(TargetClosed, ..., None)` |
| `cdp_session.rs:417/1149/1411` (×3) | `format!("CDP error {code}: {message}")` | `cdp_classified(format!(...), Some(code))` |
| `cdp_session.rs:829` | `Target.attachToTarget` failure | `cdp_with_code(ProtocolError, ..., None)` |
| `cdp_session.rs:996` | no session for target | `cdp_with_code(TargetClosed, ..., None).with_detail("target_id", ...)` |
| `cdp_session.rs:1052` | non-numeric extension tab id | `cdp_with_code(Generic, ..., None).with_detail("target_id", ...)` |
| `cdp_session.rs:1074` | match-arm substring guard (load-bearing) | destructured `CdpError { reason: ref msg, .. }`, substring match retained (comment explains — widening to `code == TargetClosed` would enable unsafe re-attach loops) |
| `cdp_session.rs:1097` | no CDP session for target | `cdp_with_code(TargetClosed, ..., None).with_detail("target_id", ...)` |
| `browser/element.rs` (×2) | iframe resolution failure | `cdp_with_code(NodeNotFound, ..., None)` |
| `browser/session/start.rs` (×1) | `Target.createTarget` did not return `targetId` | `cdp_with_code(ProtocolError, ..., None)` |

## Envelope bridge (commit B)

- `main.rs` top-level error handler: `(code, hint)` 2-tuple → `(code, hint, retryable, details)` 4-tuple via `CliError::{error_code, hint, is_retryable, envelope_details}`, wired into `JsonEnvelope::error(...)` replacing hardcoded `(false, Value::Null)`.
- `main.rs` timeout branch: navigation commands (`goto`/`back`/`forward`/`reload` via new `is_navigation_command()` helper) emit `CDP_NAV_TIMEOUT` + `details.timeout_ms` on `--timeout` expiry instead of generic `TIMEOUT`.
- `output.rs::from_result`: hardcoded `CLOUD_CONNECTION_LOST | TIMEOUT` whitelist replaced with `crate::error::is_retryable_code(code)` — drift-guarded single source of truth.

## cdp_error_to_result passthrough (commit C)

The bridge helper `daemon::cdp_session::cdp_error_to_result()` was squashing structured `CliError::CdpError { .. }` back to the call-site `default_code` literal, collapsing the new taxonomy on every interaction path (click, element, drag, fill, etc.) that routes through `cdp_error_to_result(e, "CDP_ERROR")`. A new match arm builds `ActionResult::fatal_with_details(...)` from the error's own `error_code()` / `to_string()` / `hint()` / `envelope_details()`. `default_code` stays as the non-CDP fallback (e.g. eval.rs passes `EvalErrorCode::RuntimeError`).

Two unit tests guard both paths:
- `cdp_error_to_result_preserves_structured_code_over_default`
- `cdp_error_to_result_uses_default_code_for_non_cdp_errors`

## Ignored tests rationale

Three CDP E2E tests remain `#[ignore]` with `panic!("TODO(ACT-972): ...")` bodies:
- `cdp_node_not_found_returns_structured_code`
- `cdp_target_closed_returns_structured_code`
- `cdp_unclassified_falls_back_to_generic`

These are **pure stubs**, not disabled green tests. They require direct-CDP test infrastructure that does not yet exist (stale-node repro bypassing the `REF_STALE` short-circuit, deterministic target-closed trigger, deterministic user-facing non-matching CDP error). Un-ignoring would panic, not pass.

Follow-up ticket deferred by lead for post-merge: add direct-CDP test infra + un-ignore these stubs. The ACT-972 active contract (`cdp_nav_timeout_returns_structured_code` + `cdp_not_interactable_returns_structured_code`) passes deterministically and does not depend on the stubs.

## Verification

- `cargo fmt --check` ✅ clean
- `cargo clippy --all-targets -- -D warnings` ✅ clean
- `cargo test --lib` ✅ **471 passed / 0 failed** (includes drift guard, classifier tests, 2 new passthrough guards, all red-locked CDP tests)
- `RUN_E2E_TESTS=true cargo test --test e2e cdp_errors:: -- --test-threads=1` ✅ **2 passed / 0 failed / 3 ignored**
  - `cdp_nav_timeout_returns_structured_code` ✅
  - `cdp_not_interactable_returns_structured_code` ✅
  - 3 stubs ignored per rationale above

Pre-existing failures on `origin/main` flagged as unrelated: `help_cli::top_level_help_lists_setup_command`, `setup_cli::setup_json_with_env_api_key_does_not_persist_env_value`, `stealth_contract` ×3.

## Out-of-scope follow-ups

- ~15 hand-crafted `ActionResult::fatal("CDP_ERROR", ...)` sites across `cookies/`, `element.rs`, `interaction/`, and `observation/` still exist — these are direct `ActionResult` constructions (not via `CliError`) and are untouched by this PR. Separate follow-up ticket to unify them through the factory/bridge path.
- 3 CDP E2E stubs require direct-CDP test infrastructure — separate follow-up (see Ignored tests rationale).

## Test plan

- [x] Unit tests: classifier precedence, factories, drift guard, passthrough bridge
- [x] E2E: 2/2 active `cdp_errors::` tests green locally
- [ ] CI: full test suite green on GitHub Actions
- [ ] Cross-review: `@cli-roger-test` diff pass + Codex thread resolution