### PR TITLE
[root]ci: skip Discord notification for alpha releases

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   notify-discord:
     name: Notify Discord
+    if: ${{ !contains(github.event.release.tag_name, '-alpha') }}
     runs-on: ubuntu-latest
     steps:
       - name: Determine release type metadata


### PR DESCRIPTION
## Summary
- Alpha pre-releases (tags containing `-alpha`, e.g. `actionbook-cli-v1.5.0-alpha.1`) no longer trigger the Discord release notification, to avoid noise.
- Added `if: ${{ !contains(github.event.release.tag_name, '-alpha') }}` at the job level of `discord-release-notify.yml`; when an alpha release is published the whole job is skipped.
- Applies to every package (CLI / extension / dify plugin alphas are all skipped).

## Why tag-name check
`softprops/action-gh-release` does not set `prerelease: true` by default (verified via `gh release list` — existing alpha releases still have `isPrerelease: false`), so we cannot rely on `github.event.release.prerelease`. The tag name is the most reliable signal today.

## Test plan
- [ ] Next time an `actionbook-cli-v*-alpha.*` tag is published, the `notify-discord` job in the Discord Release Notification workflow should show as Skipped.
- [ ] A stable tag (e.g. `actionbook-cli-v1.5.2`) should still post to Discord as before.
