### PR TITLE
[packages/actionbook-extension]feat: cloud mode + Clerk OAuth 2.1 PKCE (v0.5.0)

### DIFF
--- a/packages/actionbook-extension/CHANGELOG.md
+++ b/packages/actionbook-extension/CHANGELOG.md
@@ -1,5 +1,27 @@
 # @actionbookdev/extension
 
+## 0.5.0
+
+### Minor Changes
+
+- Add Cloud Mode: connect the Extension to Actionbook's edge server so remote AI agents can drive your Chrome over MCP without running the local CLI daemon.
+
+  - New popup toggle switches between **Local (CLI)** mode — identical to previous versions — and **Cloud** mode.
+  - In Cloud Mode, the Extension authenticates the user against `clerk.actionbook.dev` via OAuth 2.1 Authorization Code + PKCE, then maintains a WebSocket to `wss://edge.actionbook.dev/extension/ws`.
+  - Any MCP client pointed at `https://edge.actionbook.dev/mcp` (e.g., Claude Desktop, claude.ai Connectors, Codex) can now drive the user's Chrome, authenticated by the same user identity.
+  - Access tokens rotate automatically via refresh token; expired tokens trigger a silent refresh instead of forcing re-sign-in.
+  - Sign out from the popup clears all cloud tokens and disconnects.
+  - **Local Mode is unchanged and remains the default.** Existing Local Mode users upgrading from 0.4.x see no behavior change; no new permissions are requested.
+
+- Bump bridge protocol to `0.5.0` in the `hello` frame. CLI `EXTENSION_PROTOCOL_MIN_VERSION` remains `0.4.0`, so the new Extension is backward-compatible with older CLIs.
+
+- New files: `cloud-config.js` (public OAuth client id + Clerk endpoints), `callback.html` / `callback.js` (OAuth redirect handler). `callback.html` is listed in `web_accessible_resources` to allow the sign-in page to redirect back into the Extension.
+
+### Documentation
+
+- README.md — adds a "Cloud Mode" section with setup, Claude Desktop config example, and mode-switching instructions.
+- PRIVACY.md — substantially revised to describe the two operating modes separately. Cloud Mode data flows (Clerk authentication, device identifier, outbound WebSocket to `edge.actionbook.dev`, authorized agents, token refresh) are enumerated in a new Section 2B. Local Mode wording is unchanged.
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/actionbook-extension/PRIVACY.md
+++ b/packages/actionbook-extension/PRIVACY.md
@@ -1,67 +1,109 @@
 # Privacy Policy
 
 **Actionbook Browser Extension**
-**Last Updated: February 2026**
+**Last Updated: April 2026**
 
 ## 1. Introduction
 
 This Privacy Policy describes how the Actionbook browser extension ("the Extension"), developed by Actionbook ("we", "us", or "our"), handles information when you install and use the Extension. We are committed to protecting your privacy and being transparent about our data practices.
 
-The Extension serves as a local bridge between the Actionbook command-line interface (CLI) and your browser, enabling AI-powered browser automation on your machine.
+The Extension serves as a bridge between AI-powered automation agents and your browser. Starting with v0.5.0 it supports two independent modes:
+
+- **Local Mode** (default): the Extension talks only to the Actionbook command-line interface (CLI) on `localhost`. Nothing leaves your machine.
+- **Cloud Mode** (opt-in): the Extension authenticates you against Actionbook's sign-in provider (Clerk) and maintains an outbound WebSocket to `edge.actionbook.dev` so remote AI agents can drive your browser over MCP.
+
+Sections 2A and 2B describe the two modes in detail. Section 3 lists what we **never** do regardless of mode.
 
 ## 2. Information We Access
 
-The Extension accesses certain browser data solely to perform its core function of local browser automation. All data access occurs entirely on your local machine and is never transmitted to any external server.
+### 2A. Local Mode (default)
 
-### 2.1 Tab Information
+All data access in Local Mode occurs entirely on your local machine and is never transmitted to any external server. The Extension communicates exclusively with `localhost` (127.0.0.1) via WebSocket.
+
+#### 2A.1 Tab Information
 
 The Extension accesses browser tab metadata (tab ID, title, URL, active state, window ID) to allow the local CLI to identify, attach to, and interact with browser tabs. This information is used only within the local WebSocket connection between the Extension and the CLI running on your machine.
 
-### 2.2 Page Content via Chrome DevTools Protocol (CDP)
+#### 2A.2 Page Content via Chrome DevTools Protocol (CDP)
 
 When a tab is attached for automation, the Extension uses the Chrome Debugger API to execute CDP commands on the attached tab. This may include reading DOM structure, capturing screenshots, evaluating JavaScript, dispatching input events, and navigating pages. All CDP commands are filtered through a strict allowlist and tiered security model (see Section 5).
 
-### 2.3 Cookies
+#### 2A.3 Cookies
 
 The Extension can read, set, and remove browser cookies for specific URLs when instructed by the local CLI. Cookie operations on sensitive domains (banking, payment, government, healthcare) require explicit user confirmation through the Extension popup before execution.
 
-### 2.4 Bridge Token
+#### 2A.4 Bridge Token
 
 The Extension stores a short-lived authentication token ("bridge token") in `chrome.storage.local`. This token is generated locally by the Actionbook CLI and is used solely to authenticate the WebSocket connection between the Extension and the CLI on localhost. The token follows the format `abk_` followed by 32 hexadecimal characters.
 
-### 2.5 Bridge Port Configuration
+#### 2A.5 Bridge Port Configuration
 
 The Extension stores the WebSocket port number (default: 19222) in `chrome.storage.local` to connect to the local CLI bridge server.
 
