### PR TITLE
feat(session): collapse --set-session-id to get-or-create + profile-mismatch guard (ACT-987)

### DIFF
--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1991,6 +1991,50 @@ mod provider_start_tests {
     use crate::daemon::registry::{SessionEntry, SessionState, new_shared_registry};
     use crate::types::SessionId;
 
+    fn local_cmd(
+        session: Option<&str>,
+        set_session_id: Option<&str>,
+        profile: Option<&str>,
+    ) -> Cmd {
+        Cmd {
+            mode: Some(Mode::Local),
+            headless: Some(true),
+            profile: profile.map(str::to_string),
+            executable_path: None,
+            open_url: None,
+            tab_id: None,
+            cdp_endpoint: None,
+            provider: None,
+            header: vec![],
+            session: session.map(str::to_string),
+            set_session_id: set_session_id.map(str::to_string),
+            stealth: true,
+            max_tracked_requests: 500,
+            provider_env: ProviderEnv::new(),
+        }
+    }
+
+    async fn insert_running_local_session(
+        registry: &crate::daemon::registry::SharedRegistry,
+        sid: &str,
+        profile: &str,
+    ) {
+        let mut existing = SessionEntry::starting(
+            SessionId::new(sid).expect("session id"),
+            Mode::Local,
+            true,
+            true,
+            profile.to_string(),
+        );
+        existing.status = SessionState::Running;
+        existing.push_tab(
+            "native-tab-1".to_string(),
+            "about:blank".to_string(),
+            "Blank".to_string(),
+        );
+        registry.lock().await.insert(existing);
+    }
+
     fn spawn_single_response_server(
         response: &'static str,
     ) -> (String, thread::JoinHandle<String>) {
@@ -2208,6 +2252,150 @@ mod provider_start_tests {
             reg.get("dr3").map(|entry| entry.status),
             Some(SessionState::Starting)
         );
+    }
+
+    #[tokio::test]
+    async fn set_session_id_second_invocation_reuses_existing_running() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse1", crate::config::DEFAULT_PROFILE).await;
+
+        let result = execute(&local_cmd(None, Some("reuse1"), None), &registry).await;
+
+        match result {
+            ActionResult::Ok { data } => {
+                assert_eq!(data["session"]["session_id"], "reuse1");
+                assert_eq!(data["reused"], true);
+            }
+            other => panic!("expected reused ok result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_session_id_with_mismatched_profile_errors_session_profile_mismatch() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse2", "foo").await;
+
+        let result = execute(&local_cmd(None, Some("reuse2"), Some("bar")), &registry).await;
+
+        match result {
+            ActionResult::Fatal {
+                code,
+                message,
+                hint,
+                ..
+            } => {
+                assert_eq!(code, "SESSION_PROFILE_MISMATCH");
+                assert!(
+                    message.contains("reuse2"),
+                    "message must mention session id: {message}"
+                );
+                assert!(
+                    message.contains("foo"),
+                    "message must mention bound profile: {message}"
+                );
+                assert!(
+                    message.contains("bar"),
+                    "message must mention requested profile: {message}"
+                );
+                assert!(
+                    hint.contains("omit --profile"),
+                    "hint must tell caller they may omit --profile: {hint}"
+                );
+                assert!(
+                    hint.contains("--profile foo"),
+                    "hint must tell caller how to reuse the bound profile: {hint}"
+                );
+            }
+            other => panic!("expected SESSION_PROFILE_MISMATCH fatal, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_flag_with_mismatched_profile_errors_session_profile_mismatch() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse3", "foo").await;
+
+        let result = execute(&local_cmd(Some("reuse3"), None, Some("bar")), &registry).await;
+
+        match result {
+            ActionResult::Fatal {
+                code,
+                message,
+                hint,
+                ..
+            } => {
+                assert_eq!(code, "SESSION_PROFILE_MISMATCH");
+                assert!(
+                    message.contains("reuse3"),
+                    "message must mention session id: {message}"
+                );
+                assert!(
+                    message.contains("foo"),
+                    "message must mention bound profile: {message}"
+                );
+                assert!(
+                    message.contains("bar"),
+                    "message must mention requested profile: {message}"
+                );
+                assert!(
+                    hint.contains("omit --profile"),
+                    "hint must tell caller they may omit --profile: {hint}"
+                );
+                assert!(
+                    hint.contains("--profile foo"),
+                    "hint must tell caller how to reuse the bound profile: {hint}"
+                );
+            }
+            other => panic!("expected SESSION_PROFILE_MISMATCH fatal, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn session_flag_with_matching_profile_reuses_ok() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse4", "foo").await;
+
+        let result = execute(&local_cmd(Some("reuse4"), None, Some("foo")), &registry).await;
+
+        match result {
+            ActionResult::Ok { data } => {
+                assert_eq!(data["session"]["session_id"], "reuse4");
+                assert_eq!(data["reused"], true);
+            }
+            other => panic!("expected reused ok result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_session_id_with_matching_profile_reuses_ok() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse5", "foo").await;
+
+        let result = execute(&local_cmd(None, Some("reuse5"), Some("foo")), &registry).await;
+
+        match result {
+            ActionResult::Ok { data } => {
+                assert_eq!(data["session"]["session_id"], "reuse5");
+                assert_eq!(data["reused"], true);
+            }
+            other => panic!("expected reused ok result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn set_session_id_with_no_profile_flag_reuses_ok() {
+        let registry = new_shared_registry();
+        insert_running_local_session(&registry, "reuse6", "foo").await;
+
+        let result = execute(&local_cmd(None, Some("reuse6"), None), &registry).await;
+
+        match result {
+            ActionResult::Ok { data } => {
+                assert_eq!(data["session"]["session_id"], "reuse6");
+                assert_eq!(data["reused"], true);
+            }
+            other => panic!("expected reused ok result, got {other:?}"),
+        }
     }
 }
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -45,8 +45,8 @@ Provider examples:
   actionbook browser restart --session s1    # provider sessions: mints a fresh remote
 
 --session: get-or-create — reuses an existing session with the given ID, or creates one if not found.
---set-session-id: always creates — fails if the ID is already in use.
-Reuse: if a session with the same profile already exists, it is reused.
+--set-session-id: get-or-create — reuses an existing running session with the given ID (same as --session), otherwise creates a new one.
+Reuse: if a session with the same profile already exists, it is reused. Passing --profile with a value that does not match the bound profile fails with SESSION_PROFILE_MISMATCH.
 The returned session_id and tab_id are used to address all subsequent commands.")]
 pub struct Cmd {
     /// Browser mode
@@ -95,7 +95,7 @@ pub struct Cmd {
     #[arg(long, conflicts_with = "set_session_id")]
     #[serde(default)]
     pub session: Option<String>,
-    /// Specify a semantic session ID (always creates, fails if ID exists)
+    /// Specify a semantic session ID (get-or-create: reuse if a Running session with this ID exists, otherwise create)
     #[arg(long)]
     pub set_session_id: Option<String>,
     /// Enable stealth/anti-detection mode (default: true). Use --no-stealth to disable.
@@ -263,8 +263,10 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     };
 
     // ── Get-or-create by session ID (all modes) ──
-    // --session: reuse existing session if found, otherwise create with that ID.
-    if let Some(ref sid) = cmd.session {
+    // Both --session and --set-session-id reuse an existing Running session
+    // with the given ID; --set-session-id was originally force-create but
+    // collapsed to get-or-create in ACT-987 so scripts can be idempotent.
+    if let Some(sid) = cmd.session.as_ref().or(cmd.set_session_id.as_ref()) {
         let reg = registry.lock().await;
         if let Some(existing) = reg.get(sid) {
             match existing.status {
@@ -937,6 +939,33 @@ async fn reuse_running_session(
     registry: &SharedRegistry,
     target: ReuseTarget,
 ) -> ActionResult {
+    // Profile-mismatch guard: when the caller passes --profile explicitly, it
+    // must agree with the session's bound profile. Runs before navigate/CDP
+    // side effects so the rejection is side-effect-free.
+    if let Some(requested) = cmd.profile.as_deref() {
+        let reg = registry.lock().await;
+        if let Some(entry) = reg.get(&target.session_id)
+            && entry.profile != requested
+        {
+            let bound = entry.profile.clone();
+            let sid = target.session_id.clone();
+            let requested = requested.to_string();
+            drop(reg);
+            return ActionResult::fatal_with_details(
+                "SESSION_PROFILE_MISMATCH",
+                format!(
+                    "session '{sid}' is bound to profile '{bound}' but --profile '{requested}' was passed"
+                ),
+                format!("omit --profile or pass --profile {bound} to reuse"),
+                json!({
+                    "session_id": sid,
+                    "bound_profile": bound,
+                    "requested_profile": requested,
+                }),
+            );
+        }
+    }
+
     if let Some(url) = &cmd.open_url {
         let final_url = ensure_scheme(url).unwrap_or_else(|_| "about:blank".to_string());
         if let Some(ref cdp) = target.cdp
@@ -2141,8 +2170,13 @@ mod provider_start_tests {
         assert!(request.to_ascii_lowercase().contains("content-length: 0"));
     }
 
+    // Pre-existing test, renamed from `explicit_provider_session_conflict_fails_before_connect`
+    // to reflect ACT-987 semantics: `--set-session-id` now collapses to get-or-create, so
+    // an existing Running session with the same ID is reused instead of erroring. The
+    // unreachable `127.0.0.1:9` provider URL still proves the no-provider-connect
+    // invariant — the reuse path resolves locally before any connect attempt.
     #[tokio::test]
-    async fn explicit_provider_session_conflict_fails_before_connect() {
+    async fn explicit_set_session_id_reuses_existing_without_connecting() {
         let registry = new_shared_registry();
 
         let mut existing = SessionEntry::starting(
@@ -2183,11 +2217,11 @@ mod provider_start_tests {
         .await;
 
         match result {
-            ActionResult::Fatal { code, message, .. } => {
-                assert_eq!(code, "SESSION_ALREADY_EXISTS");
-                assert!(message.contains("session id 'hyp3' is already in use"));
+            ActionResult::Ok { data } => {
+                assert_eq!(data["session"]["session_id"], "hyp3");
+                assert_eq!(data["reused"], true);
             }
-            other => panic!("expected fatal result, got {other:?}"),
+            other => panic!("expected reused ok result, got {other:?}"),
         }
     }
 

--- a/packages/cli/tests/e2e/browser_lifecycle.rs
+++ b/packages/cli/tests/e2e/browser_lifecycle.rs
@@ -1119,13 +1119,76 @@ fn lifecycle_set_session_id_rejects_reuse_of_occupied_profile() {
 }
 
 /// When --set-session-id matches an already-running session's ID,
-/// the command must fail with SESSION_ALREADY_EXISTS, not silently reuse.
+/// the command must reuse the existing session instead of failing.
 #[test]
-fn lifecycle_set_session_id_rejects_duplicate_id() {
+fn set_session_id_twice_reuses_same_session() {
     if skip() {
         return;
     }
-    let (sid, prof) = unique_session("dupid");
+    let (sid, prof) = unique_session("setsidreuse");
+    let url = url_a();
+
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--profile",
+            &prof,
+            "--set-session-id",
+            &sid,
+            "--open-url",
+            &url,
+        ],
+        30,
+    );
+    assert_success(&out, "start session");
+    let _guard = SessionGuard::new(&sid);
+    let v = parse_json(&out);
+    let first_session_id = v["data"]["session"]["session_id"]
+        .as_str()
+        .expect("first session id")
+        .to_string();
+    wait_url_contains(&sid, "t1", "page-a");
+
+    // Try to start again with the SAME session ID.
+    let out2 = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--profile",
+            &prof,
+            "--set-session-id",
+            &sid,
+            "--open-url",
+            &url,
+        ],
+        30,
+    );
+    assert_success(&out2, "duplicate set-session-id should reuse");
+    let v = parse_json(&out2);
+    assert_eq!(
+        v["data"]["session"]["session_id"], first_session_id,
+        "reused session must keep the original session_id"
+    );
+    assert!(
+        v["data"]["reused"].as_bool().unwrap_or(false),
+        "second --set-session-id start must be marked as reused"
+    );
+}
+
+#[test]
+fn set_session_id_profile_mismatch_errors() {
+    if skip() {
+        return;
+    }
+    let (sid, prof) = unique_session("setsidmismatch");
+    let (_, other_prof) = unique_session("setsidmismatch-alt");
 
     let out = headless_json(
         &[
@@ -1144,8 +1207,6 @@ fn lifecycle_set_session_id_rejects_duplicate_id() {
     assert_success(&out, "start session");
     let _guard = SessionGuard::new(&sid);
 
-    // Try to start again with the SAME session ID (different profile).
-    let (_, prof2) = unique_session("dupid2");
     let out = headless_json(
         &[
             "browser",
@@ -1154,27 +1215,37 @@ fn lifecycle_set_session_id_rejects_duplicate_id() {
             "local",
             "--headless",
             "--profile",
-            &prof2,
+            &other_prof,
             "--set-session-id",
             &sid,
         ],
         30,
     );
-    assert_failure(&out, "duplicate set-session-id must fail");
+    assert_failure(&out, "profile mismatch should fail for --set-session-id");
     let v = parse_json(&out);
-    assert_eq!(v["ok"], false);
-    assert_eq!(
-        v["error"]["code"], "SESSION_ALREADY_EXISTS",
-        "must return SESSION_ALREADY_EXISTS for duplicate ID"
-    );
+    assert_eq!(v["error"]["code"], "SESSION_PROFILE_MISMATCH");
+    assert_eq!(v["error"]["retryable"], false);
     let message = v["error"]["message"].as_str().unwrap_or("");
+    let hint = v["error"]["hint"].as_str().unwrap_or("");
     assert!(
         message.contains(&sid),
-        "duplicate-id message must identify the conflicting session id: {message}"
+        "message must mention session id: {message}"
     );
     assert!(
-        !message.contains(&prof2),
-        "duplicate-id message must not misreport the requested profile as occupied: {message}"
+        message.contains(&prof),
+        "message must mention bound profile: {message}"
+    );
+    assert!(
+        message.contains(&other_prof),
+        "message must mention requested profile: {message}"
+    );
+    assert!(
+        hint.contains("omit --profile"),
+        "hint must allow reusing without --profile: {hint}"
+    );
+    assert!(
+        hint.contains(&format!("--profile {prof}")),
+        "hint must point to the bound profile: {hint}"
     );
 }
 
@@ -2021,6 +2092,136 @@ fn lifecycle_session_flag_reuses_when_exists() {
     assert_eq!(
         v2["data"]["reused"], true,
         "second start should be marked as reused"
+    );
+}
+
+#[test]
+fn session_flag_profile_mismatch_errors() {
+    if skip() {
+        return;
+    }
+    let (sid, prof) = unique_session("sflagmismatch");
+    let (_, other_prof) = unique_session("sflagmismatch-alt");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--profile",
+            &prof,
+            "--session",
+            &sid,
+        ],
+        30,
+    );
+    assert_success(&out, "start session");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--profile",
+            &other_prof,
+            "--session",
+            &sid,
+        ],
+        30,
+    );
+    assert_failure(&out, "profile mismatch should fail for --session");
+    let v = parse_json(&out);
+    assert_eq!(v["error"]["code"], "SESSION_PROFILE_MISMATCH");
+    assert_eq!(v["error"]["retryable"], false);
+    let message = v["error"]["message"].as_str().unwrap_or("");
+    let hint = v["error"]["hint"].as_str().unwrap_or("");
+    assert!(
+        message.contains(&sid),
+        "message must mention session id: {message}"
+    );
+    assert!(
+        message.contains(&prof),
+        "message must mention bound profile: {message}"
+    );
+    assert!(
+        message.contains(&other_prof),
+        "message must mention requested profile: {message}"
+    );
+    assert!(
+        hint.contains("omit --profile"),
+        "hint must allow reusing without --profile: {hint}"
+    );
+    assert!(
+        hint.contains(&format!("--profile {prof}")),
+        "hint must point to the bound profile: {hint}"
+    );
+}
+
+#[test]
+fn reuse_with_open_url_navigates_first_tab_in_place() {
+    if skip() {
+        return;
+    }
+    let (sid, prof) = unique_session("sflagopenurl");
+
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--profile",
+            &prof,
+            "--session",
+            &sid,
+        ],
+        30,
+    );
+    assert_success(&out, "start initial session");
+    let _guard = SessionGuard::new(&sid);
+
+    let out = headless_json(
+        &[
+            "browser",
+            "start",
+            "--mode",
+            "local",
+            "--headless",
+            "--session",
+            &sid,
+            "--open-url",
+            &url_b(),
+        ],
+        30,
+    );
+    assert_success(&out, "reuse session with open-url");
+    let v = parse_json(&out);
+    assert_eq!(v["data"]["session"]["session_id"], sid);
+    assert_eq!(v["data"]["reused"], true);
+
+    wait_url_contains(&sid, "t1", "page-b");
+    let status = headless_json(&["browser", "status", "--session", &sid], 10);
+    assert_success(&status, "status after reuse navigate");
+    let status = parse_json(&status);
+    let tabs = status["data"]["tabs"].as_array().expect("tabs array");
+    assert_eq!(
+        tabs.len(),
+        1,
+        "reuse with --open-url must not create a new tab"
+    );
+
+    let url_out = headless(&["browser", "url", "--session", &sid, "--tab", "t1"], 10);
+    assert_success(&url_out, "browser url after reuse navigate");
+    let url_text = stdout_str(&url_out);
+    assert!(
+        url_text.contains("page-b"),
+        "first tab must navigate in place, got: {url_text}"
     );
 }
 


### PR DESCRIPTION
## Summary

Implements ACT-987 (plan approved by @junliang-mk in msg `e1e18f8c`):

1. **`--set-session-id` collapses to get-or-create.** A second `actionbook browser start --set-session-id s1` against a Running `s1` now reuses (exit 0, same `session_id`, `data.reused=true`) instead of erroring `SESSION_ALREADY_EXISTS`. Mirrors existing `--session` semantics exactly. Implementation widens the reuse-by-id branch in `execute()` from `cmd.session` to `cmd.session.or(cmd.set_session_id)`.

2. **New `SESSION_PROFILE_MISMATCH` guard applies to BOTH flags.** When the caller passes `--profile` explicitly and its value differs from the session's bound profile, start fails fast with a non-retryable error before any navigate/CDP side effect. Placement is at the top of `reuse_running_session` after target lookup succeeds. Omitted or matching `--profile` continues to reuse without error. This also plugs a pre-existing silent-override bug on `--session`.

3. **Help text updated.** `--set-session-id` doc now reads "get-or-create" (was "always creates, fails if ID exists"); `after_help` block updated likewise and documents the profile-mismatch guard.

Envelope shape for the new guard:
- `error.code`: `"SESSION_PROFILE_MISMATCH"`
- `error.retryable`: `false` (derived via exclusion from `is_retryable_code`)
- `error.message`: `"session '<sid>' is bound to profile '<bound>' but --profile '<requested>' was passed"`
- `error.hint`: `"omit --profile or pass --profile <bound> to reuse"`
- `error.details`: `{ session_id, bound_profile, requested_profile }`

## Backward compatibility

- Envelope contract is additive — new `SESSION_PROFILE_MISMATCH` code, no existing code re-semantics.
- Exit-code behaviour for existing `--session` on Running with matching or omitted `--profile` is unchanged.
- Q3 zero-code-change axis (`--open-url` on reused session → `Page.navigate` on first `native_id`) is preserved; E2E `reuse_with_open_url_navigates_first_tab_in_place` passes untouched.
- `--set-session-id` flag is kept (user picked Option A, flag stays as a get-or-create alias). No flag rename, no deprecation.

## Pre-existing test rename (called out for review)

`explicit_provider_session_conflict_fails_before_connect` renamed to `explicit_set_session_id_reuses_existing_without_connecting`. The old assertion (`Fatal SESSION_ALREADY_EXISTS`) tested pre-ACT-987 behaviour that no longer applies — the new semantics reuse the existing session. The test's original intent (no provider connect for this input shape) is preserved: the unreachable `127.0.0.1:9` API URL still proves the invariant — if the widened reuse branch regressed, the test would hang on that URL. Sister test `conflicting_set_session_id_cleans_up_provider_session` is untouched and continues to cover the provider-cleanup path via `execute_cloud`. Rename pre-approved by lead (msg `b6d69022`) and test (msg `4579e519`) as obsolete-test alignment, not red-contract drift.

## Commit graph

- red (test) — `ebfe4b247` — `test: add failing session reuse contract coverage (ACT-987)`
- green (impl) — `8248b8fc5` — `feat(session): collapse --set-session-id to get-or-create + profile-mismatch guard (ACT-987)`

## Local verification

On head `8248b8fc5`:

- `cargo fmt --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --lib` (all) — 477 passed / 0 failed
- `cargo test --lib provider_start_tests` — 9 passed / 0 failed (6 red unit tests + 3 pre-existing including the renamed one)
- `RUN_E2E_TESTS=true cargo test --test e2e <name>` — all 4 locked E2Es pass serially:
  - `set_session_id_twice_reuses_same_session` — 8.84s
  - `set_session_id_profile_mismatch_errors` — 1.59s
  - `session_flag_profile_mismatch_errors` — 1.57s
  - `reuse_with_open_url_navigates_first_tab_in_place` — 8.27s
- Cross-reviewer (`cli-roger-test`) re-verified on fresh detached worktree at `8248b8fc5`: 9/9 lib + 4/4 real E2E all pass.

## Out-of-scope follow-ups

- Provider-mismatch policy (cross-provider reuse guard) — intentionally not in ACT-987.
- `--set-session-id` deprecation (Option B) — user picked A; flag stays.
- Reuse across machines / daemon restart — separate concern.

## Test plan

- [ ] CI green on main flow
- [ ] Codex review clean (any threads replied + resolved before merge)
- [ ] Lead autonomous-merge per `feedback_autonomous_merge.md`