### PR TITLE
feat(cli): flush single HAR recorder on daemon SIGTERM via --har-out (ACT-971)

### DIFF
--- a/packages/cli/src/browser/observation/network_har.rs
+++ b/packages/cli/src/browser/observation/network_har.rs
@@ -340,6 +340,22 @@ pub async fn execute_stop(cmd: &StopCmd, registry: &SharedRegistry) -> ActionRes
 
 // ── HAR 1.2 serialization ─────────────────────────────────────────────────────
 
+/// Serialize HAR entries and write pretty JSON to `path`, creating parent
+/// directories as needed. Reused by `har stop` and by the daemon SIGTERM
+/// flush path so both paths produce byte-identical output.
+pub(crate) fn write_har_file(
+    path: &std::path::Path,
+    entries: Vec<HarEntry>,
+    dropped_count: usize,
+) -> std::io::Result<()> {
+    let har = serialize_har(entries, dropped_count);
+    let har_str = serde_json::to_string_pretty(&har).map_err(std::io::Error::other)?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, har_str)
+}
+
 fn serialize_har(entries: Vec<HarEntry>, dropped_count: usize) -> serde_json::Value {
     let entries_json: Vec<serde_json::Value> = entries.into_iter().map(har_entry_to_json).collect();
     let mut log = json!({

--- a/packages/cli/src/browser/session/restart.rs
+++ b/packages/cli/src/browser/session/restart.rs
@@ -217,6 +217,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
         set_session_id: Some(cmd.session.clone()),
         stealth,
         max_tracked_requests,
+        har_out: None,
         provider_env: effective_provider_env,
     };
 

--- a/packages/cli/src/browser/session/start.rs
+++ b/packages/cli/src/browser/session/start.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::process::Child;
 
 use clap::Args;
@@ -107,6 +108,13 @@ pub struct Cmd {
     #[arg(long, default_value_t = 500)]
     #[serde(default = "default_max_tracked_requests")]
     pub max_tracked_requests: usize,
+    /// Opt-in HAR flush path. When set and a single `har_start` recorder is
+    /// active at daemon SIGTERM, the in-memory recorder is serialized to this
+    /// path as part of graceful shutdown. Without this flag, SIGTERM never
+    /// implicitly writes HAR output.
+    #[arg(long, value_name = "PATH")]
+    #[serde(default)]
+    pub har_out: Option<PathBuf>,
     /// Snapshot of provider env vars forwarded from the CLI client to the
     /// daemon (DRIVER_*, HYPERBROWSER_*, BROWSER_USE_*).
     /// The daemon must NOT read these from its own process env — its env was
@@ -881,6 +889,7 @@ pub async fn execute(cmd: &Cmd, registry: &SharedRegistry) -> ActionResult {
     }
     entry.cdp = Some(cdp);
     entry.stealth_ua = user_agent;
+    entry.har_out = cmd.har_out.clone();
 
     // Create per-session data directory for artifacts (snapshots, etc.)
     let session_data_dir = config::session_data_dir(session_id.as_str());
@@ -1343,6 +1352,7 @@ async fn execute_cloud(
     entry.headers = headers.to_vec();
     entry.provider = provider_name.map(|provider| provider.to_string());
     entry.provider_session = provider_session;
+    entry.har_out = cmd.har_out.clone();
 
     // Create per-session data directory for artifacts (snapshots, etc.)
     let session_data_dir = config::session_data_dir(session_id.as_str());
@@ -1628,6 +1638,7 @@ async fn execute_extension(
     }
     entry.chrome_process = None;
     entry.cdp = Some(cdp);
+    entry.har_out = cmd.har_out.clone();
 
     let session_data_dir = config::session_data_dir(session_id.as_str());
     std::fs::create_dir_all(&session_data_dir).ok();
@@ -2039,6 +2050,7 @@ mod provider_start_tests {
             set_session_id: set_session_id.map(str::to_string),
             stealth: true,
             max_tracked_requests: 500,
+            har_out: None,
             provider_env: ProviderEnv::new(),
         }
     }
@@ -2137,6 +2149,7 @@ mod provider_start_tests {
                 set_session_id: Some("hyp3".to_string()),
                 stealth: true,
                 max_tracked_requests: 500,
+                har_out: None,
                 provider_env: ProviderEnv::new(),
             },
             &registry,
@@ -2204,6 +2217,7 @@ mod provider_start_tests {
                 set_session_id: Some("hyp3".to_string()),
                 stealth: true,
                 max_tracked_requests: 500,
+                har_out: None,
                 provider_env: ProviderEnv::from([
                     ("HYPERBROWSER_API_KEY".to_string(), "hb-key".to_string()),
                     (
@@ -2257,6 +2271,7 @@ mod provider_start_tests {
                 set_session_id: Some("bs1".to_string()),
                 stealth: true,
                 max_tracked_requests: 500,
+                har_out: None,
                 provider_env: ProviderEnv::new(),
             },
             &registry,

--- a/packages/cli/src/config.rs
+++ b/packages/cli/src/config.rs
@@ -474,6 +474,7 @@ mod tests {
             set_session_id: None,
             stealth: true,
             max_tracked_requests: 500,
+            har_out: None,
             provider_env: Default::default(),
         }
     }

--- a/packages/cli/src/daemon/cdp_session.rs
+++ b/packages/cli/src/daemon/cdp_session.rs
@@ -1550,6 +1550,18 @@ impl CdpSession {
         self.tab_har_recorders.lock().await.remove(cdp_session_id);
     }
 
+    /// Snapshot the set of CDP session IDs that currently have an active HAR
+    /// recorder. Used by the daemon SIGTERM path to decide whether to flush
+    /// the single-recorder case or skip (0 or >1 active recorders).
+    pub async fn har_recorder_ids(&self) -> Vec<String> {
+        self.tab_har_recorders
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect()
+    }
+
     /// Background task: read WS messages and route responses/events to callers.
     #[allow(clippy::too_many_arguments)]
     async fn reader_loop<S>(

--- a/packages/cli/src/daemon/registry.rs
+++ b/packages/cli/src/daemon/registry.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt;
+use std::path::PathBuf;
 use std::process::Child;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -86,6 +87,11 @@ pub struct SessionEntry {
     pub next_tab_id: u32,
     /// Maximum number of network requests tracked per tab (ring buffer cap).
     pub max_tracked_requests: usize,
+    /// Opt-in HAR flush path captured from `browser start --har-out <PATH>`.
+    /// When set and exactly one `har_start` recorder is active at daemon
+    /// SIGTERM, the graceful shutdown path serializes the recorder to this
+    /// path. See `daemon::server` shutdown logic for the skip/flush rules.
+    pub har_out: Option<PathBuf>,
 }
 
 impl Drop for SessionEntry {
@@ -127,6 +133,7 @@ impl SessionEntry {
             provider_session: None,
             next_tab_id: 1,
             max_tracked_requests: crate::daemon::cdp_session::MAX_TRACKED_REQUESTS,
+            har_out: None,
         }
     }
 

--- a/packages/cli/src/daemon/server.rs
+++ b/packages/cli/src/daemon/server.rs
@@ -384,8 +384,8 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Graceful shutdown: collect all sessions, then release registry lock
-    // before slow I/O (CDP close + Chrome kill).
-    let entries_to_close = {
+    // before slow I/O (HAR flush + CDP close + Chrome kill).
+    let (entries_to_close, har_flush_tasks) = {
         let mut reg = registry.lock().await;
         let session_ids: Vec<String> = reg
             .list()
@@ -393,19 +393,67 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
             .map(|s| s.id.as_str().to_string())
             .collect();
         let mut entries = Vec::new();
+        let mut har_tasks = Vec::new();
         for sid in session_ids {
             if let Some(mut entry) = reg.remove(&sid) {
+                let har_out = entry.har_out.take();
                 let cdp = entry.cdp.take();
                 let chrome = entry.chrome_process.take();
                 // Windows: entry.job_object drops here (end of if-let block),
                 // which calls ChromeJobObject::Drop → TerminateJobObject →
                 // kills all Chrome processes (main + helpers) atomically.
+                if let (Some(path), Some(cdp_ref)) = (har_out, cdp.clone()) {
+                    har_tasks.push((entry.id.as_str().to_string(), path, cdp_ref));
+                }
                 entries.push((cdp, chrome));
             }
         }
-        entries
+        (entries, har_tasks)
     };
-    // Registry lock released — cleanup below runs without blocking.
+    // Registry lock released — HAR flush and cleanup run without blocking.
+
+    // HAR flush: for sessions started with `--har-out`, serialize the single
+    // active recorder to the requested path. 0 or >1 active recorders → skip
+    // and log. Runs before cdp.close() so the WebSocket is still alive for
+    // the body-fetch drain inside har_stop.
+    for (sid, path, cdp) in har_flush_tasks {
+        let ids = cdp.har_recorder_ids().await;
+        match ids.as_slice() {
+            [cdp_session_id] => match cdp.har_stop(cdp_session_id).await {
+                Ok((har_entries, dropped, _max)) => {
+                    match crate::browser::observation::network_har::write_har_file(
+                        &path,
+                        har_entries,
+                        dropped,
+                    ) {
+                        Ok(()) => {
+                            cdp.har_commit(cdp_session_id).await;
+                            info!(
+                                "flushed HAR for session {} to {} on shutdown",
+                                sid,
+                                path.display()
+                            );
+                        }
+                        Err(e) => {
+                            warn!("HAR flush write failed for session {sid}: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    warn!("HAR snapshot failed for session {sid}: {e}");
+                }
+            },
+            _ => {
+                warn!(
+                    "skipping HAR flush for session {} (active_recorders={}, har_out={})",
+                    sid,
+                    ids.len(),
+                    path.display()
+                );
+            }
+        }
+    }
+
     for (cdp, chrome) in entries_to_close {
         if let Some(cdp) = cdp {
             cdp.close().await;

--- a/packages/cli/src/main.rs
+++ b/packages/cli/src/main.rs
@@ -243,6 +243,7 @@ async fn handle_browser(
                         set_session_id: None,
                         stealth: true,
                         max_tracked_requests: 500,
+                        har_out: None,
                         provider_env: Default::default(),
                     });
                 let result = ActionResult::fatal(err.error_code(), err.to_string());

--- a/packages/cli/tests/e2e/network_har.rs
+++ b/packages/cli/tests/e2e/network_har.rs
@@ -2,13 +2,14 @@
 //!
 //! Covers the planned `browser network har start/stop` commands.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use crate::harness::{
-    SessionGuard, assert_error_envelope, assert_failure, assert_meta, assert_success,
-    headless_json, new_tab_json, parse_json, skip, start_session, url_fast_redirect,
-    url_network_load, url_network_xhr,
+    SessionGuard, SoloEnv, assert_error_envelope, assert_failure, assert_meta, assert_success,
+    headless_json, new_tab_json, parse_json, skip, start_session, unique_session,
+    url_fast_redirect, url_network_load, url_network_xhr,
 };
 
 fn har_start(session_id: &str, tab_id: &str) -> std::process::Output {
@@ -155,6 +156,216 @@ fn har_entries(v: &serde_json::Value) -> &[serde_json::Value] {
         .as_array()
         .map(Vec::as_slice)
         .unwrap_or(&[])
+}
+
+fn har_start_in_env(env: &SoloEnv, session_id: &str, tab_id: &str) -> std::process::Output {
+    env.headless_json(
+        &[
+            "browser",
+            "network",
+            "har",
+            "start",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+        ],
+        15,
+    )
+}
+
+fn har_stop_in_env(env: &SoloEnv, session_id: &str, tab_id: &str) -> std::process::Output {
+    env.headless_json(
+        &[
+            "browser",
+            "network",
+            "har",
+            "stop",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+        ],
+        15,
+    )
+}
+
+fn wait_requests_done_in_env(env: &SoloEnv, session_id: &str, tab_id: &str) {
+    let out = env.headless_json(
+        &[
+            "browser",
+            "wait",
+            "condition",
+            "window.__ab_requests_done === true",
+            "--session",
+            session_id,
+            "--tab",
+            tab_id,
+            "--timeout",
+            "5000",
+        ],
+        10,
+    );
+    assert_success(&out, "wait requests done");
+}
+
+fn issue_bulk_requests_in_env(env: &SoloEnv, session_id: &str, tab_id: &str, count: usize) {
+    let api_prefix = url_network_xhr().replace("/network-xhr", "/api/data?source=");
+    let expression = format!(
+        "await Promise.all(Array.from({{ length: {count} }}, (_, i) => fetch(`{api_prefix}act971-${{i}}`).then(r => r.text())))"
+    );
+    let argv = [
+        "browser".to_string(),
+        "eval".to_string(),
+        expression,
+        "--session".to_string(),
+        session_id.to_string(),
+        "--tab".to_string(),
+        tab_id.to_string(),
+    ];
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    let out = env.headless_json(&args, 30);
+    assert_success(&out, "issue bulk requests");
+}
+
+fn wait_page_ready_in_env(env: &SoloEnv, session_id: &str, tab_id: &str) {
+    for _ in 0..10 {
+        let out = env.headless_json(
+            &[
+                "browser",
+                "eval",
+                "document.readyState",
+                "--session",
+                session_id,
+                "--tab",
+                tab_id,
+            ],
+            5,
+        );
+        if out.status.success() {
+            let v = parse_json(&out);
+            if v["data"]["value"].as_str() == Some("complete") {
+                return;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+}
+
+fn start_named_session_in_env(
+    env: &SoloEnv,
+    session_id: &str,
+    profile: &str,
+    url: &str,
+    har_out: Option<&Path>,
+) -> std::process::Output {
+    let mut argv = vec![
+        "browser".to_string(),
+        "start".to_string(),
+        "--mode".to_string(),
+        "local".to_string(),
+        "--headless".to_string(),
+        "--profile".to_string(),
+        profile.to_string(),
+        "--set-session-id".to_string(),
+        session_id.to_string(),
+    ];
+    if let Some(path) = har_out {
+        argv.push("--har-out".to_string());
+        argv.push(path.to_string_lossy().to_string());
+    }
+    argv.push("--open-url".to_string());
+    argv.push(url.to_string());
+    let args: Vec<&str> = argv.iter().map(String::as_str).collect();
+    env.headless_json(&args, 30)
+}
+
+fn start_named_session_tab_in_env(
+    env: &SoloEnv,
+    session_id: &str,
+    profile: &str,
+    url: &str,
+    har_out: Option<&Path>,
+) -> String {
+    let out = start_named_session_in_env(env, session_id, profile, url, har_out);
+    assert_success(&out, &format!("start {session_id}"));
+    let v = parse_json(&out);
+    let tid = v["data"]["tab"]["tab_id"]
+        .as_str()
+        .expect("tab id")
+        .to_string();
+    wait_page_ready_in_env(env, session_id, &tid);
+    tid
+}
+
+fn new_tab_json_in_env(env: &SoloEnv, session_id: &str, url: &str) -> String {
+    let out = env.headless_json(&["browser", "new-tab", url, "--session", session_id], 30);
+    assert_success(&out, "new-tab");
+    let v = parse_json(&out);
+    let tid = v["data"]["tab"]["tab_id"]
+        .as_str()
+        .expect("new-tab tab id")
+        .to_string();
+    wait_page_ready_in_env(env, session_id, &tid);
+    tid
+}
+
+fn daemon_pid(env: &SoloEnv) -> u32 {
+    let pid_path = Path::new(&env.actionbook_home).join("daemon.pid");
+    fs::read_to_string(&pid_path)
+        .unwrap_or_else(|e| panic!("read daemon pid {}: {e}", pid_path.display()))
+        .trim()
+        .parse()
+        .unwrap_or_else(|e| panic!("parse daemon pid {}: {e}", pid_path.display()))
+}
+
+#[cfg(unix)]
+fn pid_alive(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .args(["-0", &pid.to_string()])
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+#[cfg(unix)]
+fn send_sigterm_and_wait(env: &SoloEnv) {
+    let pid = daemon_pid(env);
+    let out = std::process::Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .output()
+        .expect("spawn kill -TERM");
+    assert!(
+        out.status.success(),
+        "kill -TERM {pid} failed: status={:?} stderr={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    while std::time::Instant::now() < deadline {
+        let pid_file_exists = Path::new(&env.actionbook_home).join("daemon.pid").exists();
+        if !pid_alive(pid) && !pid_file_exists {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    panic!("daemon pid {pid} did not exit after SIGTERM");
+}
+
+fn daemon_log_path(env: &SoloEnv) -> PathBuf {
+    Path::new(&env.actionbook_home).join("daemon.log")
+}
+
+fn har_dir_listing(env: &SoloEnv) -> BTreeSet<String> {
+    let dir = Path::new(&env.actionbook_home).join("har");
+    match fs::read_dir(&dir) {
+        Ok(entries) => entries
+            .flatten()
+            .map(|entry| entry.file_name().to_string_lossy().to_string())
+            .collect(),
+        Err(_) => BTreeSet::new(),
+    }
 }
 
 fn assert_har_entry_shape(entry: &serde_json::Value) {
@@ -881,6 +1092,153 @@ mod truncation {
         assert!(
             warnings.is_empty(),
             "clean stop should not emit warnings, got {warnings:?}"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "SIGTERM-based graceful shutdown is Unix-only")]
+    fn sigterm_flushes_har_when_har_out_set_and_single_recorder() {
+        if skip() {
+            return;
+        }
+
+        let env = SoloEnv::new();
+        let (sid, profile) = unique_session("act971-positive");
+        let har_path = Path::new(&env.actionbook_home).join("act971-positive.har");
+        let tid = start_named_session_tab_in_env(
+            &env,
+            &sid,
+            &profile,
+            &url_network_xhr(),
+            Some(&har_path),
+        );
+        wait_requests_done_in_env(&env, &sid, &tid);
+
+        assert_success(&har_start_in_env(&env, &sid, &tid), "har start");
+        issue_bulk_requests_in_env(&env, &sid, &tid, 4);
+
+        send_sigterm_and_wait(&env);
+
+        assert!(
+            har_path.exists(),
+            "SIGTERM with --har-out and a single recorder should flush HAR to {}",
+            har_path.display()
+        );
+        let har = har_json_from_file(&har_path);
+        assert!(
+            har["log"]["entries"].is_array(),
+            "flushed HAR should contain log.entries array: {har:?}"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "SIGTERM-based graceful shutdown is Unix-only")]
+    fn sigterm_without_har_out_does_not_implicit_write() {
+        if skip() {
+            return;
+        }
+
+        let env = SoloEnv::new();
+        let before = har_dir_listing(&env);
+        let (sid, profile) = unique_session("act971-noharout");
+        let tid = start_named_session_tab_in_env(&env, &sid, &profile, &url_network_xhr(), None);
+        wait_requests_done_in_env(&env, &sid, &tid);
+
+        assert_success(&har_start_in_env(&env, &sid, &tid), "har start");
+        issue_bulk_requests_in_env(&env, &sid, &tid, 3);
+
+        send_sigterm_and_wait(&env);
+
+        let after = har_dir_listing(&env);
+        assert_eq!(
+            after, before,
+            "SIGTERM without --har-out must not implicitly write under ACTIONBOOK_HOME/har"
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "SIGTERM-based graceful shutdown is Unix-only")]
+    fn sigterm_with_multi_recorder_skips_flush_and_warns() {
+        if skip() {
+            return;
+        }
+
+        let env = SoloEnv::new();
+        let (sid, profile) = unique_session("act971-multi");
+        let har_path = Path::new(&env.actionbook_home).join("act971-multi.har");
+        let log_path = daemon_log_path(&env);
+        let tid_a = start_named_session_tab_in_env(
+            &env,
+            &sid,
+            &profile,
+            &url_network_xhr(),
+            Some(&har_path),
+        );
+        wait_requests_done_in_env(&env, &sid, &tid_a);
+
+        let tid_b = new_tab_json_in_env(&env, &sid, &url_network_xhr());
+        wait_requests_done_in_env(&env, &sid, &tid_b);
+
+        assert_success(&har_start_in_env(&env, &sid, &tid_a), "har start tab a");
+        assert_success(&har_start_in_env(&env, &sid, &tid_b), "har start tab b");
+        issue_bulk_requests_in_env(&env, &sid, &tid_a, 2);
+        issue_bulk_requests_in_env(&env, &sid, &tid_b, 2);
+
+        send_sigterm_and_wait(&env);
+
+        assert!(
+            !har_path.exists(),
+            "multi-recorder SIGTERM flush must skip writing {}",
+            har_path.display()
+        );
+        let daemon_log = fs::read_to_string(&log_path).unwrap_or_default();
+        assert!(
+            daemon_log.contains("skipping HAR flush"),
+            "expected daemon log {} to mention skip, got:\n{}",
+            log_path.display(),
+            daemon_log
+        );
+    }
+
+    #[test]
+    #[cfg_attr(windows, ignore = "SIGTERM-based graceful shutdown is Unix-only")]
+    fn har_stop_after_sigterm_flush_stays_parseable() {
+        if skip() {
+            return;
+        }
+
+        let env = SoloEnv::new();
+        let (sid, profile) = unique_session("act971-stop-after");
+        let har_path = Path::new(&env.actionbook_home).join("act971-stop-after.har");
+        let tid = start_named_session_tab_in_env(
+            &env,
+            &sid,
+            &profile,
+            &url_network_xhr(),
+            Some(&har_path),
+        );
+        wait_requests_done_in_env(&env, &sid, &tid);
+
+        assert_success(&har_start_in_env(&env, &sid, &tid), "har start");
+        issue_bulk_requests_in_env(&env, &sid, &tid, 4);
+
+        send_sigterm_and_wait(&env);
+
+        let before = fs::read(&har_path)
+            .unwrap_or_else(|e| panic!("read flushed har {}: {e}", har_path.display()));
+        let _: serde_json::Value = serde_json::from_slice(&before)
+            .unwrap_or_else(|e| panic!("parse flushed har {}: {e}", har_path.display()));
+
+        let stop_out = har_stop_in_env(&env, &sid, &tid);
+        assert_failure(&stop_out, "har stop after sigterm flush");
+
+        let after = fs::read(&har_path)
+            .unwrap_or_else(|e| panic!("re-read flushed har {}: {e}", har_path.display()));
+        let _: serde_json::Value = serde_json::from_slice(&after)
+            .unwrap_or_else(|e| panic!("parse har after failed stop {}: {e}", har_path.display()));
+        assert_eq!(
+            after, before,
+            "failed har stop after SIGTERM flush must not mutate existing flushed HAR"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Adds opt-in `browser start --har-out <PATH>` flag; captured on `SessionEntry.har_out` at commit time.
- Daemon SIGTERM shutdown path now inspects each session: if `har_out` is set and exactly one `har_start` recorder is active, it serializes the recorder to the configured path via a shared `write_har_file` helper before Chrome teardown.
- Multi-recorder sessions are skipped with a `warn!` log ("skipping HAR flush for session ... (active_recorders=N, har_out=...)") so ambiguous routing is surfaced rather than silently picking one. Sessions without `--har-out` are never implicitly written.

## Implementation touch points

- `start.rs` — clap arg, 3 commit paths, 4 unit-test Cmd literals
- `registry.rs` — `SessionEntry.har_out: Option<PathBuf>` + `starting()` default
- `cdp_session.rs` — read-only `har_recorder_ids()` snapshot accessor
- `network_har.rs` — reusable `pub(crate) write_har_file()` (same serializer as `har_stop`, byte-identical output)
- `server.rs` — graceful-shutdown: collect flush tasks in single lock scope; iterate after release with match on recorder count (flush / skip+warn); existing cdp.close / reaper unchanged
- `main.rs`, `config.rs`, `restart.rs` — `har_out: None` pass-throughs in existing Cmd literals

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --lib` — 483 passed / 0 failed
- [x] `RUN_E2E_TESTS=true cargo test --test e2e network_har -- --test-threads=1 --nocapture` — 21 passed / 0 failed, including all 6 `truncation::` tests:
  - `sigterm_flushes_har_when_har_out_set_and_single_recorder`
  - `sigterm_with_multi_recorder_skips_flush_and_warns`
  - `sigterm_without_har_out_does_not_implicit_write`
  - `har_stop_after_sigterm_flush_stays_parseable`
  - `har_clean_stop_has_no_truncation_marker` (existing guard)
  - `har_truncation_surfaces_in_envelope` (existing guard)

Red test commit from test agent: `e848e20ef`. This green commit adds only the production changes required to satisfy the red contract.