+### 2B. Cloud Mode (opt-in, v0.5.0+)
+
+Cloud Mode is **opt-in and reversible**. You enable it by selecting "Cloud" in the popup; you can return to Local Mode at any time. When Cloud Mode is enabled, the Extension transmits a narrow set of data to Actionbook-operated and Clerk-operated infrastructure, strictly in the service of routing your chosen AI agents' browser automation commands to your browser.
+
+#### 2B.1 Authentication via Clerk
+
+Sign-in for Cloud Mode uses [Clerk](https://clerk.com) (at `clerk.actionbook.dev`) through a standard OAuth 2.1 Authorization Code flow with PKCE. During sign-in, Clerk receives and processes your authentication credentials (email and, depending on your sign-in method, password or third-party provider). **The Extension itself never sees your password** — authentication happens entirely in Clerk's hosted sign-in page.
+
+After sign-in, Clerk returns a short-lived **access token** (a signed JWT) and optionally a **refresh token**. The Extension stores these in `chrome.storage.local`; they are used only to authenticate subsequent connections to `edge.actionbook.dev`.
+
+#### 2B.2 Device Identifier
+
+On first Cloud Mode sign-in, the Extension generates a random per-install device ID (`d_` + UUID) and stores it in `chrome.storage.local`. The device ID is reported to the edge server during WebSocket handshake to label your connection (useful if you later use the Extension across multiple machines). It does not identify you personally.
+
+#### 2B.3 Outbound WebSocket to edge.actionbook.dev
+
+In Cloud Mode the Extension maintains a WebSocket connection to `wss://edge.actionbook.dev/extension/ws`. Over this connection flow the same categories of data described in Sections 2A.1–2A.3 (tab metadata, CDP commands and their results, cookie operations), **but only when an authenticated AI agent explicitly invokes a tool that requires them**. The edge server forwards those commands to your Extension and relays the responses back to the requesting agent.
+
+Commands are processed ephemerally: the edge server does not persist CDP command content beyond the lifetime of the in-flight request-response cycle.
+
+#### 2B.4 Authorized AI Agents
+
+Agents that can send commands to your browser must present a valid Clerk-issued access token whose subject matches your user ID. In practice this means only agents you have explicitly authorized (e.g., by adding an MCP Connector in Claude Desktop and completing its OAuth prompt) can drive your browser. You can revoke any agent's session from your account settings on actionbook.dev or through Clerk's session management.
+
+#### 2B.5 Token Refresh and Expiry
+
+Access tokens expire quickly (minutes to an hour depending on Clerk configuration). The Extension uses the refresh token, if available, to transparently obtain new access tokens without re-prompting you. If refresh fails or the session has been revoked, the Extension returns to the "sign-in required" state and disconnects until you sign in again.
+
 ## 3. Information We Do NOT Collect
 
-We want to be explicit about what we do not do:
+Regardless of mode, the Extension does **not**:
 
-- **No data collection.** We do not collect, record, or aggregate any personal information, browsing history, page content, cookies, or any other user data.
-- **No external transmission.** No data accessed by the Extension is ever sent to any external server, cloud service, or third-party endpoint. The Extension communicates exclusively with `localhost` (127.0.0.1) via WebSocket.
-- **No analytics or tracking.** The Extension contains no analytics, telemetry, crash reporting, or usage tracking of any kind.
-- **No user accounts.** The Extension does not require or support user accounts, sign-ins, or registration.
-- **No advertising.** The Extension contains no advertising, ad networks, or monetization mechanisms.
-- **No third-party sharing.** No data is shared with, sold to, or made available to any third party.
+- **Collect, aggregate, or sell personal data.** We do not maintain analytics, aggregate browsing history, or sell user information to third parties.
+- **Include analytics, telemetry, or crash reporting** of any kind.
+- **Include advertising or monetization mechanisms.**
+- **Read or transmit page content** beyond what AI agents explicitly request through tools you have authorized.
+
+**Mode-specific clarifications:**
+
+- In **Local Mode**, no data accessed by the Extension is ever sent to any external server. The WebSocket connection is restricted to `localhost` (127.0.0.1).
+- In **Cloud Mode**, the only external destinations are `clerk.actionbook.dev` (during sign-in) and `edge.actionbook.dev` (during active operation). Data flows to either destination are listed exhaustively in Section 2B.
 
 ## 4. Data Storage and Retention
 
 ### 4.1 Local Storage Only
 
-All data stored by the Extension resides in `chrome.storage.local` on your device. The only items stored are:
+All data stored by the Extension resides in `chrome.storage.local` on your device. The items stored are:
 
-| Data Item     | Purpose                                      | Retention                     |
-|---------------|----------------------------------------------|-------------------------------|
-| `bridgeToken` | Authenticate local WebSocket connection       | Cleared on disconnect or expiry |
-| `bridgePort`  | WebSocket port for local CLI bridge           | Persists until changed         |
+| Data Item                | Mode  | Purpose                                                | Retention                                          |
+|--------------------------|-------|--------------------------------------------------------|----------------------------------------------------|
+| `bridgeToken`            | Local | Authenticate local WebSocket connection                | Cleared on disconnect or expiry                    |
+| `bridgePort`             | Local | WebSocket port for local CLI bridge                    | Persists until changed                             |
+| `mode`                   | Both  | User's selected mode (`"local"` or `"cloud"`)          | Persists until changed                             |
+| `cloudToken`             | Cloud | OAuth access token (short-lived Clerk JWT)             | Cleared on sign-out or on-demand refresh rotation |
+| `cloudRefreshToken`      | Cloud | OAuth refresh token (used to rotate access tokens)     | Cleared on sign-out                                |
+| `cloudTokenExpiresAt`    | Cloud | Expected access-token expiry timestamp                 | Cleared on sign-out                                |
+| `deviceId`               | Cloud | Per-install device identifier                          | Persists across sign-outs to stabilize device naming |
+| `cloudEndpoint`          | Cloud | Edge server WebSocket URL (default `wss://edge.actionbook.dev/extension/ws`) | Persists; only changes if you override it        |
+| `pkce:<state>`           | Cloud | One-shot PKCE verifier, written during sign-in         | Deleted immediately after token exchange           |
 
 ### 4.2 Token Expiration
 
-Bridge tokens expire automatically after 30 minutes of inactivity. When a token expires, the Extension clears it from local storage and requires re-authentication with the CLI. The Extension also clears the stored token when:
-
-- The WebSocket connection is lost
-- The server reports the token as expired or invalid
-- A handshake with the bridge server fails
+- **Local Mode bridge tokens** expire automatically after 30 minutes of inactivity, or when the WebSocket connection, handshake, or server-side validity check fails.
+- **Cloud Mode access tokens** are short-lived (typically minutes to one hour). The Extension refreshes them automatically using the refresh token; if refresh fails, the Extension clears the access token and returns to a signed-out state.
 
 ### 4.3 No Persistent Data
 
@@ -87,9 +129,10 @@ Commands that perform high-risk operations (e.g., setting cookies, deleting cook
 
 - **CDP Command Allowlist**: Only a curated set of Chrome DevTools Protocol methods are permitted. Any method not on the allowlist is rejected.
 - **Sensitive Domain Detection**: Domains matching patterns for banking, payment, government, and healthcare sites trigger elevated security requirements.
-- **Token Validation**: All tokens are validated against a strict format before acceptance.
-- **Popup-Only Token Input**: Token changes are accepted only from the Extension's own popup, verified by sender identity.
-- **Localhost-Only Communication**: The WebSocket connection is restricted to `localhost` (127.0.0.1).
+- **Token Format Validation**: All tokens are validated against strict formats before acceptance.
+- **Popup-Only Configuration Changes**: Mode switches and token updates are accepted only from the Extension's own popup or sign-in callback page, verified by sender identity.
+- **Localhost-Only Communication in Local Mode**: The WebSocket connection is restricted to `localhost` (127.0.0.1).
+- **HTTPS/WSS-Only External Communication in Cloud Mode**: All external traffic uses TLS (WSS for the WebSocket, HTTPS for OAuth endpoints).
 
 ## 6. Permissions Justification
 
@@ -98,10 +141,11 @@ The Extension requests the following Chrome permissions, each necessary for its 
 | Permission        | Why It Is Needed                                                      |
 |-------------------|-----------------------------------------------------------------------|
 | `debugger`        | Attach Chrome DevTools Protocol to tabs for browser automation         |
-| `tabs`            | List and query browser tabs for the local CLI to select targets        |
+| `tabs`            | List and query browser tabs so AI agents can select automation targets |
+| `tabGroups`       | Group tabs opened by the Extension into a dedicated Chrome tab group   |
 | `activeTab`       | Access the currently active tab for automation commands                 |
 | `offscreen`       | Keep the service worker alive for persistent WebSocket connection      |
-| `storage`         | Store local connection state for bridge communication                   |
+| `storage`         | Store local connection state (mode, tokens, device ID)                 |
 | `cookies`         | Read and manage cookies for web automation tasks                       |
 | `<all_urls>`      | Enable automation on any website the user chooses to automate          |
 

--- a/packages/actionbook-extension/README.md
+++ b/packages/actionbook-extension/README.md
@@ -78,6 +78,49 @@ If you need to switch modes later, run `actionbook setup` again.
 
 See the full command reference in the [main README](../../README.md).
 
+## Cloud Mode (v0.5.0+)
+
+Cloud Mode lets remote AI agents (Claude Desktop, Codex, claude.ai Connectors, etc.) drive your Chrome through the Actionbook edge server — **without running the local CLI daemon**. The extension connects via WebSocket to `edge.actionbook.dev`, authenticated by a short-lived OAuth token.
+
+Local Mode (the default) is unchanged and remains fully offline-capable.
+
+### Setup
+
+1. Click the Actionbook toolbar icon → popup
+2. Switch the **Mode** dropdown from **Local (CLI)** to **Cloud**
+3. Click **Sign in to Actionbook**
+4. A new tab opens the Actionbook sign-in page (Clerk) → sign in → approve the authorization prompt
+5. Back in the popup, the **Bridge** indicator turns green and shows your device ID
+
+Any MCP client pointed at `https://edge.actionbook.dev/mcp` can now drive your Chrome. No CLI daemon needed.
+
+### Example: Claude Desktop
+
+```jsonc
+// ~/Library/Application Support/Claude/claude_desktop_config.json  (macOS)
+{
+  "mcpServers": {
+    "actionbook": {
+      "url": "https://edge.actionbook.dev/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop → it will walk through OAuth sign-in on first use → the `actionbook` tool becomes available in your conversations.
+
+### Switching back to Local
+
+Popup → **Mode** dropdown → **Local (CLI)**. The extension reconnects to `ws://127.0.0.1:19222` as in previous versions. No sign-out required.
+
+### Sign out of Cloud Mode
+
+Popup (while in Cloud mode) → **Sign out**. Clears the stored access/refresh tokens and disconnects. To revoke the session server-side as well, use your account settings on actionbook.dev.
+
+### Privacy summary
+
+In Cloud Mode, CDP commands from your authorized AI agents transit `edge.actionbook.dev` (Cloudflare Workers + Durable Objects). The extension holds only a short-lived Clerk-signed JWT in `chrome.storage.local`; no passwords or long-lived credentials ever leave your machine. See [PRIVACY.md](./PRIVACY.md) for the detailed data-flow breakdown.
+
 ## Releasing a new version
 
 The extension has its own independent release cycle, separate from the CLI.

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -93,6 +93,36 @@ const SENSITIVE_DOMAIN_PATTERNS = [
 ];
 
 let ws = null;
+
+// Cleanly tear down the current WebSocket before reconnecting. Without this,
+// `ws.close()` fires the old socket's onclose asynchronously, which unconditionally
+// mutates module-level state (`ws = null`, `connectionState`, reconnect polling).
+// If a new `connect()` has already created a replacement socket by then, the
+// stale onclose clobbers the new `ws` reference and drives the state machine
+// backwards — especially nasty during mode switches / auth updates / sign-out,
+// all of which close-then-reconnect back-to-back.
+//
+// Solution: detach all handlers first so the old socket's death is silent, then
+// close and null out `ws`. Callers free to call `connect()` immediately after.
+function detachAndCloseWs(reason) {
+  if (!ws) return;
+  const oldWs = ws;
+  ws = null;
+  try {
+    oldWs.onopen = null;
+    oldWs.onmessage = null;
+    oldWs.onerror = null;
+    oldWs.onclose = null;
+  } catch (_) {
+    /* ignore */
+  }
+  try {
+    oldWs.close(1000, reason || "replaced");
+  } catch (_) {
+    /* ignore */
+  }
+}
+
 // Set<number> of Chrome tab IDs that the extension currently has
 // chrome.debugger attached to. Multiple tabs can be attached concurrently;
 // every CDP command from the CLI must carry its target `tabId` field.
@@ -203,7 +233,6 @@ async function refreshCloudTokenIfNeeded({ force = false } = {}) {
     "cloudRefreshToken",
     "cloudTokenExpiresAt",
   ]);
-  if (!cloudRefreshToken) return cloudToken || null;
 
   // Refresh 60s before expiry to avoid mid-connect expiry.
   const REFRESH_SKEW_MS = 60_000;
@@ -211,7 +240,18 @@ async function refreshCloudTokenIfNeeded({ force = false } = {}) {
     force ||
     !cloudToken ||
     (typeof cloudTokenExpiresAt === "number" && Date.now() + REFRESH_SKEW_MS >= cloudTokenExpiresAt);
-  if (!needsRefresh) return cloudToken;
+
+  if (!needsRefresh) {
+    // Token still fresh — return it so callers (pre-flight connect) can short-circuit.
+    // A missing refresh_token is fine in this branch: we're not refreshing anyway.
+    return cloudToken;
+  }
+
+  // From here on we actually need a new token. Without a refresh_token we can't
+  // get one; return null so callers (especially the invalid_token path) can
+  // transition to sign-in-required instead of retrying with the same rejected
+  // access token indefinitely.
+  if (!cloudRefreshToken) return null;
 
   // cloud-config.js constants are not loaded in the service worker (it's a plain
   // worker, not a module + no importScripts in MV3). Hardcode here; if you
@@ -435,7 +475,10 @@ async function connect() {
         clearTimeout(handshakeTimer);
         handshakeTimer = null;
       }
-      if (ws) { ws.close(); ws = null; }
+      // Detach handlers before close — the invalid_token branch below will
+      // await a token refresh and then call connect(), and we don't want the
+      // old socket's onclose to race with the new one mid-refresh.
+      detachAndCloseWs("hello_error");
 
       if (msg.error === "invalid_token") {
         // Cloud mode: try a one-shot refresh before giving up. If refresh
@@ -1259,10 +1302,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         clearTimeout(reconnectTimer);
         reconnectTimer = null;
       }
-      if (ws) {
-        try { ws.close(); } catch (_) {}
-        ws = null;
-      }
+      // Must detach handlers before closing — otherwise the old socket's
+      // onclose races with the new connection below.
+      detachAndCloseWs("mode_switch");
       connect();
     });
     return false;
