### PR TITLE
chore(changesets): drop "Thanks" prefix via custom formatter + body-style rule

### DIFF
--- a/.changeset/changelog.js
+++ b/.changeset/changelog.js
@@ -1,0 +1,43 @@
+const { getInfo } = require("@changesets/get-github-info");
+
+async function getReleaseLine(changeset, type, options) {
+  if (!options || !options.repo) {
+    throw new Error(
+      'A `repo` option is required — specify in .changeset/config.json: "changelog": ["./changelog.js", { "repo": "owner/name" }]'
+    );
+  }
+
+  const [firstLine, ...rest] = changeset.summary
+    .split("\n")
+    .map((line) => line.trimEnd());
+
+  let prInfo;
+  if (changeset.commit) {
+    prInfo = await getInfo({ repo: options.repo, commit: changeset.commit });
+  }
+
+  const prLink =
+    prInfo && prInfo.pull !== null && prInfo.pull !== undefined
+      ? ` [#${prInfo.pull}](https://github.com/${options.repo}/pull/${prInfo.pull})`
+      : "";
+
+  const commitLink = changeset.commit
+    ? ` [\`${changeset.commit.slice(0, 7)}\`](https://github.com/${options.repo}/commit/${changeset.commit})`
+    : "";
+
+  const continuation = rest.length
+    ? "\n" + rest.map((line) => `  ${line}`).join("\n")
+    : "";
+
+  return `\n\n-${prLink}${commitLink} ${firstLine}${continuation}`;
+}
+
+async function getDependencyReleaseLine(changesets, dependenciesUpdated) {
+  if (dependenciesUpdated.length === 0) return "";
+  const updated = dependenciesUpdated
+    .map((dep) => `  - ${dep.name}@${dep.newVersion}`)
+    .join("\n");
+  return `- Updated dependencies\n${updated}`;
+}
+
+module.exports = { getReleaseLine, getDependencyReleaseLine };

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@latest/schema.json",
   "changelog": [
-    "@changesets/changelog-github",
+    "./changelog.js",
     { "repo": "actionbook/actionbook" }
   ],
   "commit": false,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,6 +197,16 @@ git commit -m "[scope]feat: description"
 # 3. Push/merge to main — CI handles the rest
 ```
 
+#### Changeset body style
+
+The body (text under the frontmatter) becomes one bullet in `CHANGELOG.md`. Keep it short and caller-facing:
+
+- **One sentence.** No multi-paragraph bodies, no "Previously X, now Y" rationale, no CI/test/refactor detail.
+- **No "Thanks …" / courtesy prefixes.** Attribution is added by the changelog formatter; do not duplicate.
+- **Describe what the caller sees**, not implementation motivation. Prefer active voice.
+- Good: `` `browser eval` accepts expressions from `--file` or stdin when no positional is given. ``
+- Avoid: `Adds support for ... This change was motivated by ... The implementation refactors ...`
+
 ### CI Release Process (Two-Phase)
 
 **Phase 1 — Version PR**: When changesets are detected on `main`, CI automatically creates a "Version Packages" PR that updates package versions, CHANGELOGs, and runs `scripts/sync-versions.js` to keep derived manifests in sync.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
+    "@changesets/get-github-info": "^0.7.0",
     "turbo": "^2.6.3"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@25.5.0)
+      '@changesets/get-github-info':
+        specifier: ^0.7.0
+        version: 0.7.0
       turbo:
         specifier: ^2.6.3
         version: 2.7.2
@@ -2312,7 +2315,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}


### PR DESCRIPTION
## Summary

Addresses @junliang-mk's `Changelog 写法需要注意下，不能带 thanks` + `应该加个 prompt 约束，毕竟 changelog 也是人写的` on thread #ab-cli-roger:7ee9f45e.

Two complementary changes so future `packages/cli/CHANGELOG.md` entries stay short and have no `Thanks [@author]!` prefix:

- **Formatter (`.changeset/changelog.js`)** — replaces `@changesets/changelog-github` in `.changeset/config.json`. Retains the `[#PR](...)` + `[`sha`](...)` links (useful for debugging attribution), drops the `Thanks [@author]!` prefix the upstream formatter hard-codes. `@changesets/get-github-info` is promoted from transitive (via `@changesets/changelog-github`) to a direct `devDependency` so the require resolves cleanly under pnpm's strict hoisting.
- **Author rule (`CLAUDE.md`)** — new paragraph under Release Workflow / Developer Steps stating changeset bodies must be one sentence, caller-facing, no Thanks prefix, no rationale. Applies to agents and humans writing changesets.

Together these produce entries like:

```
- [#590](https://…) [`5396a14`](https://…) CDP errors surface as six classified codes, with CDP_NAV_TIMEOUT and CDP_TARGET_CLOSED retryable.
```

vs. the 1.5.1-era format:

```
- [#590](https://…) [`5396a14`](https://…) Thanks [@mcfn](https://…)! - Structured CDP error taxonomy. CDP failures now surface through a fixed set of codes. Previously X; now Y. This change is motivated by …
```

## Follow-up

PR #592 already simplified the 1.6.0 section manually; that is now merged. This PR prevents recurrence.

## Test plan

- [ ] `pnpm changeset version` on a throwaway `.changeset/_test.md` with a 1-sentence body → verify generated bullet = `- [#NNN](...) [\`SHA\`](...) <body>` (no Thanks, has links). `git restore` after.
- [ ] CI `Analyze (actions)` / `Lint (fmt + clippy)` / `Unit Tests` all pass.
- [ ] Inspect `.changeset/config.json` schema remains valid (changesets loads the JS module).