### PR TITLE
docs(har): document HAR truncation signal and default bump

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -348,7 +348,17 @@ actionbook browser network har stop --session s1 --tab t1             # Stop and
 actionbook browser network har stop --session s1 --tab t1 --out /tmp/trace.har  # Custom output path
 ```
 
-HAR recording is per-tab. Multiple tabs or sessions can record independently. Output is HAR 1.2 JSON with request/response headers and timings (no response bodies — use `--dump` for that). If `--out` is omitted, a timestamped file is created in `~/.actionbook/har/`. Redirect chains produce one entry per hop. Error codes: `HAR_ALREADY_RECORDING`, `HAR_NOT_RECORDING`.
+HAR recording is per-tab. Multiple tabs or sessions can record independently. `har start` accepts `--max-entries N` to set the ring-buffer cap (default: 10000). Output is HAR 1.2 JSON with request/response headers and timings (no response bodies — use `--dump` for that). If `--out` is omitted, a timestamped file is created in `~/.actionbook/har/`. Redirect chains produce one entry per hop. Error codes: `HAR_ALREADY_RECORDING`, `HAR_NOT_RECORDING`.
+
+<Note>
+  When `har stop` completes and entries were dropped due to the ring-buffer cap, the envelope signals truncation:
+
+  - `meta.truncated == true`
+  - `meta.warnings` contains `"HAR_TRUNCATED: <N> earlier entries dropped (max_entries=<cap>); raise --max-entries or stop recording sooner to keep the full trace"`
+  - `data.max_entries` — the configured cap at stop time
+
+  On a clean stop (`dropped == 0`), `meta.truncated` is `false` and `meta.warnings` is empty. `data.path`, `data.count`, and `data.dropped` are always present.
+</Note>
 
 ### Cookies & Storage
 

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -294,6 +294,12 @@ actionbook browser network har start --session s1 --tab t1         # start HAR r
 actionbook browser network har stop --session s1 --tab t1          # stop and export HAR 1.2 file
 ```
 
+`har start` accepts `--max-entries N` to set the ring-buffer cap (default: 10000).
+
+<Tip>
+  When `har stop` detects dropped entries, the envelope includes `meta.truncated = true` and a `HAR_TRUNCATED` warning in `meta.warnings` with the drop count and configured cap. Read `data.dropped` and `data.max_entries` to decide whether to raise `--max-entries` or stop recording sooner.
+</Tip>
+
 ### Cookie & Storage Operations
 
 ```bash

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -177,6 +177,10 @@ Do not switch tools just because a login page appears.
 - Read `meta.warnings` to distinguish a fresh close from an already-gone session. Do not treat a warning inside an `ok: true` response as a signal that the session is still alive.
 - If another close is already in flight for the same session, the command returns `SESSION_CLOSING` (fatal).
 
+## HAR Recording
+
+`network har start` accepts `--max-entries N` to set the ring-buffer cap (default: 10000). When `har stop` detects dropped entries (`data.dropped > 0`), the envelope includes `meta.truncated = true` and a `HAR_TRUNCATED` warning in `meta.warnings`. Read `data.max_entries` to see the configured cap. Raise `--max-entries` or stop recording sooner to keep the full trace.
+
 ## References
 
 | Reference | Description |

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -311,9 +311,16 @@ actionbook browser network har stop --session s1 --tab t1                       
 actionbook browser network har stop --session s1 --tab t1 --out /tmp/trace.har    # Stop and export to custom path
 ```
 
-Recording is per-tab: multiple tabs (or sessions) can record independently at the same time. `har stop` writes a HAR 1.2 JSON file and returns `{ path, count }`. If `--out` is omitted, a timestamped file is created in `~/.actionbook/har/`.
+Recording is per-tab: multiple tabs (or sessions) can record independently at the same time. `har start` accepts `--max-entries N` to set the ring-buffer cap (default: 10000). `har stop` writes a HAR 1.2 JSON file and returns `{ path, count, dropped, max_entries }`. If `--out` is omitted, a timestamped file is created in `~/.actionbook/har/`.
 
 Output contains request/response headers, status, mimeType, and detailed timings per entry. Response bodies are not included — use `network requests --dump` if you need bodies. Redirect chains produce one entry per hop.
+
+**Truncation signal**: When `har stop` completes and entries were dropped due to the ring-buffer cap (`dropped > 0`), the envelope includes:
+- `meta.truncated == true`
+- `meta.warnings` containing `"HAR_TRUNCATED: <N> earlier entries dropped (max_entries=<cap>); raise --max-entries or stop recording sooner to keep the full trace"`
+- `data.max_entries` — the configured cap at stop time
+
+On a clean stop (`dropped == 0`), `meta.truncated` is `false` and `meta.warnings` is empty.
 
 Error codes: `HAR_ALREADY_RECORDING` (start while already recording on that tab), `HAR_NOT_RECORDING` (stop without a prior start). Recording data is held in memory; closing the tab while recording discards it. Cross-origin iframe requests are not captured (v1 limitation).
 


### PR DESCRIPTION
## Summary

- Syncs HAR truncation envelope behavior (ACT-970, PR #583) across all four doc surfaces
- Documents `--max-entries` default bump from 2000 to 10000
- Documents truncation signal: `meta.truncated`, `meta.warnings` with `HAR_TRUNCATED` message, `data.max_entries`
- Documents clean stop behavior: `meta.truncated = false`, empty `meta.warnings`
- Documents `har stop` return shape: `{ path, count, dropped, max_entries }`

## Surfaces updated

- `skills/actionbook/references/command-reference.md` — `--max-entries` default, `har stop` return shape, truncation signal section
- `docs/api-reference/cli.mdx` — `--max-entries` default, Note block with truncation envelope details
- `docs/guides/browser.mdx` — `--max-entries` default, Tip on truncation detection
- `skills/actionbook/SKILL.md` — new "HAR Recording" section with truncation guidance

## Source of truth

- `packages/cli/src/browser/observation/network_har.rs` — `DEFAULT_MAX_ENTRIES = 10000`, `execute_stop` emits `__truncated` + `__warnings`
- `packages/cli/src/output.rs:31-48` — envelope bridge for `meta.truncated` / `meta.warnings`

## Test plan

- [ ] Verify command-reference.md truncation signal section renders correctly
- [ ] Verify cli.mdx Note block renders in docs site
- [ ] Verify browser.mdx Tip renders in docs site
- [ ] Verify SKILL.md HAR Recording section parses correctly as skill context
- [ ] Cross-check default (10000), warning message format, and field names against source of truth