### PR TITLE
chore: backfill CLI changesets for 1.6.0 release

### DIFF
--- a/.changeset/cli-browser-close-idempotent.md
+++ b/.changeset/cli-browser-close-idempotent.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": patch
+---
+
+`browser close` is now idempotent. When the target session is already gone (never started, or closed by another caller), the command returns success with `meta.warnings: ["SESSION_ALREADY_GONE: ..."]` instead of a fatal error. Cleanup scripts can call `browser close` unconditionally without having to first check session existence. A concurrent close for the same session still returns the fatal `SESSION_CLOSING` code (unchanged).

--- a/.changeset/cli-cdp-error-taxonomy.md
+++ b/.changeset/cli-cdp-error-taxonomy.md
@@ -1,0 +1,7 @@
+---
+"@actionbookdev/cli": minor
+---
+
+Structured CDP error taxonomy. CDP failures now surface through a fixed set of codes in `error.code` — `CDP_NAV_TIMEOUT`, `CDP_NOT_INTERACTABLE`, `CDP_NODE_NOT_FOUND`, `CDP_TARGET_CLOSED`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC` — each with a stable `retryable` flag and `error.details` containing `cdp_code` (upstream numeric code) and `reason` (raw message). Replaces the previous single `CDP_ERROR` literal for classified cases.
+
+Behavior change: `CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` now report `retryable: true` (previously all CDP errors were `retryable: false`). Callers that key retry decisions off the envelope's `retryable` flag should verify the new behavior matches their expectations. Fifteen-plus hand-crafted `CDP_ERROR` literals remain as a legacy fallback and will migrate in a follow-up.

--- a/.changeset/cli-daemon-sweep-empty-session-dirs.md
+++ b/.changeset/cli-daemon-sweep-empty-session-dirs.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": patch
+---
+
+Daemon now sweeps empty session directories and stale `__fetch_*.json` files at start and stop. Prevents `~/.actionbook/sessions/` from accumulating orphan directories when sessions exit abnormally.

--- a/.changeset/cli-eval-file-stdin-sources.md
+++ b/.changeset/cli-eval-file-stdin-sources.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": minor
+---
+
+`browser eval` now accepts expression input from a file via `--file <path>` or from stdin when the positional expression is omitted. Existing positional-arg usage is unchanged. Useful for evaluating multi-line scripts without escaping them on the shell.

--- a/.changeset/cli-eval-structured-error-codes.md
+++ b/.changeset/cli-eval-structured-error-codes.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": minor
+---
+
+`browser eval` now returns a structured error envelope with an `EvalErrorCode` taxonomy in `error.code`: `EVAL_COMPILE_ERROR`, `EVAL_RUNTIME_ERROR`, `EVAL_TIMEOUT`, `EVAL_SERIALIZATION_ERROR`, `EVAL_INVALID_INPUT`. The raw V8 reason and line/column offsets are preserved under `error.details`. Replaces the previous free-form error message so callers can branch on the code instead of string-matching.

--- a/.changeset/cli-har-truncation-signal.md
+++ b/.changeset/cli-har-truncation-signal.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": minor
+---
+
+HAR truncation now surfaces explicitly in the `browser network har stop` envelope. When the FIFO ring buffer dropped older entries, the response adds `meta.truncated: true`, `meta.warnings: ["HAR_TRUNCATED: N earlier entries dropped (max_entries=M); raise --max-entries or stop recording sooner to keep the full trace"]`, and `data.max_entries` (the configured cap). Clean stops emit no truncation marker. `DEFAULT_MAX_ENTRIES` is bumped from 2000 to 10000 so longer interactive sessions fit without truncation.

--- a/.changeset/cli-session-reuse-collapse.md
+++ b/.changeset/cli-session-reuse-collapse.md
@@ -1,0 +1,7 @@
+---
+"@actionbookdev/cli": minor
+---
+
+`browser start --set-session-id <id>` is now get-or-create (functional alias for `--session <id>`). Previously it always created a new session and failed with `SESSION_ALREADY_EXISTS` when the ID was already running; scripts calling it twice for idempotent attach had to handle that error. Both flags now reuse a Running session with the given ID or create one if not found.
+
+When reusing, passing `--profile <name>` that does not match the session's bound profile fails with the new `SESSION_PROFILE_MISMATCH` error code (retryable: false). `error.hint` explains the required profile; `error.details` includes `session_id`, `bound_profile`, and `requested_profile`. Omit `--profile` or pass the matching value to reuse successfully.

--- a/.changeset/cli-wait-network-idle-edge-triggered.md
+++ b/.changeset/cli-wait-network-idle-edge-triggered.md
@@ -1,0 +1,5 @@
+---
+"@actionbookdev/cli": patch
+---
+
+`wait network-idle` is now edge-triggered: pre-existing long-lived connections at the start of the wait (websockets, long-poll requests that opened before the command ran) are ignored. Previously these could keep the wait from ever resolving on pages with persistent background traffic.


### PR DESCRIPTION
## Summary

- Backfills eight missing \`.changeset/*.md\` files for user-facing CLI PRs merged since 1.5.1 (tag \`8cf1a3e0b\`) that shipped without changesets.
- Once merged, [changesets-action](https://github.com/changesets/action) will roll these into the existing release PR #585, expanding its \`Releases\` section for \`@actionbookdev/cli@1.6.0\`.
- Release version stays \`1.6.0\` (minor) — matches the pre-existing \`cli-hyperbrowser-proxy-country\` changeset from #572.

## Coverage

| PR | Type | ACT | Summary |
|----|------|-----|---------|
| #558 | patch | ACT-965 | \`wait network-idle\` edge-triggered (pre-existing connections ignored) |
| #564 | patch | — | Daemon sweeps empty session dirs + stale \`__fetch_*.json\` at start/stop |
| #573 | minor | ACT-967/973 | \`browser eval\` structured error taxonomy (\`EVAL_COMPILE_ERROR\`, \`EVAL_RUNTIME_ERROR\`, \`EVAL_TIMEOUT\`, \`EVAL_SERIALIZATION_ERROR\`, \`EVAL_INVALID_INPUT\`) |
| #576 | minor | ACT-975 | \`browser eval\` accepts \`--file <path>\` and stdin expression sources |
| #577 | patch | ACT-969 | \`browser close\` idempotent when session is already gone (returns ok + \`meta.warnings: ["SESSION_ALREADY_GONE: ..."]\`) |
| #580 | minor | ACT-972 | Structured CDP error taxonomy (6 codes: \`CDP_NAV_TIMEOUT\`, \`CDP_NOT_INTERACTABLE\`, \`CDP_NODE_NOT_FOUND\`, \`CDP_TARGET_CLOSED\`, \`CDP_PROTOCOL_ERROR\`, \`CDP_GENERIC\`); \`retryable\` true for NAV_TIMEOUT + TARGET_CLOSED |
| #583 | minor | ACT-970 | HAR truncation signal in \`network har stop\` envelope (\`meta.truncated\`, \`meta.warnings\`, \`data.max_entries\`) + \`DEFAULT_MAX_ENTRIES\` 2000 → 10000 |
| #587 | minor | ACT-987 | \`--set-session-id\` collapsed to get-or-create (alias for \`--session\`) + \`SESSION_PROFILE_MISMATCH\` error on profile conflict |

## Rationale

Audit found PR #585 referenced only a single changeset (\`cli-hyperbrowser-proxy-country\`) while eight user-facing CLI PRs had already merged. Without this backfill, the 1.6.0 release notes would miss every behavior change shipped after #572.

Docs PRs, CI, tests, extension package changes, and \`chore: version packages\` are correctly excluded — those do not produce changesets for the \`@actionbookdev/cli\` package.

## Test plan

- [ ] CI runs \`changesets-action\` and verifies all 8 \`.md\` files parse (no version conflicts, no malformed frontmatter)
- [ ] After merge, confirm PR #585 auto-updates to list all 8 entries in its \`Releases\` section for \`@actionbookdev/cli@1.6.0\`
- [ ] Release type remains \`minor\` (1.5.1 → 1.6.0), not bumped to \`major\` by any entry