@@ -1274,10 +1316,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     wasReplaced = false;
     retryCount = 0;
     reconnectDelay = RECONNECT_BASE_MS;
-    if (ws) {
-      try { ws.close(); } catch (_) {}
-      ws = null;
-    }
+    detachAndCloseWs("token_updated");
     connect();
     return false;
   }
@@ -1288,10 +1327,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     chrome.storage.local.remove(
       ["cloudToken", "cloudRefreshToken", "cloudTokenExpiresAt"],
       () => {
-        if (ws) {
-          try { ws.close(); } catch (_) {}
-          ws = null;
-        }
+        detachAndCloseWs("sign_out");
         connectionState = "pairing_required";
         logStateTransition("pairing_required", "user signed out");
         broadcastState();

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -189,6 +189,68 @@ async function getEffectiveBridgeUrl() {
   return cfg.url;
 }
 
+// Try to refresh the cloud access token using the stored refresh_token.
+// Returns the new access_token (and persists it), or null if refresh failed
+// (missing refresh_token, network error, Clerk rejection — caller should then
+// force the user through sign-in again).
+//
+// Called opportunistically before a connect when the stored token is close to
+// or past expiry, and reactively if a connect attempt fails with auth-related
+// errors.
+async function refreshCloudTokenIfNeeded({ force = false } = {}) {
+  const { cloudToken, cloudRefreshToken, cloudTokenExpiresAt } = await chrome.storage.local.get([
+    "cloudToken",
+    "cloudRefreshToken",
+    "cloudTokenExpiresAt",
+  ]);
+  if (!cloudRefreshToken) return cloudToken || null;
+
+  // Refresh 60s before expiry to avoid mid-connect expiry.
+  const REFRESH_SKEW_MS = 60_000;
+  const needsRefresh =
+    force ||
+    !cloudToken ||
+    (typeof cloudTokenExpiresAt === "number" && Date.now() + REFRESH_SKEW_MS >= cloudTokenExpiresAt);
+  if (!needsRefresh) return cloudToken;
+
+  // cloud-config.js constants are not loaded in the service worker (it's a plain
+  // worker, not a module + no importScripts in MV3). Hardcode here; if you
+  // change the Clerk tenant, update both places.
+  const CLERK_TOKEN_URL = "https://clerk.actionbook.dev/oauth/token";
+  const CLERK_CLIENT_ID = "HP91Xj6adCm3TjPr";
+
+  try {
+    const res = await fetch(CLERK_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "refresh_token",
+        refresh_token: cloudRefreshToken,
+        client_id: CLERK_CLIENT_ID,
+      }),
+    });
+    if (!res.ok) {
+      debugLog("[actionbook] refresh failed:", res.status, await res.text());
+      return null;
+    }
+    const tokens = await res.json();
+    if (!tokens.access_token) return null;
+
+    const update = { cloudToken: tokens.access_token };
+    if (typeof tokens.refresh_token === "string") {
+      update.cloudRefreshToken = tokens.refresh_token;
+    }
+    if (typeof tokens.expires_in === "number") {
+      update.cloudTokenExpiresAt = Date.now() + tokens.expires_in * 1000;
+    }
+    await chrome.storage.local.set(update);
+    return tokens.access_token;
+  } catch (err) {
+    debugLog("[actionbook] refresh error:", err?.message || err);
+    return null;
+  }
+}
+
 // Lazily generate and persist a per-install deviceId (only used in cloud mode).
 async function ensureDeviceId() {
   const { deviceId } = await chrome.storage.local.get("deviceId");
@@ -237,7 +299,17 @@ async function connect() {
   logStateTransition("connecting");
   broadcastState();
 
-  const cfg = await getConnectionConfig();
+  let cfg = await getConnectionConfig();
+
+  // Cloud mode: rotate expiring tokens before we even try the WS handshake.
+  // `refreshCloudTokenIfNeeded` is a no-op when the token is fresh. If it
+  // returns null we fall through to the "no token" branch and wait for sign-in.
+  if (cfg.mode === "cloud") {
+    const refreshed = await refreshCloudTokenIfNeeded();
+    if (refreshed && refreshed !== cfg.token) {
+      cfg = await getConnectionConfig();
+    }
+  }
 
   // Cloud mode requires a token. If missing, wait for popup-driven login
   // instead of retrying pointlessly. State "pairing_required" already signals
@@ -366,10 +438,25 @@ async function connect() {
       if (ws) { ws.close(); ws = null; }
 
       if (msg.error === "invalid_token") {
-        connectionState = "disconnected";
-        logStateTransition("disconnected", "invalid token");
-        broadcastState();
-        startBridgePolling();
+        // Cloud mode: try a one-shot refresh before giving up. If refresh
+        // succeeds, kick off a reconnect with the fresh token. If it fails
+        // we drop into pairing_required so popup prompts the user to sign in
+        // again.
+        refreshCloudTokenIfNeeded({ force: true }).then((fresh) => {
+          if (fresh) {
+            connectionState = "disconnected";
+            logStateTransition("disconnected", "token refreshed, reconnecting");
+            broadcastState();
+            retryCount = 0;
+            reconnectDelay = RECONNECT_BASE_MS;
+            connect();
+          } else {
+            connectionState = "pairing_required";
+            logStateTransition("pairing_required", "invalid token, refresh failed");
+            broadcastState();
+            startBridgePolling();
+          }
+        });
       } else {
         connectionState = "failed";
         logStateTransition("failed", msg.message || "handshake rejected by server");
@@ -1194,18 +1281,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     connect();
     return false;
   }
-  // Cloud mode: popup asks to sign out — clear token and disconnect.
+  // Cloud mode: popup asks to sign out — clear token + refresh token + expiry
+  // and disconnect so a subsequent Sign in starts a fresh OAuth flow.
   if (message.type === "cloud_sign_out") {
     if (!isSenderPopup(sender)) return false;
-    chrome.storage.local.remove(["cloudToken"], () => {
-      if (ws) {
-        try { ws.close(); } catch (_) {}
-        ws = null;
-      }
-      connectionState = "pairing_required";
-      logStateTransition("pairing_required", "user signed out");
-      broadcastState();
-    });
+    chrome.storage.local.remove(
+      ["cloudToken", "cloudRefreshToken", "cloudTokenExpiresAt"],
+      () => {
+        if (ws) {
+          try { ws.close(); } catch (_) {}
+          ws = null;
+        }
+        connectionState = "pairing_required";
+        logStateTransition("pairing_required", "user signed out");
+        broadcastState();
+      },
+    );
     return false;
   }
   return false;

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -485,21 +485,27 @@ async function connect() {
         // succeeds, kick off a reconnect with the fresh token. If it fails
         // we drop into pairing_required so popup prompts the user to sign in
         // again.
-        refreshCloudTokenIfNeeded({ force: true }).then((fresh) => {
-          if (fresh) {
-            connectionState = "disconnected";
-            logStateTransition("disconnected", "token refreshed, reconnecting");
-            broadcastState();
-            retryCount = 0;
-            reconnectDelay = RECONNECT_BASE_MS;
-            connect();
-          } else {
-            connectionState = "pairing_required";
-            logStateTransition("pairing_required", "invalid token, refresh failed");
-            broadcastState();
-            startBridgePolling();
-          }
-        });
+        const fresh = await refreshCloudTokenIfNeeded({ force: true });
+        if (fresh) {
+          connectionState = "disconnected";
+          logStateTransition("disconnected", "token refreshed, reconnecting");
+          broadcastState();
+          retryCount = 0;
+          reconnectDelay = RECONNECT_BASE_MS;
+          connect();
+        } else {
+          // Terminal auth failure: clear the cached token bundle so polling
+          // can't keep retrying with credentials the server already rejected.
+          await chrome.storage.local.remove([
+            "cloudToken",
+            "cloudRefreshToken",
+            "cloudTokenExpiresAt",
+          ]);
+          connectionState = "pairing_required";
+          logStateTransition("pairing_required", "invalid token, refresh failed");
+          broadcastState();
+          startBridgePolling();
+        }
       } else {
         connectionState = "failed";
         logStateTransition("failed", msg.message || "handshake rejected by server");

--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -1,7 +1,12 @@
 // Actionbook Browser Bridge - Background Service Worker
-// Connects to the CLI bridge server via WebSocket and executes browser commands
+// Connects to either the local CLI bridge (`local` mode) or the Cloudflare
+// edge-server (`cloud` mode) via WebSocket and executes browser commands.
+//
+// Mode is read from chrome.storage.local.mode; default "local" preserves
+// backward compatibility with pre-0.5 behavior.
 
-const BRIDGE_URL = "ws://127.0.0.1:19222";
+const LOCAL_BRIDGE_URL = "ws://127.0.0.1:19222";
+const DEFAULT_CLOUD_ENDPOINT = "wss://edge.actionbook.dev/extension/ws";
 const RECONNECT_BASE_MS = 1000;
 const RECONNECT_MAX_MS = 30000;
 const MAX_RETRIES = 8;
@@ -9,6 +14,9 @@ const BRIDGE_PROBE_TIMEOUT_MS = 750;
 
 const HANDSHAKE_TIMEOUT_MS = 2000;
 const L3_CONFIRM_TIMEOUT_MS = 30000;
+
+// Protocol version reported in the hello frame. Bumped to 0.5.0 for cloud mode.
+const PROTOCOL_VERSION = "0.5.0";
 
 // --- Tab Group Config ---
 // All tabs opened by Actionbook (via Extension.createTab or the reuse-empty-tab
@@ -155,8 +163,41 @@ function logStateTransition(newState, detail) {
   }
 }
 
+// Resolve the current connection mode + URL from chrome.storage.local.
+// Returns { mode, url, token, deviceId } — token/deviceId are undefined in local mode.
+// Default mode is "local" to preserve pre-0.5 behavior for existing installs.
+async function getConnectionConfig() {
+  const { mode, cloudEndpoint, cloudToken, deviceId } = await chrome.storage.local.get([
+    "mode",
+    "cloudEndpoint",
+    "cloudToken",
+    "deviceId",
+  ]);
+  if (mode === "cloud") {
+    return {
+      mode: "cloud",
+      url: cloudEndpoint || DEFAULT_CLOUD_ENDPOINT,
+      token: cloudToken || null,
+      deviceId: deviceId || null,
+    };
+  }
+  return { mode: "local", url: LOCAL_BRIDGE_URL, token: null, deviceId: null };
+}
+
 async function getEffectiveBridgeUrl() {
-  return BRIDGE_URL;
+  const cfg = await getConnectionConfig();
+  return cfg.url;
+}
+
+// Lazily generate and persist a per-install deviceId (only used in cloud mode).
+async function ensureDeviceId() {
+  const { deviceId } = await chrome.storage.local.get("deviceId");
+  if (deviceId) return deviceId;
+  const fresh = (self.crypto && typeof self.crypto.randomUUID === "function")
+    ? `d_${self.crypto.randomUUID()}`
+    : `d_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+  await chrome.storage.local.set({ deviceId: fresh });
+  return fresh;
 }
 
 function getBridgeHealthUrl(bridgeUrl) {
@@ -196,16 +237,31 @@ async function connect() {
   logStateTransition("connecting");
   broadcastState();
 
+  const cfg = await getConnectionConfig();
+
+  // Cloud mode requires a token. If missing, wait for popup-driven login
+  // instead of retrying pointlessly. State "pairing_required" already signals
+  // this in the popup UI.
+  if (cfg.mode === "cloud" && !cfg.token) {
+    connectionState = "pairing_required";
+    logStateTransition("pairing_required", "cloud mode without token");
+    broadcastState();
+    return;
+  }
+
   try {
-    const bridgeUrl = await getEffectiveBridgeUrl();
-    if (!(await canReachBridge(bridgeUrl))) {
+    // Skip healthz probe in cloud mode: the endpoint is always up (Cloudflare
+    // hosted) and HEAD /healthz may not be implemented. Go straight to WS.
+    if (cfg.mode === "local" && !(await canReachBridge(cfg.url))) {
       connectionState = "disconnected";
       logStateTransition("disconnected", "bridge not listening");
       broadcastState();
       scheduleReconnect();
       return;
     }
-    ws = new WebSocket(bridgeUrl);
+    ws = cfg.mode === "cloud"
+      ? new WebSocket(cfg.url, ["bearer", cfg.token])
+      : new WebSocket(cfg.url);
   } catch (err) {
     connectionState = "disconnected";
     logStateTransition("disconnected", "WebSocket constructor error");
@@ -217,17 +273,20 @@ async function connect() {
   handshakeCompleted = false;
   let wsOpened = false;
 
-  ws.onopen = () => {
+  ws.onopen = async () => {
     wsOpened = true;
-    // Send hello handshake (tokenless - server validates via origin + extension ID).
-    // Protocol 0.4.0 narrows `Extension.listTabs` to Actionbook-managed tabs
-    // (debugger-attached OR in the "Actionbook" tab group), making session
-    // ownership first-class instead of returning every open Chrome tab.
-    wsSend({
+    // Local mode: tokenless, origin-validated. Cloud mode: token already went
+    // up via Sec-WebSocket-Protocol at upgrade; hello is used to report the
+    // per-install deviceId for device registry.
+    const hello = {
       type: "hello",
       role: "extension",
-      version: "0.4.0",
-    });
+      version: PROTOCOL_VERSION,
+    };
+    if (cfg.mode === "cloud") {
+      hello.deviceId = await ensureDeviceId();
+    }
+    wsSend(hello);
 
     // Start handshake timeout - if no hello_ack within this window, treat as auth failure
     handshakeTimer = setTimeout(() => {
@@ -1016,6 +1075,17 @@ function isSenderPopup(sender) {
   );
 }
 
+// Validate that a message sender is the extension's own callback page
+// (callback.html is loaded from chrome-extension://<id>/callback.html after
+// the OAuth module redirects the user back).
+function isSenderCallback(sender) {
+  return (
+    sender.id === chrome.runtime.id &&
+    sender.url &&
+    sender.url.includes("callback.html")
+  );
+}
+
 // Listen for messages from popup and offscreen document
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "getState") {
@@ -1087,6 +1157,55 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (!isSenderPopup(sender)) return false;
     groupingEnabled = message.enabled === true;
     chrome.storage.local.set({ groupTabs: groupingEnabled });
+    return false;
+  }
+  // Cloud mode: popup asks to switch between local / cloud. We close the
+  // current WS and reconnect with the new config.
+  if (message.type === "setMode") {
+    if (!isSenderPopup(sender)) return false;
+    const mode = message.mode === "cloud" ? "cloud" : "local";
+    chrome.storage.local.set({ mode }, () => {
+      wasReplaced = false;
+      retryCount = 0;
+      reconnectDelay = RECONNECT_BASE_MS;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      if (ws) {
+        try { ws.close(); } catch (_) {}
+        ws = null;
+      }
+      connect();
+    });
+    return false;
+  }
+  // Cloud mode: callback.html received a token from the OAuth redirect and
+  // stashed it into storage. Trigger a reconnect so we pick it up.
+  if (message.type === "cloud_auth_updated") {
+    if (!isSenderCallback(sender) && !isSenderPopup(sender)) return false;
+    wasReplaced = false;
+    retryCount = 0;
+    reconnectDelay = RECONNECT_BASE_MS;
+    if (ws) {
+      try { ws.close(); } catch (_) {}
+      ws = null;
+    }
+    connect();
+    return false;
+  }
+  // Cloud mode: popup asks to sign out — clear token and disconnect.
+  if (message.type === "cloud_sign_out") {
+    if (!isSenderPopup(sender)) return false;
+    chrome.storage.local.remove(["cloudToken"], () => {
+      if (ws) {
+        try { ws.close(); } catch (_) {}
+        ws = null;
+      }
+      connectionState = "pairing_required";
+      logStateTransition("pairing_required", "user signed out");
+      broadcastState();
+    });
     return false;
   }
   return false;

--- a/packages/actionbook-extension/callback.html
+++ b/packages/actionbook-extension/callback.html
@@ -35,6 +35,7 @@
       <div id="msg">Processing sign-in...</div>
       <div id="detail" class="status"></div>
     </div>
+    <script src="cloud-config.js"></script>
     <script src="callback.js"></script>
   </body>
 </html>

--- a/packages/actionbook-extension/callback.html
+++ b/packages/actionbook-extension/callback.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Actionbook · Sign in</title>
+    <style>
+      body {
+        font-family: -apple-system, system-ui, sans-serif;
+        margin: 0;
+        padding: 40px 24px;
+        background: #fafafa;
+        color: #111;
+      }
+      .box {
+        max-width: 420px;
+        margin: 0 auto;
+        padding: 24px;
+        background: #fff;
+        border: 1px solid #e5e5e5;
+        border-radius: 8px;
+      }
+      .status {
+        font-size: 14px;
+        margin-top: 8px;
+        color: #555;
+      }
+      .error {
+        color: #b00020;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="box">
+      <h2 style="margin: 0 0 12px">Actionbook</h2>
+      <div id="msg">Processing sign-in...</div>
+      <div id="detail" class="status"></div>
+    </div>
+    <script src="callback.js"></script>
+  </body>
+</html>

--- a/packages/actionbook-extension/callback.js
+++ b/packages/actionbook-extension/callback.js
@@ -1,0 +1,55 @@
+// Invoked when the OAuth module redirects back to
+//   chrome-extension://<EXTENSION_ID>/callback.html?token=<token>[&deviceId=<id>]
+// or on failure:
+//   chrome-extension://<EXTENSION_ID>/callback.html?error=<code>[&error_description=<msg>]
+//
+// We read the query params, persist the token to chrome.storage.local,
+// notify background.js so it reconnects with the new token, then close.
+
+const msgEl = document.getElementById("msg");
+const detailEl = document.getElementById("detail");
+
+function showError(code, detail) {
+  msgEl.textContent = `Sign-in failed: ${code}`;
+  msgEl.className = "error";
+  if (detail) detailEl.textContent = detail;
+}
+
+function showSuccess() {
+  msgEl.textContent = "Signed in. You can close this tab.";
+}
+
+(async () => {
+  const params = new URLSearchParams(location.search);
+  const token = params.get("token");
+  const deviceIdParam = params.get("deviceId");
+  const error = params.get("error");
+  const errorDescription = params.get("error_description");
+
+  if (error) {
+    showError(error, errorDescription);
+    return;
+  }
+
+  if (!token) {
+    showError("missing_token", "The redirect did not include a token parameter.");
+    return;
+  }
+
+  // Persist and signal background.
+  const update = { cloudToken: token, mode: "cloud" };
+  if (deviceIdParam) update.deviceId = deviceIdParam;
+
+  try {
+    await chrome.storage.local.set(update);
+    await chrome.runtime.sendMessage({ type: "cloud_auth_updated" });
+  } catch (err) {
+    showError("storage_failed", err?.message || String(err));
+    return;
+  }
+
+  showSuccess();
+  setTimeout(() => {
+    try { window.close(); } catch (_) {}
+  }, 1500);
+})();

--- a/packages/actionbook-extension/callback.js
+++ b/packages/actionbook-extension/callback.js
@@ -1,10 +1,16 @@
-// Invoked when the OAuth module redirects back to
-//   chrome-extension://<EXTENSION_ID>/callback.html?token=<token>[&deviceId=<id>]
-// or on failure:
+// Invoked when Clerk redirects back to
+//   chrome-extension://<EXTENSION_ID>/callback.html?code=<code>&state=<state>
+// (success) or
 //   chrome-extension://<EXTENSION_ID>/callback.html?error=<code>[&error_description=<msg>]
+// (failure).
 //
-// We read the query params, persist the token to chrome.storage.local,
-// notify background.js so it reconnects with the new token, then close.
+// Flow:
+//   1. Pull ?code + ?state from URL
+//   2. Look up the PKCE verifier we stashed under pkce:<state> when kicking off
+//      the authorize request in popup.js
+//   3. POST to Clerk's /oauth/token with code + code_verifier → access_token
+//      (+ refresh_token if offline_access scope was granted)
+//   4. Persist to chrome.storage.local and tell background.js to reconnect
 
 const msgEl = document.getElementById("msg");
 const detailEl = document.getElementById("detail");
@@ -20,9 +26,11 @@ function showSuccess() {
 }
 
 (async () => {
+  const cfg = self.ACTIONBOOK_CLOUD_CONFIG;
+
   const params = new URLSearchParams(location.search);
-  const token = params.get("token");
-  const deviceIdParam = params.get("deviceId");
+  const code = params.get("code");
+  const state = params.get("state");
   const error = params.get("error");
   const errorDescription = params.get("error_description");
 
@@ -31,14 +39,73 @@ function showSuccess() {
     return;
   }
 
-  if (!token) {
-    showError("missing_token", "The redirect did not include a token parameter.");
+  if (!code || !state) {
+    showError("missing_params", "The redirect URL didn't include code + state.");
     return;
   }
 
-  // Persist and signal background.
-  const update = { cloudToken: token, mode: "cloud" };
-  if (deviceIdParam) update.deviceId = deviceIdParam;
+  // Retrieve + immediately remove the one-shot PKCE verifier stashed by popup.js.
+  const stashKey = `pkce:${state}`;
+  const stash = (await chrome.storage.local.get(stashKey))[stashKey];
+  if (!stash || !stash.verifier) {
+    showError(
+      "pkce_missing",
+      "No PKCE verifier found for this state — did you start sign-in from a different session?"
+    );
+    return;
+  }
+  await chrome.storage.local.remove(stashKey);
+
+  // Exchange code for access token (+ refresh token if scope included offline_access).
+  // Public client: no client_secret, PKCE verifier authenticates us instead.
+  const redirectUri = `chrome-extension://${chrome.runtime.id}/callback.html`;
+  let tokenRes;
+  try {
+    tokenRes = await fetch(cfg.CLERK_TOKEN_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        redirect_uri: redirectUri,
+        client_id: cfg.CLERK_CLIENT_ID,
+        code_verifier: stash.verifier,
+      }),
+    });
+  } catch (err) {
+    showError("network", err?.message || String(err));
+    return;
+  }
+
+  if (!tokenRes.ok) {
+    const body = await tokenRes.text();
+    showError(`token_${tokenRes.status}`, body);
+    return;
+  }
+
+  let tokens;
+  try {
+    tokens = await tokenRes.json();
+  } catch (err) {
+    showError("parse_failed", err?.message || String(err));
+    return;
+  }
+
+  if (!tokens.access_token) {
+    showError("no_access_token", "Clerk did not return an access_token.");
+    return;
+  }
+
+  // Persist + tell background to reconnect. refreshToken is optional — only
+  // present if the user granted offline_access scope (they will have, per
+  // cloud-config.js, but be tolerant if Clerk omits it).
+  const update = { cloudToken: tokens.access_token, mode: "cloud" };
+  if (typeof tokens.refresh_token === "string") {
+    update.cloudRefreshToken = tokens.refresh_token;
+  }
+  if (typeof tokens.expires_in === "number") {
+    update.cloudTokenExpiresAt = Date.now() + tokens.expires_in * 1000;
+  }
 
   try {
     await chrome.storage.local.set(update);
@@ -50,6 +117,8 @@ function showSuccess() {
 
   showSuccess();
   setTimeout(() => {
-    try { window.close(); } catch (_) {}
+    try {
+      window.close();
+    } catch (_) {}
   }, 1500);
 })();

--- a/packages/actionbook-extension/cloud-config.js
+++ b/packages/actionbook-extension/cloud-config.js
@@ -1,0 +1,39 @@
+// Cloud-mode OAuth configuration. These values are public — a Chrome extension
+// is a "public" OAuth client and cannot hold secrets. Token exchange relies on
+// PKCE (code_verifier) instead of a client_secret, so the client_id being
+// visible here is by design and matches what is registered in Clerk Dashboard.
+
+// The "Actionbook Extension" OAuth application registered in Clerk.
+const CLERK_CLIENT_ID = "HP91Xj6adCm3TjPr";
+
+// Clerk authorization server endpoints (all public, see clerk.actionbook.dev
+// /.well-known/oauth-authorization-server).
+const CLERK_AUTHORIZE_URL = "https://clerk.actionbook.dev/oauth/authorize";
+const CLERK_TOKEN_URL = "https://clerk.actionbook.dev/oauth/token";
+
+// What we ask Clerk for on the user's behalf.
+// - openid: required for `sub` claim in the JWT (= userId for DO routing)
+// - profile/email: surfaced in popup + audit logs
+// - offline_access: issues a refresh_token so we can rotate expired access tokens
+//   without dragging the user back through the sign-in flow
+const CLERK_SCOPES = "openid profile email offline_access";
+
+// Stable dev-build extension ID derived from manifest.json `key` field. Used
+// only as a sanity check: if chrome.runtime.id differs we warn that the
+// Clerk redirect-URI whitelist probably doesn't include the current build.
+// The production (Chrome Web Store) build will have a different id — once we
+// publish, add that id to Clerk's whitelist AND extend EXPECTED_EXTENSION_IDS.
+const EXPECTED_EXTENSION_IDS = [
+  "dpfioflkmnkklgjldmaggkodhlidkdcd", // local unpacked / dev
+];
+
+// Export for both importScripts (service worker) and plain <script> (popup / callback)
+if (typeof self !== "undefined") {
+  self.ACTIONBOOK_CLOUD_CONFIG = {
+    CLERK_CLIENT_ID,
+    CLERK_AUTHORIZE_URL,
+    CLERK_TOKEN_URL,
+    CLERK_SCOPES,
+    EXPECTED_EXTENSION_IDS,
+  };
+}

--- a/packages/actionbook-extension/manifest.json
+++ b/packages/actionbook-extension/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "Actionbook",
-  "version": "0.4.2",
-  "description": "Bridge between Actionbook CLI and your browser for AI-powered automation",
+  "version": "0.5.0",
+  "description": "Bridge between Actionbook CLI / Cloud and your browser for AI-powered automation",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5xhsOXoi029BKiQTCV7UTZd/f/nzgW6JerV8XfbJLOEr+gHAVNU6J+2Yq3DvTE7+Tnx9EW9jQNGtE4ZXXaGpkvpkcP2ch3ggQQFpjOvHdlVGljepRB2gJivGWR5ooQ1QPWAyxwDLeA09/w2oZ54W9RMXeuzfjv1KRceq9FHlmkIIGaaqYfLzrQbbE7GSV1DSeRG1kG0f7Km2wUsuNDCINI6XyBbhM+662Clurs1GdP7S+Gw/+N/97YEY8Ir2smotGTknHmHuUl5N2XXJjhxfaCT85DkaMV0Kn9D9pVczK4xgqGypplCna5I61YjNDMrymA25qLNKQv2nf/mv7Y7l9wIDAQAB",
   "permissions": [
     "debugger",
@@ -26,5 +26,11 @@
     "16": "icons/icon-16.png",
     "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
-  }
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["callback.html"],
+      "matches": ["<all_urls>"]
+    }
+  ]
 }

