### PR TITLE
docs(start): document --set-session-id get-or-create and SESSION_PROFILE_MISMATCH

### DIFF
--- a/docs/api-reference/cli.mdx
+++ b/docs/api-reference/cli.mdx
@@ -121,7 +121,7 @@ Start or attach a browser session. Entry point for all modes including cloud pro
 | `--mode <mode>` | Browser mode: `local`, `extension`, or `cloud` |
 | `-p, --provider <name>` | Cloud browser provider: `driver`, `hyperbrowser`, `browseruse`. Implies `--mode cloud` |
 | `--session <id>` | Session ID (get-or-create: reuse if exists, create if not) |
-| `--set-session-id <id>` | Always create a new session with this ID (fails if already exists) |
+| `--set-session-id <id>` | Session ID (get-or-create: same as `--session`) |
 | `--open-url <url>` | Open this URL on start |
 | `--cdp-endpoint <url>` | Connect to an existing CDP endpoint |
 | `--header <KEY:VALUE>` | Headers for CDP endpoint (may be repeated) |
@@ -142,6 +142,16 @@ actionbook browser start --mode cloud --cdp-endpoint wss://browser.example.com/w
 <Note>
   `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
   See [Cloud Providers](/guides/browser#cloud-providers) for provider-specific env vars.
+</Note>
+
+<Note>
+  Both `--session` and `--set-session-id` are **get-or-create**: they reuse a Running session with the given ID, or create one if not found. When reusing, if `--profile` is passed and does not match the session's bound profile, the command fails with `SESSION_PROFILE_MISMATCH`:
+
+  - `error.code`: `"SESSION_PROFILE_MISMATCH"` (retryable: false)
+  - `error.hint`: `"omit --profile or pass --profile <bound> to reuse"`
+  - `error.details`: `{ session_id, bound_profile, requested_profile }`
+
+  Omitting `--profile` or passing a matching value allows reuse.
 </Note>
 
 #### Other Session Commands

--- a/docs/guides/browser.mdx
+++ b/docs/guides/browser.mdx
@@ -212,6 +212,12 @@ actionbook browser restart --session s1              # restart, preserving sessi
 actionbook browser close --session s1                # close a session
 ```
 
+Both `--session` and `--set-session-id` are get-or-create: they reuse a Running session with the given ID, or create one if not found.
+
+<Tip>
+  When reusing a session, if `--profile` is passed and does not match the session's bound profile, the command fails with `SESSION_PROFILE_MISMATCH`. Omit `--profile` or pass the matching value to reuse.
+</Tip>
+
 ### Tab Management
 
 ```bash

--- a/skills/actionbook/SKILL.md
+++ b/skills/actionbook/SKILL.md
@@ -54,6 +54,8 @@ Every browser command is **stateless** — pass `--session` and `--tab` explicit
 actionbook browser start --set-session-id s1
 ```
 
+Both `--session` and `--set-session-id` are get-or-create: they reuse a Running session with the given ID, or create one if not found. If `--profile` is passed and does not match the session's bound profile, the command fails with `SESSION_PROFILE_MISMATCH`.
+
 ### Core workflow: snapshot, act, wait
 
 ```bash

--- a/skills/actionbook/references/command-reference.md
+++ b/skills/actionbook/references/command-reference.md
@@ -36,7 +36,7 @@ actionbook man youtube                                     # Alias for manual
 
 ```bash
 actionbook browser start                                   # Start a browser session
-actionbook browser start --set-session-id s1               # Start with a custom session ID
+actionbook browser start --set-session-id s1               # Get-or-create: reuse if Running, create if not (same as --session)
 actionbook browser start --session s1                      # Get-or-create: reuse if exists, create if not
 actionbook browser start --headless                        # Start headless
 actionbook browser start --mode cloud --cdp-endpoint <ws>  # Connect to cloud browser
@@ -60,6 +60,8 @@ actionbook browser restart --session s1                    # Restart a session
 - `meta.warnings: ["session not found in daemon — already closed or daemon restarted"]`
 
 If another close is already in flight for the same session, the command returns `SESSION_CLOSING` (fatal, unchanged). Safe to call unconditionally during cleanup without checking session existence first. Read `meta.warnings` to distinguish a fresh close from an already-gone session.
+
+Both `--session` and `--set-session-id` are get-or-create: they reuse a Running session with the given ID, or create one if not found. `--set-session-id` is a functional alias for `--session`. When reusing, if `--profile` is passed and does not match the session's bound profile, the command fails with `SESSION_PROFILE_MISMATCH` (retryable: false). Omitting `--profile` or passing a matching value allows reuse.
 
 Supported cloud providers: `driver` (`DRIVER_API_KEY`), `hyperbrowser` (`HYPERBROWSER_API_KEY`), `browseruse` (`BROWSER_USE_API_KEY`). `-p` is mutually exclusive with `--cdp-endpoint` and `--mode local/extension`.
 


### PR DESCRIPTION
## Summary

- Syncs session reuse semantics (ACT-987, PR #587) across all four doc surfaces
- Updates `--set-session-id` from "always create, fails if exists" to "get-or-create" (now a functional alias for `--session`)
- Documents new `SESSION_PROFILE_MISMATCH` error code: fires when reusing a session with a `--profile` that doesn't match the bound profile
- Documents error envelope: `error.code`, `error.hint`, `error.details` with `session_id`, `bound_profile`, `requested_profile`

## Surfaces updated

- `skills/actionbook/references/command-reference.md` — updated `--set-session-id` comment, added reuse/profile-mismatch paragraph
- `docs/api-reference/cli.mdx` — updated flag table, added Note block with SESSION_PROFILE_MISMATCH envelope details
- `docs/guides/browser.mdx` — added get-or-create explanation + Tip on profile mismatch
- `skills/actionbook/SKILL.md` — added session reuse + profile mismatch note

## Source of truth

- `packages/cli/src/browser/session/start.rs:47-49` — after_help docs
- `packages/cli/src/browser/session/start.rs:937-966` — profile mismatch guard implementation

## Test plan

- [ ] Verify command-reference.md updated comment and paragraph render correctly
- [ ] Verify cli.mdx flag table + Note block renders in docs site
- [ ] Verify browser.mdx Tip renders in docs site
- [ ] Verify SKILL.md session reuse note parses correctly as skill context
- [ ] Cross-check error code, hint text, and details fields against source of truth