### PR TITLE
feat(har): bump DEFAULT_MAX_ENTRIES to 10000 + surface truncation signal in stop envelope (ACT-970)

### DIFF
--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -278,7 +278,7 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
     // Peek at entries without removing the recorder yet.  The recorder is
     // only committed (removed) after the file has been written successfully,
     // so an I/O failure leaves the data intact and the user can retry.
-    let (entries, dropped_count) = match cdp.har_stop(&cdp_session_id).await {
+    let (entries, dropped_count, max_entries) = match cdp.har_stop(&cdp_session_id).await {
         Ok(v) => v,
         Err("HAR_NOT_RECORDING") => {
             return ActionResult::fatal(
@@ -322,11 +322,20 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
     // File written successfully — release the recorder from memory.
     cdp.har_commit(&cdp_session_id).await;
 
-    ActionResult::ok(json!({
+    let mut payload = json!({
         "path": out_path.to_string_lossy().as_ref(),
         "count": count,
         "dropped": dropped_count,
-    }))
+        "max_entries": max_entries,
+    });
+    if dropped_count > 0 {
+        let warning = format!(
+            "HAR_TRUNCATED: {dropped_count} earlier entries dropped (max_entries={max_entries}); raise --max-entries or stop recording sooner to keep the full trace"
+        );
+        payload["__truncated"] = json!(true);
+        payload["__warnings"] = json!([warning]);
+    }
+    ActionResult::ok(payload)
 }
 
 // ── HAR 1.2 serialization ─────────────────────────────────────────────────────
@@ -738,7 +747,11 @@ mod tests {
         }
     }
 
-    async fn setup_extension_registry() -> (crate::daemon::registry::SharedRegistry, CdpSession, MockWriter) {
+    async fn setup_extension_registry() -> (
+        crate::daemon::registry::SharedRegistry,
+        CdpSession,
+        MockWriter,
+    ) {
         let (url, mut conns) = mock_ws_server().await;
         let cdp = CdpSession::connect(&url).await.unwrap();
         let (mut reader, mut writer) = conns.recv().await.unwrap();
@@ -753,7 +766,11 @@ mod tests {
         );
         entry.status = SessionState::Running;
         entry.cdp = Some(cdp.clone());
-        entry.push_tab("100".to_string(), "about:blank".to_string(), "Blank".to_string());
+        entry.push_tab(
+            "100".to_string(),
+            "about:blank".to_string(),
+            "Blank".to_string(),
+        );
         registry.lock().await.insert(entry);
 
         let cdp_clone = cdp.clone();
@@ -919,8 +936,7 @@ mod tests {
         };
 
         assert!(
-            data.get("__truncated").is_none()
-                || data["__truncated"].as_bool() == Some(false),
+            data.get("__truncated").is_none() || data["__truncated"].as_bool() == Some(false),
             "clean stop should not mark truncation: {data:?}"
         );
         assert!(

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -20,7 +20,7 @@ use crate::output::ResponseContext;
 /// recordings.
 const DEFAULT_MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
 /// Default ring-buffer cap on number of entries. Oldest evicted when full.
-const DEFAULT_MAX_ENTRIES: usize = 2000;
+const DEFAULT_MAX_ENTRIES: usize = 10000;
 
 // ── Start ─────────────────────────────────────────────────────────────────────
 

--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -650,6 +650,146 @@ fn default_har_path() -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddr;
+
+    use clap::Parser;
+    use futures_util::{SinkExt, StreamExt, stream::SplitSink};
+    use serde_json::Value;
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio_tungstenite::tungstenite::Message;
+
+    use crate::action_result::ActionResult;
+    use crate::cli::{BrowserCommands, Cli, Commands, HarCommands, NetworkCommands};
+    use crate::daemon::cdp_session::CdpSession;
+    use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
+    use crate::types::{Mode, SessionId};
+
+    type MockStream = tokio_tungstenite::WebSocketStream<tokio::net::TcpStream>;
+    type MockReader = futures_util::stream::SplitStream<MockStream>;
+    type MockWriter = SplitSink<MockStream, Message>;
+
+    async fn mock_ws_server() -> (String, mpsc::Receiver<(MockReader, MockWriter)>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr: SocketAddr = listener.local_addr().unwrap();
+        let url = format!("ws://127.0.0.1:{}", addr.port());
+
+        let (tx, rx) = mpsc::channel(4);
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+                let (writer, reader) = ws.split();
+                if tx.send((reader, writer)).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        (url, rx)
+    }
+
+    async fn read_json<S>(reader: &mut S) -> Value
+    where
+        S: StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+    {
+        loop {
+            let msg = reader.next().await.unwrap().unwrap();
+            if let Message::Text(t) = msg {
+                return serde_json::from_str(t.as_ref()).unwrap();
+            }
+        }
+    }
+
+    async fn send_json<S>(writer: &mut S, value: Value)
+    where
+        S: SinkExt<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+    {
+        writer
+            .send(Message::Text(value.to_string().into()))
+            .await
+            .unwrap();
+    }
+
+    fn parse_start_cmd_without_max_entries() -> StartCmd {
+        let cli = Cli::try_parse_from([
+            "actionbook",
+            "browser",
+            "network",
+            "har",
+            "start",
+            "--session",
+            "s1",
+            "--tab",
+            "t1",
+        ])
+        .expect("parse cli");
+
+        match cli.command.expect("command") {
+            Commands::Browser {
+                command:
+                    BrowserCommands::Network {
+                        command:
+                            NetworkCommands::Har {
+                                command: HarCommands::Start(cmd),
+                            },
+                    },
+            } => cmd,
+            other => panic!("unexpected command tree: {other:?}"),
+        }
+    }
+
+    async fn setup_extension_registry() -> (crate::daemon::registry::SharedRegistry, CdpSession, MockWriter) {
+        let (url, mut conns) = mock_ws_server().await;
+        let cdp = CdpSession::connect(&url).await.unwrap();
+        let (mut reader, mut writer) = conns.recv().await.unwrap();
+
+        let registry = new_shared_registry();
+        let mut entry = SessionEntry::starting(
+            SessionId::new_unchecked("s1"),
+            Mode::Extension,
+            true,
+            false,
+            "profile-har-test".to_string(),
+        );
+        entry.status = SessionState::Running;
+        entry.cdp = Some(cdp.clone());
+        entry.push_tab("100".to_string(), "about:blank".to_string(), "Blank".to_string());
+        registry.lock().await.insert(entry);
+
+        let cdp_clone = cdp.clone();
+        let register = tokio::spawn(async move {
+            cdp_clone.register_extension_tab("100").await;
+        });
+        let enable = read_json(&mut reader).await;
+        assert_eq!(enable["method"], "Network.enable");
+        assert_eq!(enable["tabId"], 100);
+        send_json(&mut writer, json!({"id": enable["id"], "result": {}})).await;
+        register.await.unwrap();
+
+        (registry, cdp, writer)
+    }
+
+    async fn send_request_will_be_sent(writer: &mut MockWriter, tab_id: u64, request_id: &str) {
+        send_json(
+            writer,
+            json!({
+                "method": "Network.requestWillBeSent",
+                "tabId": tab_id,
+                "params": {
+                    "requestId": request_id,
+                    "timestamp": 1.0,
+                    "wallTime": 1_710_000_000.0,
+                    "type": "XHR",
+                    "request": {
+                        "url": format!("https://example.test/api/{request_id}"),
+                        "method": "GET",
+                        "headers": {},
+                    }
+                }
+            }),
+        )
+        .await;
+    }
 
     #[test]
     fn parse_resource_types_known_tokens_canonicalize() {
@@ -675,5 +815,120 @@ mod tests {
     fn parse_resource_types_mixed_valid_invalid_is_error() {
         let err = parse_resource_types("xhr,bogus").unwrap_err();
         assert_eq!(err, vec!["bogus".to_string()]);
+    }
+
+    #[test]
+    fn default_max_entries_is_10000() {
+        assert_eq!(DEFAULT_MAX_ENTRIES, 10000);
+    }
+
+    #[tokio::test]
+    async fn start_command_without_flag_uses_default_max_entries() {
+        let cmd = parse_start_cmd_without_max_entries();
+        let (registry, _cdp, _writer) = setup_extension_registry().await;
+        let result = execute_start(&cmd, &registry).await;
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok start result, got {other:?}"),
+        };
+        assert_eq!(data["max_entries"], 10000);
+    }
+
+    #[tokio::test]
+    async fn execute_stop_emits_truncated_marker_when_dropped_nonzero() {
+        let (registry, cdp, mut writer) = setup_extension_registry().await;
+        cdp.har_start(
+            "tab:100",
+            "100",
+            HashSet::new(),
+            10,
+            true,
+            DEFAULT_MAX_BODY_SIZE,
+        )
+        .await
+        .expect("start har");
+
+        for idx in 0..15 {
+            send_request_will_be_sent(&mut writer, 100, &format!("req-{idx}")).await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let out = temp.path().join("truncated.har");
+        let result = execute_stop(
+            &StopCmd {
+                session: "s1".to_string(),
+                tab: "t1".to_string(),
+                out: Some(out.to_string_lossy().to_string()),
+            },
+            &registry,
+        )
+        .await;
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok stop result, got {other:?}"),
+        };
+
+        assert_eq!(data["__truncated"], true);
+        let warnings = data["__warnings"].as_array().expect("__warnings array");
+        let warning = warnings
+            .first()
+            .and_then(|v| v.as_str())
+            .expect("warning string");
+        assert!(
+            warning.starts_with("HAR_TRUNCATED: 5 earlier entries dropped (max_entries=10); "),
+            "expected truncation warning prefix, got {warning:?}"
+        );
+        assert_eq!(data["max_entries"], 10);
+        assert!(data["dropped"].as_u64().is_some_and(|v| v > 0));
+    }
+
+    #[tokio::test]
+    async fn execute_stop_omits_truncated_marker_on_clean_stop() {
+        let (registry, cdp, mut writer) = setup_extension_registry().await;
+        cdp.har_start(
+            "tab:100",
+            "100",
+            HashSet::new(),
+            10,
+            true,
+            DEFAULT_MAX_BODY_SIZE,
+        )
+        .await
+        .expect("start har");
+
+        for idx in 0..3 {
+            send_request_will_be_sent(&mut writer, 100, &format!("clean-{idx}")).await;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let temp = tempfile::tempdir().expect("tempdir");
+        let out = temp.path().join("clean.har");
+        let result = execute_stop(
+            &StopCmd {
+                session: "s1".to_string(),
+                tab: "t1".to_string(),
+                out: Some(out.to_string_lossy().to_string()),
+            },
+            &registry,
+        )
+        .await;
+        let data = match result {
+            ActionResult::Ok { data } => data,
+            other => panic!("expected ok stop result, got {other:?}"),
+        };
+
+        assert!(
+            data.get("__truncated").is_none()
+                || data["__truncated"].as_bool() == Some(false),
+            "clean stop should not mark truncation: {data:?}"
+        );
+        assert!(
+            data.get("__warnings").is_none()
+                || data["__warnings"]
+                    .as_array()
+                    .is_some_and(|warnings| warnings.is_empty()),
+            "clean stop should omit warnings: {data:?}"
+        );
     }
 }

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -1506,13 +1506,14 @@ impl CdpSession {
     /// immediately after `wait network-idle` still get populated response bodies.
     ///
     /// `dropped_count` is the number of entries evicted due to the `max_entries`
-    /// ring-buffer cap; surface this so callers can warn the user.
+    /// ring-buffer cap; surface this so callers can warn the user. `max_entries`
+    /// is the configured cap, so callers can mention it in user-facing warnings.
     ///
     /// Returns `Err("HAR_NOT_RECORDING")` if no recording was active.
     pub async fn har_stop(
         &self,
         cdp_session_id: &str,
-    ) -> Result<(Vec<HarEntry>, usize), &'static str> {
+    ) -> Result<(Vec<HarEntry>, usize, usize), &'static str> {
         // Snapshot the pending-fetch counter handle, then release the lock
         // while polling so body-fetch spawn tasks can acquire it to write back.
         let pending_counter = {
@@ -1538,6 +1539,7 @@ impl CdpSession {
             Some(recorder) => Ok((
                 recorder.entries.iter().cloned().collect(),
                 recorder.dropped_count,
+                recorder.max_entries,
             )),
         }
     }

--- a/packages/cli/tests/e2e/network_har.rs
+++ b/packages/cli/tests/e2e/network_har.rs
@@ -27,6 +27,29 @@ fn har_start(session_id: &str, tab_id: &str) -> std::process::Output {
     )
 }
 
+fn har_start_with_max_entries(
+    session_id: &str,
+    tab_id: &str,
+    max_entries: usize,
+) -> std::process::Output {
+    let max_entries = max_entries.to_string();
+    headless_json(
+        &[
+            "browser",
+            "network",
+            "har",
+            "start",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+            "--max-entries",
+            &max_entries,
+        ],
+        15,
+    )
+}
+
 /// Start HAR recording capturing **all** resource types, not just the default
 /// xhr,fetch. Used by tests that navigate to static fixtures (network-load,
 /// redirect) where Document/Script/Stylesheet entries are the whole point.
@@ -100,6 +123,25 @@ fn wait_requests_done(session_id: &str, tab_id: &str) {
         10,
     );
     assert_success(&out, "wait requests done");
+}
+
+fn issue_bulk_requests(session_id: &str, tab_id: &str, count: usize, prefix: &str) {
+    let api_prefix = url_network_xhr().replace("/network-xhr", "/api/data?source=");
+    let expression = format!(
+        "await Promise.all(Array.from({{ length: {count} }}, (_, i) => fetch(`{api_prefix}{prefix}-${{i}}`).then(r => r.text())))"
+    );
+    let argv = [
+        "browser".to_string(),
+        "eval".to_string(),
+        expression,
+        "--session".to_string(),
+        session_id.to_string(),
+        "--tab".to_string(),
+        tab_id.to_string(),
+    ];
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = headless_json(&args, 30);
+    assert_success(&out, "issue bulk requests");
 }
 
 fn har_json_from_file(path: &Path) -> serde_json::Value {
@@ -765,4 +807,74 @@ fn har_cross_session_independent_recording() {
     );
     // Session 1 should have entries (the static page load).
     assert!(!urls_s1.is_empty(), "session 1 HAR should not be empty");
+}
+
+mod truncation {
+    use super::*;
+
+    #[test]
+    fn har_truncation_surfaces_in_envelope() {
+        if skip() {
+            return;
+        }
+
+        let (sid, tid) = start_session(&url_network_xhr());
+        let _guard = SessionGuard::new(&sid);
+        wait_requests_done(&sid, &tid);
+
+        let start_out = har_start_with_max_entries(&sid, &tid, 5);
+        assert_success(&start_out, "har start --max-entries 5");
+
+        issue_bulk_requests(&sid, &tid, 12, "truncation");
+
+        let stop_out = har_stop(&sid, &tid);
+        assert_success(&stop_out, "har stop after truncation");
+        let v = parse_json(&stop_out);
+
+        assert_eq!(v["meta"]["truncated"], true);
+        let warnings = v["meta"]["warnings"].as_array().expect("meta warnings array");
+        let warning = warnings
+            .first()
+            .and_then(|value| value.as_str())
+            .expect("first warning string");
+        assert!(
+            warning.starts_with("HAR_TRUNCATED:"),
+            "expected HAR_TRUNCATED warning, got {warning:?}"
+        );
+        assert!(
+            warning.contains("max_entries=5"),
+            "expected warning to mention cap, got {warning:?}"
+        );
+        assert!(v["data"]["dropped"].as_u64().is_some_and(|dropped| dropped >= 5));
+        assert_eq!(v["data"]["max_entries"], 5);
+    }
+
+    #[test]
+    fn har_clean_stop_has_no_truncation_marker() {
+        if skip() {
+            return;
+        }
+
+        let (sid, tid) = start_session(&url_network_xhr());
+        let _guard = SessionGuard::new(&sid);
+        wait_requests_done(&sid, &tid);
+
+        let start_out = har_start_with_max_entries(&sid, &tid, 100);
+        assert_success(&start_out, "har start --max-entries 100");
+
+        issue_bulk_requests(&sid, &tid, 3, "clean-stop");
+
+        let stop_out = har_stop(&sid, &tid);
+        assert_success(&stop_out, "har stop clean");
+        let v = parse_json(&stop_out);
+
+        assert_ne!(v["meta"]["truncated"], true);
+        let warnings = v["meta"]["warnings"]
+            .as_array()
+            .expect("meta warnings array should exist");
+        assert!(
+            warnings.is_empty(),
+            "clean stop should not emit warnings, got {warnings:?}"
+        );
+    }
 }

--- a/packages/cli/tests/e2e/network_har.rs
+++ b/packages/cli/tests/e2e/network_har.rs
@@ -832,7 +832,9 @@ mod truncation {
         let v = parse_json(&stop_out);
 
         assert_eq!(v["meta"]["truncated"], true);
-        let warnings = v["meta"]["warnings"].as_array().expect("meta warnings array");
+        let warnings = v["meta"]["warnings"]
+            .as_array()
+            .expect("meta warnings array");
         let warning = warnings
             .first()
             .and_then(|value| value.as_str())
@@ -845,7 +847,11 @@ mod truncation {
             warning.contains("max_entries=5"),
             "expected warning to mention cap, got {warning:?}"
         );
-        assert!(v["data"]["dropped"].as_u64().is_some_and(|dropped| dropped >= 5));
+        assert!(
+            v["data"]["dropped"]
+                .as_u64()
+                .is_some_and(|dropped| dropped >= 5)
+        );
         assert_eq!(v["data"]["max_entries"], 5);
     }
 


### PR DESCRIPTION
## Summary

Implements ACT-970: raises the HAR ring-buffer cap and gives the CLI a structured, discoverable signal when entries have been dropped.

- **Const bump** (`6c7778fa7`): `DEFAULT_MAX_ENTRIES` raised from `2000` → `10000` in `packages/cli/src/browser/observation/network_har.rs`.
- **Envelope signal** (`1a3efcd71`): `execute_stop` now always emits `data.max_entries`; when the recorder reports `dropped_count > 0`, it also emits `data.__truncated: true` and `data.__warnings: ["HAR_TRUNCATED: ..."]`. These bridge through the existing `JsonEnvelope` machinery in `output.rs` to `meta.truncated` / `meta.warnings` — no new plumbing required.
- **har_stop signature**: return type migrated from `Result<(Vec<HarEntry>, usize), _>` to `Result<(Vec<HarEntry>, usize, usize), _>` (adds `max_entries`). Only production caller is `execute_stop`; signature change is contained.

The warning string follows the red spec verbatim:

    HAR_TRUNCATED: {N} earlier entries dropped (max_entries={M}); raise --max-entries or stop recording sooner to keep the full trace

## Backward compatibility

- Envelope contract is **additive**: `data.max_entries` is a new field; `data.__truncated` / `data.__warnings` are only present when truncation actually occurred.
- Exit code behavior is unchanged — truncation is a warning, not an error.
- No CLI flag changes; `--max-entries` still overrides the default, it is just a higher default now.

## Dispatch-deviation note

Plan (b) called for adding `max_entries` echo to `execute_start`. `packages/cli/src/browser/observation/network_har.rs:188` already echoed `cmd.max_entries`, so the const bump alone satisfied the red test `start_command_without_flag_uses_default_max_entries`. Deviation was accepted by lead-review; (b) collapsed into (a) as a legitimate no-op, not hidden scope.

## Commit graph

- red (test) — `8fcb3973b` — `test: add failing HAR truncation signal tests (ACT-970)`
- green (impl) — `6c7778fa7` — `feat(har): bump DEFAULT_MAX_ENTRIES from 2000 to 10000 (ACT-970)`
- green (impl) — `1a3efcd71` — `feat(har): surface truncation signal in stop envelope (ACT-970)`

## Local verification

On head `1a3efcd71`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` — 475 passed / 0 failed
- `cargo test --test e2e network_har` — 17 passed / 0 failed (including 2 new truncation gates + 15 regression)
- Cross-reviewer (`cli-roger-test`) re-verified on fresh detached worktree at same head:
  - Unit `browser::observation::network_har::tests::` — 8/8 passed
  - Real E2E `RUN_E2E_TESTS=true ... --test e2e network_har::truncation` — 2/2 passed

## Out-of-scope follow-up

ACT-1004 (disk-first recorder) is the proper long-term answer for very long sessions; this PR is the immediate-relief increment (larger ring + visible signal).

## Test plan

- [ ] CI green on main flow
- [ ] Codex review clean (any threads replied + resolved before merge)
- [ ] Lead autonomous-merge per `feedback_autonomous_merge.md`