--- a/packages/actionbook-extension/package.json
+++ b/packages/actionbook-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@actionbookdev/extension",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "private": true,
   "description": "Actionbook Chrome Extension - Bridge for CLI-to-browser communication",
   "scripts": {

--- a/packages/actionbook-extension/popup.html
+++ b/packages/actionbook-extension/popup.html
@@ -203,6 +203,27 @@
   </div>
 
   <div class="settings-row">
+    <label for="modeSelect">Mode</label>
+    <select id="modeSelect" style="padding: 2px 4px; font-size: 12px;">
+      <option value="local">Local (CLI)</option>
+      <option value="cloud">Cloud</option>
+    </select>
+  </div>
+
+  <div class="status-row hidden" id="deviceRow">
+    <span class="dot gray"></span>
+    <span class="label">Device</span>
+    <span class="value" id="deviceLabel">--</span>
+  </div>
+
+  <div class="action-row hidden" id="cloudActionRow">
+    <button class="action-btn" id="cloudSignInBtn">Sign in to Actionbook</button>
+  </div>
+  <div class="action-row hidden" id="cloudSignOutRow">
+    <button class="action-btn" id="cloudSignOutBtn">Sign out</button>
+  </div>
+
+  <div class="settings-row">
     <label for="groupTabsToggle">Group Actionbook tabs</label>
     <input type="checkbox" id="groupTabsToggle" checked>
   </div>

--- a/packages/actionbook-extension/popup.html
+++ b/packages/actionbook-extension/popup.html
@@ -254,6 +254,7 @@
     CLI: <code>actionbook extension serve</code>
   </div>
 
+  <script src="cloud-config.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>

--- a/packages/actionbook-extension/popup.js
+++ b/packages/actionbook-extension/popup.js
@@ -144,6 +144,82 @@ chrome.storage.local.get("bridgeToken", (result) => {
   }
 });
 
