### PR TITLE
docs(CLAUDE.md): add Cross-Agent Discipline section from team retro

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,6 +313,21 @@ Every error response includes a hint field telling the agent what to do next. Fo
 - **Stealth off by default.** Anti-detection is opt-in. Users must explicitly enable it. Anti-pattern: stealth on by default causes non-reproducible E2E tests — User-Agent differs on every run.
 - **Binary size is a hard constraint.** Target < 10MB (stripped). Means: `opt-level="z"` + LTO + strip + `panic="abort"` + feature-gate non-core modules. Periodically run `cargo bloat` to track size contributors.
 
+---
+
+### Cross-Agent Discipline (CLI team)
+
+Rules agreed by the CLI agent team retrospective (2026-04-23, Rounds 1–3, unanimous). Apply when planning, reviewing, or merging CLI work.
+
+- **Red-read sweep before editing.** Before modifying a target module, scan the module's existing tests and docs for legacy assertions that would break under the new contract. Call them out up-front as either (a) to-update in the same PR, or (b) locked-contract collisions that require the plan to change. Do not let stale assertions become discovered collateral mid-review.
+- **Phase-split trigger = contract surface count.** A plan MUST be split into phases when it touches **≥2 user-visible contract surfaces** (error code, envelope shape, flag, side-effect) OR **any cross-layer bridge surface** (`CliError → envelope`, `data → __meta`, `flag → runtime semantics`, `CLI parse → error bridge → output/help/docs`). LOC and abstract "dimensions" are not valid triggers — only surface count and cross-layer bridges are.
+- **Blocker upgrade gate.** Raise a blocker only on a locked-contract failure proven by either a concrete repro OR a code-path proof. Code-path proof MUST include all four:
+  1. `file:path:line`
+  2. input → wrong user-visible output / wrong mutation (data + control flow)
+  3. explicit tie to the locked contract or immediate correctness break
+  4. one explicit sentence on why the user-facing contract breaks
+  Label format: `[code-path proof] <file:line> → <dataflow>`. Without all four items, downgrade to `follow-up candidate` or `evidence gap` — speculative broadening does not qualify as a blocker.
+
 ## gstack
 
 ### Available Skills


### PR DESCRIPTION
## Summary

Persists R1, R2, R6 from the CLI agent team retrospective on 2026-04-23 (`#ab-cli-roger` Rounds 1–3, unanimous 4/4 among test / dev / dev-cx / help-writer).

- **R1 Red-read sweep** — before editing a module, scan its tests/docs for legacy assertions that would break under the new contract; surface them up-front, not mid-review.
- **R2 Phase-split trigger = contract surface count** — split when touching ≥2 user-visible contract surfaces (error code / envelope / flag / side-effect) or any cross-layer bridge surface. LOC and abstract "dimensions" are no longer valid triggers.
- **R6 Blocker upgrade gate** — blocker requires concrete repro OR 4-item code-path proof (file:line + data/control flow + locked-contract tie + why-user-facing-breaks). Speculative broadening downgrades to follow-up / evidence gap.

R3 (thread-state mutation pre-check ≤60s), R4 (source-of-truth > second-hand quote), and R5 (cross-review run-proof with fresh worktree / exact command / pass) are persisted as agent-side feedback memories since they are operational discipline for agents rather than author-facing rules. They are not duplicated in CLAUDE.md.

## Background

Retro was requested by @junliang-mk via msg `f1bc6bc4` on `#ab-cli-roger` ("你组织互相讨论总结下，至少 3 轮。总结沉淀下来。"). Round 1 surfaced candidate rules from each agent, Round 2 converged to 5 candidates + 1 dispute, Round 3 merged dispute resolution and unanimously voted R1–R6.

## Test plan

- [ ] CI passes (doc-only change, no code paths touched).
- [ ] Visual diff of CLAUDE.md renders Cross-Agent Discipline section cleanly between Security & Feature Boundaries and gstack.