### PR TITLE
docs(cdp): document CDP_* structured error taxonomy

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -298,6 +298,21 @@ actionbook browser upload "<selector>" /path/to/file.pdf --session s1 --tab t1
   Each error includes `error.hint` and `error.details` with diagnostic fields (`reason`, and for fetch errors: `status`, `content_type`, `body_head`). Read `error.code` to branch on the failure class instead of parsing the message string.
 </Note>
 
+<Note>
+  Browser commands that interact with elements, navigate, or communicate via CDP return structured `CDP_*` error codes:
+
+  - `CDP_NODE_NOT_FOUND` — DOM node is stale or nonexistent (retryable: no)
+  - `CDP_NOT_INTERACTABLE` — element exists but can't be acted on (retryable: no)
+  - `CDP_NAV_TIMEOUT` — navigation or eval timeout (retryable: **yes**)
+  - `CDP_TARGET_CLOSED` — CDP target closed mid-command (retryable: **yes**)
+  - `CDP_PROTOCOL_ERROR` — CDP response malformed or missing fields (retryable: no)
+  - `CDP_GENERIC` — unclassified CDP error (retryable: no)
+
+  When `error.code` is a `CDP_*` code, `error.details` includes `reason` (raw CDP message) and `cdp_code` (upstream numeric code) when available. `CDP_NAV_TIMEOUT` also includes `timeout_ms`. Each code (except `CDP_GENERIC`) includes an actionable `error.hint`.
+
+  Some interaction paths still emit the legacy `CDP_ERROR` code — these are being migrated to the structured taxonomy (ACT-999).
+</Note>
+
 ### Wait
 
 ```bash

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -474,6 +474,29 @@ Extension mode connects via a local WebSocket bridge with the following guarante
   For `EVAL_RESPONSE_NOT_OK` and `EVAL_RESPONSE_NOT_JSON`, inspect `error.details.body_head` (first ≤256 chars of the response body) to decide whether to retry — a 403 challenge page is not worth retrying blindly.
 </Tip>
 
+## CDP Error Handling
+
+Browser commands that interact with elements, navigate, or communicate via CDP return structured `CDP_*` error codes. Branch on `error.code`:
+
+| Code | Meaning | Best practice | Retryable |
+|------|---------|---------------|-----------|
+| `CDP_NODE_NOT_FOUND` | DOM node is stale or nonexistent | Call `snapshot` to refresh node refs then retry | No |
+| `CDP_NOT_INTERACTABLE` | Element exists but can't be acted on | Scroll into view, wait for visibility, or dismiss overlays | No |
+| `CDP_NAV_TIMEOUT` | Navigation or eval timeout | Increase `--timeout` or verify URL reachability | Yes |
+| `CDP_TARGET_CLOSED` | Tab navigated away or session torn down mid-command | Start a fresh session or re-attach to the tab | Yes |
+| `CDP_PROTOCOL_ERROR` | CDP response malformed (`-32xxx` codes) | Inspect `details.reason` and `details.cdp_code` | No |
+| `CDP_GENERIC` | Unclassified CDP error (transport/parse) | *(no specific remediation)* | No |
+
+When `error.code` is a `CDP_*` code, `error.details` includes `reason` (raw CDP message) and `cdp_code` (upstream numeric code) when available. `CDP_NAV_TIMEOUT` also includes `timeout_ms`.
+
+<Tip>
+  `CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` set `error.retryable = true` in the JSON envelope — orchestrators can auto-retry these. All other CDP codes require caller intervention (e.g. refreshing snapshot refs, scrolling elements into view).
+</Tip>
+
+<Note>
+  Some interaction paths (cookies, screenshots, PDF, etc.) still emit the legacy `CDP_ERROR` code. These are being migrated to the structured `CDP_*` taxonomy (ACT-999).
+</Note>
+
 ## Troubleshooting
 
 <AccordionGroup>

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -141,6 +141,19 @@ actionbook browser wait navigation --session s1 --tab t1
 - `EVAL_STDIN_TTY` — `-` but stdin is a terminal. Pipe the expression.
 - `EVAL_STDIN_EMPTY` — stdin produced empty input. Verify the upstream pipeline.
 
+## CDP Error Handling
+
+Browser commands that interact with elements, navigate, or communicate via CDP return structured error codes — branch on `error.code`:
+
+- `CDP_NODE_NOT_FOUND` — DOM node is stale. Call `snapshot` to refresh refs then retry.
+- `CDP_NOT_INTERACTABLE` — element exists but can't be acted on. Scroll into view, wait for visibility, or dismiss overlays.
+- `CDP_NAV_TIMEOUT` — navigation timeout. Increase `--timeout` or verify URL reachability. **Retryable.**
+- `CDP_TARGET_CLOSED` — tab navigated away or session torn down mid-command. Start a fresh session. **Retryable.**
+- `CDP_PROTOCOL_ERROR` — CDP response malformed. Inspect `details.reason` and `details.cdp_code`.
+- `CDP_GENERIC` — unclassified CDP error (transport/parse). No specific remediation.
+
+`CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` are retryable (`error.retryable == true`). All other CDP codes require caller intervention before retrying. When `error.code` is a `CDP_*` code, `error.details` includes `reason` and `cdp_code` when available.
+
 ## Selectors
 
 Selectors should come from `actionbook browser snapshot` — not from prior knowledge or memory. Always snapshot first to get current refs, then use those refs to interact with the page.

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -175,6 +175,23 @@ Read `error.code` to branch on the failure class. For `EVAL_RESPONSE_NOT_OK` and
 
 **fill vs type:** `fill` clears the field and sets the value directly (like pasting). `type` simulates individual keystrokes and appends to existing content.
 
+**CDP error codes:** Browser commands that interact with elements, navigate, or communicate via CDP return structured error codes on failure. Branch on `error.code`:
+
+| Code | When | Hint | Retryable | `error.details` extras |
+|------|------|------|-----------|------------------------|
+| `CDP_NODE_NOT_FOUND` | DOM node is stale or nonexistent | Call `actionbook browser snapshot` to refresh node references then retry | No | `reason`, `cdp_code` |
+| `CDP_NOT_INTERACTABLE` | Element exists but can't be acted on (no box model) | Scroll it into view, wait for visibility, or dismiss overlays | No | `reason`, `cdp_code` |
+| `CDP_NAV_TIMEOUT` | Navigation or eval timeout | Increase `--timeout` or verify the target URL is reachable | Yes | `reason`, `cdp_code`, `timeout_ms` |
+| `CDP_TARGET_CLOSED` | CDP target closed mid-command (tab navigated away or session torn down) | Start a fresh session or re-attach to the tab | Yes | `reason`, `cdp_code` |
+| `CDP_PROTOCOL_ERROR` | CDP response malformed or missing expected fields (`-32xxx` error codes) | Inspect `details.reason` and `details.cdp_code` for the raw protocol error | No | `reason`, `cdp_code` |
+| `CDP_GENERIC` | CDP error that doesn't match any of the above (transport/parse) | *(no specific remediation)* | No | `reason` |
+
+`CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` are retryable (`error.retryable == true` in the JSON envelope). All other CDP codes require caller intervention before retrying.
+
+When `error.code` is a `CDP_*` code, `error.details` includes `reason` (raw CDP message) and `cdp_code` (upstream CDP numeric code, e.g. `-32000`) when available. Some sites include additional fields like `timeout_ms` for navigation timeouts.
+
+**Legacy `CDP_ERROR`**: Some interaction paths (cookies, screenshots, PDF, etc.) still emit the legacy `CDP_ERROR` code. These are being migrated to the structured `CDP_*` taxonomy (ACT-999).
+
 ## Observation
 
 ```bash