+// --- Cloud mode UI ---
+
+const modeSelect = document.getElementById("modeSelect");
+const deviceRow = document.getElementById("deviceRow");
+const deviceLabel = document.getElementById("deviceLabel");
+const cloudActionRow = document.getElementById("cloudActionRow");
+const cloudSignOutRow = document.getElementById("cloudSignOutRow");
+const cloudSignInBtn = document.getElementById("cloudSignInBtn");
+const cloudSignOutBtn = document.getElementById("cloudSignOutBtn");
+
+// Shown only when mode=cloud.
+function renderCloudSection(mode, cloudToken, deviceId) {
+  if (mode !== "cloud") {
+    deviceRow.classList.add("hidden");
+    cloudActionRow.classList.add("hidden");
+    cloudSignOutRow.classList.add("hidden");
+    return;
+  }
+  // Device row always shown in cloud mode (even if not signed in — shows "--")
+  deviceRow.classList.remove("hidden");
+  deviceLabel.textContent = deviceId
+    ? deviceId.slice(0, 10) + (deviceId.length > 10 ? "…" : "")
+    : "—";
+
+  if (cloudToken) {
+    cloudActionRow.classList.add("hidden");
+    cloudSignOutRow.classList.remove("hidden");
+  } else {
+    cloudActionRow.classList.remove("hidden");
+    cloudSignOutRow.classList.add("hidden");
+  }
+}
+
+async function refreshCloudUi() {
+  const { mode, cloudToken, deviceId } = await chrome.storage.local.get([
+    "mode",
+    "cloudToken",
+    "deviceId",
+  ]);
+  const current = mode === "cloud" ? "cloud" : "local";
+  modeSelect.value = current;
+  renderCloudSection(current, cloudToken, deviceId);
+}
+
+modeSelect.addEventListener("change", () => {
+  chrome.runtime.sendMessage({ type: "setMode", mode: modeSelect.value });
+  // Re-render shortly so the UI reflects the new mode
+  setTimeout(refreshCloudUi, 100);
+});
+
+cloudSignInBtn?.addEventListener("click", () => {
+  // Default pair URL; override via chrome.storage.local.cloudPairUrl if needed.
+  // OAuth module owns /pair, so this URL is part of the cross-module contract.
+  chrome.storage.local.get(["cloudPairUrl"], ({ cloudPairUrl }) => {
+    const base = cloudPairUrl || "https://edge.actionbook.dev/pair";
+    const url = `${base}?extensionId=${encodeURIComponent(chrome.runtime.id)}`;
+    chrome.tabs.create({ url });
+  });
+});
+
+cloudSignOutBtn?.addEventListener("click", () => {
+  chrome.runtime.sendMessage({ type: "cloud_sign_out" });
+  setTimeout(refreshCloudUi, 100);
+});
+
+// Refresh when storage changes (e.g. callback.html stored a fresh token)
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "local") return;
+  if (changes.cloudToken || changes.mode || changes.deviceId) {
+    refreshCloudUi();
+  }
+});
+
+// Initial render
+refreshCloudUi();
+
 // Tab-grouping toggle — reflects and writes background's in-memory
 // groupingEnabled flag; background persists to chrome.storage.local.
 const groupTabsToggle = document.getElementById("groupTabsToggle");

