### PR TITLE
chore(changesets): simplify 1.6.0 entries to one sentence each

### DIFF
--- a/.changeset/cli-browser-close-idempotent.md
+++ b/.changeset/cli-browser-close-idempotent.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": patch
 ---
 
-`browser close` is now idempotent. When the target session is already gone (never started, or closed by another caller), the command returns success with `meta.warnings: ["SESSION_ALREADY_GONE: ..."]` instead of a fatal error. Cleanup scripts can call `browser close` unconditionally without having to first check session existence. A concurrent close for the same session still returns the fatal `SESSION_CLOSING` code (unchanged).
+`browser close` is idempotent — when the session is already gone it returns ok with `meta.warnings: ["SESSION_ALREADY_GONE: ..."]` instead of a fatal error.

--- a/.changeset/cli-cdp-error-taxonomy.md
+++ b/.changeset/cli-cdp-error-taxonomy.md
@@ -2,6 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-Structured CDP error taxonomy. CDP failures now surface through a fixed set of codes in `error.code` — `CDP_NAV_TIMEOUT`, `CDP_NOT_INTERACTABLE`, `CDP_NODE_NOT_FOUND`, `CDP_TARGET_CLOSED`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC` — each with a stable `retryable` flag and `error.details` containing `cdp_code` (upstream numeric code) and `reason` (raw message). Replaces the previous single `CDP_ERROR` literal for classified cases.
-
-Behavior change: `CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` now report `retryable: true` (previously all CDP errors were `retryable: false`). Callers that key retry decisions off the envelope's `retryable` flag should verify the new behavior matches their expectations. Fifteen-plus hand-crafted `CDP_ERROR` literals remain as a legacy fallback and will migrate in a follow-up.
+CDP errors surface as six classified codes (`CDP_NAV_TIMEOUT`, `CDP_NOT_INTERACTABLE`, `CDP_NODE_NOT_FOUND`, `CDP_TARGET_CLOSED`, `CDP_PROTOCOL_ERROR`, `CDP_GENERIC`), with `CDP_NAV_TIMEOUT` and `CDP_TARGET_CLOSED` now `retryable: true`.

--- a/.changeset/cli-daemon-sweep-empty-session-dirs.md
+++ b/.changeset/cli-daemon-sweep-empty-session-dirs.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": patch
 ---
 
-Daemon now sweeps empty session directories and stale `__fetch_*.json` files at start and stop. Prevents `~/.actionbook/sessions/` from accumulating orphan directories when sessions exit abnormally.
+Daemon sweeps empty session directories and stale `__fetch_*.json` files at start and stop.

--- a/.changeset/cli-eval-file-stdin-sources.md
+++ b/.changeset/cli-eval-file-stdin-sources.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-`browser eval` now accepts expression input from a file via `--file <path>` or from stdin when the positional expression is omitted. Existing positional-arg usage is unchanged. Useful for evaluating multi-line scripts without escaping them on the shell.
+`browser eval` accepts expressions from `--file <path>` or stdin when no positional expression is given.

--- a/.changeset/cli-eval-structured-error-codes.md
+++ b/.changeset/cli-eval-structured-error-codes.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-`browser eval` now returns a structured error envelope with an `EvalErrorCode` taxonomy in `error.code`: `EVAL_COMPILE_ERROR`, `EVAL_RUNTIME_ERROR`, `EVAL_TIMEOUT`, `EVAL_SERIALIZATION_ERROR`, `EVAL_INVALID_INPUT`. The raw V8 reason and line/column offsets are preserved under `error.details`. Replaces the previous free-form error message so callers can branch on the code instead of string-matching.
+`browser eval` returns structured error codes (`EVAL_COMPILE_ERROR`, `EVAL_RUNTIME_ERROR`, `EVAL_TIMEOUT`, `EVAL_SERIALIZATION_ERROR`, `EVAL_INVALID_INPUT`) with the raw V8 reason preserved in `error.details`.

--- a/.changeset/cli-har-truncation-signal.md
+++ b/.changeset/cli-har-truncation-signal.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-HAR truncation now surfaces explicitly in the `browser network har stop` envelope. When the FIFO ring buffer dropped older entries, the response adds `meta.truncated: true`, `meta.warnings: ["HAR_TRUNCATED: N earlier entries dropped (max_entries=M); raise --max-entries or stop recording sooner to keep the full trace"]`, and `data.max_entries` (the configured cap). Clean stops emit no truncation marker. `DEFAULT_MAX_ENTRIES` is bumped from 2000 to 10000 so longer interactive sessions fit without truncation.
+`browser network har stop` surfaces truncation via `meta.truncated` / `meta.warnings` / `data.max_entries`, and `DEFAULT_MAX_ENTRIES` is raised from 2000 to 10000.

--- a/.changeset/cli-hyperbrowser-proxy-country.md
+++ b/.changeset/cli-hyperbrowser-proxy-country.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-Add optional `HYPERBROWSER_PROXY_COUNTRY` env var to pin the Hyperbrowser proxy exit region (ISO country code, e.g. `US`, `JP`). Forwarded as `proxyCountry` on the create-session request; when unset, the field is omitted and Hyperbrowser's own default applies. Matches the existing per-provider pattern (`DRIVER_DEV_COUNTRY`, `BROWSER_USE_PROXY_COUNTRY_CODE`).
+Add `HYPERBROWSER_PROXY_COUNTRY` env var to pin the Hyperbrowser proxy exit region (ISO country code, e.g. `US`, `JP`).

--- a/.changeset/cli-session-reuse-collapse.md
+++ b/.changeset/cli-session-reuse-collapse.md
@@ -2,6 +2,4 @@
 "@actionbookdev/cli": minor
 ---
 
-`browser start --set-session-id <id>` is now get-or-create (functional alias for `--session <id>`). Previously it always created a new session and failed with `SESSION_ALREADY_EXISTS` when the ID was already running; scripts calling it twice for idempotent attach had to handle that error. Both flags now reuse a Running session with the given ID or create one if not found.
-
-When reusing, passing `--profile <name>` that does not match the session's bound profile fails with the new `SESSION_PROFILE_MISMATCH` error code (retryable: false). `error.hint` explains the required profile; `error.details` includes `session_id`, `bound_profile`, and `requested_profile`. Omit `--profile` or pass the matching value to reuse successfully.
+`browser start --set-session-id` is get-or-create (alias for `--session`); reusing with a conflicting `--profile` returns the new `SESSION_PROFILE_MISMATCH` error code.

--- a/.changeset/cli-wait-network-idle-edge-triggered.md
+++ b/.changeset/cli-wait-network-idle-edge-triggered.md
@@ -2,4 +2,4 @@
 "@actionbookdev/cli": patch
 ---
 
-`wait network-idle` is now edge-triggered: pre-existing long-lived connections at the start of the wait (websockets, long-poll requests that opened before the command ran) are ignored. Previously these could keep the wait from ever resolving on pages with persistent background traffic.
+`wait network-idle` is edge-triggered: long-lived connections opened before the wait started are ignored.


### PR DESCRIPTION
## Summary
- Collapses the nine CLI changesets backing the auto-generated PR #585 to a single sentence per entry (per @junliang-mk).
- Includes `cli-hyperbrowser-proxy-country.md` (originally @mcfn's) for consistency across the 1.6.0 changelog surface.
- No code changes. Purely edits `.changeset/*.md` bodies — frontmatter + bump levels unchanged.

## Heads up on "Thanks @author!" prefix
The "Thanks @author!" prefix in generated release notes comes from `@changesets/changelog-github` (configured in `.changeset/config.json`), not from the changeset bodies. This PR does not remove it. If we want it gone, we'd need to swap to `@changesets/cli/changelog` (loses PR/author links) or add a minimal custom formatter — happy to follow up in a separate PR.

## Test plan
- [x] `git diff --stat` — 9 files, +9/-13
- [ ] PR #585 ("chore: version packages") rebases automatically after this merges; verify its generated CHANGELOG preview shows one-sentence entries.