### PR DESCRIPTION
## Summary

- Syncs CDP error code taxonomy (ACT-972, PR #580) across all four doc surfaces
- Documents 6 structured `CDP_*` error codes: `CDP_NODE_NOT_FOUND`, `CDP_NOT_INTERACTABLE`, `CDP_NAV_TIMEOUT`, `CDP_TARGET_CLOSED`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC`
- Documents retryable behavior: `CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` set `error.retryable = true`
- Documents `error.details` schema: `reason`, `cdp_code`, and site-specific fields like `timeout_ms`
- Documents `error.hint` for all CDP_* codes (except `CDP_GENERIC`)
- Notes legacy `CDP_ERROR` migration status (ACT-999)

## Surfaces updated

- `skills/actionbook/references/command-reference.md` — full CDP error table with codes, hints, retryable, and details
- `docs/api-reference/cli.mdx` — Note block listing 6 CDP_* codes with retryable indicators
- `docs/guides/browser.mdx` — new "CDP Error Handling" section with best-practice table + Tip on retryability
- `skills/actionbook/SKILL.md` — new "CDP Error Handling" section with agent-facing guidance

## Source of truth

- `packages/cli/src/daemon/cdp_error_classifier.rs` — `CdpErrorCode` enum + `classify()` + hints
- `packages/cli/src/error.rs` — `is_retryable_code()` 9-code list

## Test plan

- [ ] Verify command-reference.md CDP error table renders correctly
- [ ] Verify cli.mdx Note block renders in docs site
- [ ] Verify browser.mdx CDP Error Handling section + Tip + Note renders
- [ ] Verify SKILL.md CDP Error Handling section parses correctly as skill context
- [ ] Cross-check all 6 codes, hints, and retryable flags against source of truth