### PR TITLE
[packages/cli]fix(test): align global-timeout nav assertion with CDP_NAV_TIMEOUT

### DIFF
--- a/packages/cli/tests/e2e/timeout.rs
+++ b/packages/cli/tests/e2e/timeout.rs
@@ -30,7 +30,7 @@ fn global_timeout_applies_to_browser_commands() {
     assert_failure(&out, "global timeout on goto");
     let v = parse_json(&out);
     assert_eq!(v["command"], "browser goto");
-    assert_error_envelope(&v, "TIMEOUT");
+    assert_error_envelope(&v, "CDP_NAV_TIMEOUT");
     assert_eq!(v["error"]["retryable"], true);
     assert_eq!(v["context"]["session_id"], sid);
     assert_eq!(v["context"]["tab_id"], tid);


### PR DESCRIPTION
## Summary

- `timeout::global_timeout_applies_to_browser_commands` has been breaking CI on `main` since #580 (ACT-972) landed.
- That PR deliberately changed the global `--timeout` expiry path for navigation commands (`goto`/`back`/`forward`/`reload`) in `packages/cli/src/main.rs:333-340` to emit `CDP_NAV_TIMEOUT` instead of the generic `TIMEOUT` — matching the new CDP error taxonomy. The existing test was not updated alongside.
- One-line fix: update the assertion to expect `CDP_NAV_TIMEOUT`. `retryable: true` still holds — both codes are in the retryable set at `packages/cli/src/error.rs:232-234`.

Failing run: https://github.com/actionbook/actionbook/actions/runs/24763652857/job/72452741846

```
thread 'timeout::global_timeout_applies_to_browser_commands' panicked at tests/e2e/harness.rs:1485:5:
assertion `left == right` failed
  left:  "CDP_NAV_TIMEOUT"
 right:  "TIMEOUT"
```

## Test plan

- [x] CI green on `Tests (cli)` workflow (Lint + Unit + E2E)
- [x] Locally: `cd packages/cli && RUN_E2E_TESTS=true cargo test --test e2e timeout::global_timeout_applies_to_browser_commands`

🤖 Generated with [Claude Code](https://claude.com/claude-code)