--- a/packages/actionbook-extension/popup.js
+++ b/packages/actionbook-extension/popup.js
@@ -194,15 +194,65 @@ modeSelect.addEventListener("change", () => {
   setTimeout(refreshCloudUi, 100);
 });
 
-cloudSignInBtn?.addEventListener("click", () => {
-  // Default pair URL; override via chrome.storage.local.cloudPairUrl if needed.
-  // OAuth module owns /pair, so this URL is part of the cross-module contract.
-  chrome.storage.local.get(["cloudPairUrl"], ({ cloudPairUrl }) => {
-    const base = cloudPairUrl || "https://edge.actionbook.dev/pair";
-    const url = `${base}?extensionId=${encodeURIComponent(chrome.runtime.id)}`;
-    chrome.tabs.create({ url });
+// Sign in starts the OAuth 2.1 authorization-code + PKCE flow against Clerk.
+// We generate a PKCE verifier here, stash it in chrome.storage.local keyed by
+// `state`, and open Clerk's authorize URL in a new tab. When Clerk redirects
+// back to chrome-extension://<id>/callback.html?code=...&state=..., callback.js
+// reads the verifier by state, exchanges the code for an access token, and
+// signals background.js to reconnect.
+cloudSignInBtn?.addEventListener("click", async () => {
+  const cfg = self.ACTIONBOOK_CLOUD_CONFIG;
+
+  // Sanity check: warn if dev-build id doesn't match Clerk's whitelisted URI.
+  // Prod / CWS build will have a different id — add it to cloud-config.js then.
+  if (!cfg.EXPECTED_EXTENSION_IDS.includes(chrome.runtime.id)) {
+    console.warn(
+      "[actionbook] unexpected extension id:",
+      chrome.runtime.id,
+      "— Clerk's redirect-URI whitelist may not include this build, sign-in will fail."
+    );
+  }
+
+  const { verifier, challenge } = await generatePkcePair();
+  const state = crypto.randomUUID();
+
+  // Stash by state so callback.js can retrieve the exact verifier used here.
+  // Short TTL is enforced implicitly by the state check — callback.js deletes
+  // the entry after using it, and we don't trust stale entries.
+  await chrome.storage.local.set({
+    [`pkce:${state}`]: { verifier, createdAt: Date.now() },
   });
+
+  const redirectUri = `chrome-extension://${chrome.runtime.id}/callback.html`;
+  const params = new URLSearchParams({
+    client_id: cfg.CLERK_CLIENT_ID,
+    response_type: "code",
+    redirect_uri: redirectUri,
+    scope: cfg.CLERK_SCOPES,
+    state,
+    code_challenge: challenge,
+    code_challenge_method: "S256",
+  });
+
+  chrome.tabs.create({ url: `${cfg.CLERK_AUTHORIZE_URL}?${params.toString()}` });
 });
+
+// PKCE helpers: verifier is a 43–128 char random URL-safe string; challenge is
+// base64url(SHA256(verifier)) for S256 flow. RFC 7636.
+async function generatePkcePair() {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64Url(verifierBytes);
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  const challenge = base64Url(new Uint8Array(digest));
+  return { verifier, challenge };
+}
+
+function base64Url(bytes) {
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
 
 cloudSignOutBtn?.addEventListener("click", () => {
   chrome.runtime.sendMessage({ type: "cloud_sign_out" });

--- a/packages/actionbook-extension/scripts/package.js
+++ b/packages/actionbook-extension/scripts/package.js
@@ -23,6 +23,10 @@ const includeFiles = [
   'popup.js',
   'offscreen.html',
   'offscreen.js',
+  // Cloud Mode (v0.5.0+): PKCE OAuth sign-in flow.
+  'cloud-config.js',
+  'callback.html',
+  'callback.js',
   'icons/icon-16.png',
   'icons/icon-48.png',
   'icons/icon-128.png',

--- a/packages/cli/src/extension/installer.rs
+++ b/packages/cli/src/extension/installer.rs
@@ -56,6 +56,31 @@ static BUNDLED_EXTENSION: &[(&str, &[u8])] = &[
             "/../actionbook-extension/offscreen.js"
         )),
     ),
+    // Cloud Mode (extension v0.5.0+): PKCE OAuth sign-in flow. Omitting these
+    // would silently produce a broken install for users of `actionbook extension
+    // install` — popup.js would fail to load cloud-config.js and the OAuth
+    // redirect would land on a missing callback.html.
+    (
+        "cloud-config.js",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/cloud-config.js"
+        )),
+    ),
+    (
+        "callback.html",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/callback.html"
+        )),
+    ),
+    (
+        "callback.js",
+        include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../actionbook-extension/callback.js"
+        )),
+    ),
     (
         "icons/icon-16.png",
         include_bytes!(concat!(


### PR DESCRIPTION
## Summary
Adds Cloud Mode to the Actionbook browser extension so remote AI agents (Claude Desktop, Codex, claude.ai Connectors, etc.) can drive the user's Chrome over MCP without running the local CLI daemon. Sign-in uses Clerk OAuth 2.1 + PKCE. **Local Mode is the default and unchanged**, so existing users updating from 0.4.x see no behavior change.

## Commits
- \`3c48ef40e\` — cloud-mode skeleton: mode switch in \`background.js\`, \`callback.html\` wiring, popup UI, \`manifest.json\` 0.5.0
- \`0a5d12673\` — Clerk OAuth 2.1 + PKCE sign-in flow, refresh token rotation, \`cloud-config.js\`
- \`b13de19f1\` — documentation updates (README, PRIVACY, CHANGELOG)

## What changes for existing users
- **Local Mode users**: nothing. Default mode is still local; no new permissions requested; silent auto-update. Bridge protocol hello frame goes from \`0.4.0\` → \`0.5.0\`, and the CLI's \`EXTENSION_PROTOCOL_MIN_VERSION = 0.4.0\` accepts it.
- **Cloud Mode (opt-in)**: new popup toggle, Sign in to Actionbook button opens Clerk OAuth, extension reconnects to \`wss://edge.actionbook.dev/extension/ws\` with the returned JWT.

## Files added
- \`packages/actionbook-extension/cloud-config.js\` — public OAuth client id + Clerk endpoints
- \`packages/actionbook-extension/callback.html\` — OAuth redirect target
- \`packages/actionbook-extension/callback.js\` — code → token exchange + PKCE verifier handling

## Files modified
- \`manifest.json\` — version 0.5.0, \`callback.html\` in \`web_accessible_resources\`. No new permissions.
- \`background.js\` — mode switch, WS with bearer subprotocol, device ID generation, refresh-token flow, \`cloud_sign_out\` / \`cloud_auth_updated\` / \`setMode\` message handlers.
- \`popup.html\` / \`popup.js\` — mode dropdown, sign-in button with PKCE generation, device display, sign-out.
- \`README.md\` — Cloud Mode section with setup + Claude Desktop example.
- \`PRIVACY.md\` — restructured Section 2 into 2A (Local) and 2B (Cloud, new), Section 3 mode-scoped clarifications, Section 4 cloud storage keys, Section 5 cloud security notes.
- \`CHANGELOG.md\` — 0.5.0 Minor Changes entry.

## Testing
- ✅ Existing Local Mode flow: extension loaded unpacked, \`actionbook browser\` commands continue to work unchanged
- ✅ Cloud Mode end-to-end: popup Sign in → Clerk OAuth → callback stores token → WS connects to \`edge.actionbook.dev\`
- ✅ \`curl\` against \`https://edge.actionbook.dev/mcp\` with a real Clerk JWT drives CDP commands in the extension's browser
- ✅ Claude Desktop Connector at \`https://edge.actionbook.dev/mcp\` walks through DCR + OAuth and drives tabs in conversations
- ✅ Refresh token flow: access token expiry triggers silent refresh, no user re-prompt
- ✅ Sign-out clears all cloud tokens and returns extension to \`pairing_required\` state
- ✅ Mode switch Cloud → Local → Cloud: reconnects correctly each way

## CWS publishing
This PR targets \`main\` so the repo reflects 0.5.0 before we build the CWS zip. CWS submission is a separate step after merge:
1. Clerk OAuth app redirect URIs to include \`chrome-extension://<CWS prod id>/callback.html\` **after** Google issues the prod id
2. \`cloud-config.js\` \`EXPECTED_EXTENSION_IDS\` to append the CWS prod id (ships in a subsequent 0.5.x)