### PR TITLE
[packages/actionbook-extension]fix: enable DOM domain on attachTab/createTab/activateTab

### DIFF
--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -626,6 +626,27 @@ chrome.debugger.onEvent.addListener((source, method, params) => {
 // group if none exists there. All failures are swallowed: grouping is a UX
 // nicety and must never break the CDP command that triggered it. Callers
 // should not await any particular outcome — treat this as fire-and-log.
+/**
+ * Ensure DOM domain is enabled for a tab. Required for DOM.resolveNode and
+ * other backendNodeId-based lookups to work; chrome.debugger.attach does NOT
+ * auto-enable any domains.
+ *
+ * Without this, Accessibility.getFullAXTree (a separate domain that does not
+ * require DOM enable) returns valid backendDOMNodeIds, but later
+ * DOM.resolveNode(backendNodeId) calls reject those IDs as unknown — surfacing
+ * to cloud callers as REF_STALE on `@eN` references.
+ *
+ * Idempotent: safe to call repeatedly. Failures are logged but not fatal —
+ * many cloud commands work without DOM enabled (Runtime.evaluate, Page.*).
+ */
+async function ensureDomEnabled(tabId) {
+  try {
+    await chrome.debugger.sendCommand({ tabId }, "DOM.enable", {});
+  } catch (err) {
+    debugLog(`[actionbook] DOM.enable failed for tab ${tabId}:`, err?.message || err);
+  }
+}
+
 async function ensureTabInActionbookGroup(tabId) {
   if (!groupingEnabled) return;
   if (typeof tabId !== "number") return;
@@ -805,6 +826,10 @@ async function handleExtensionCommand(id, method, params) {
           return { id, error: { code: -32000, message: `attach failed: ${err.message}` } };
         }
       }
+      // chrome.debugger.attach does not auto-enable any CDP domains. Enable
+      // DOM so backendNodeId-based lookups (DOM.resolveNode, etc.) work for
+      // refs returned by Accessibility.getFullAXTree.
+      await ensureDomEnabled(tabId);
       await ensureTabInActionbookGroup(tabId);
       broadcastState();
       return {
@@ -830,6 +855,8 @@ async function handleExtensionCommand(id, method, params) {
           await chrome.debugger.attach({ tabId: tab.id }, "1.3");
           attachedTabs.add(tab.id);
         }
+        // Enable DOM domain — see ensureDomEnabled() for rationale.
+        await ensureDomEnabled(tab.id);
         broadcastState();
         return { id, result: { tabId: tab.id, title: tab.title || "", url: tab.url || url, attached: true, reused } };
       } catch (err) {
@@ -852,6 +879,8 @@ async function handleExtensionCommand(id, method, params) {
           await chrome.debugger.attach({ tabId }, "1.3");
           attachedTabs.add(tabId);
         }
+        // Enable DOM domain — see ensureDomEnabled() for rationale.
+        await ensureDomEnabled(tabId);
         broadcastState();
         return { id, result: { success: true, tabId, title: tab.title, url: tab.url, attached: true } };
       } catch (err) {


### PR DESCRIPTION
## Problem

User reported intermittent `REF_STALE` errors from cloud-mode `@eN` ref-based commands (e.g. `describe @e1`) even after the actionbook-cloud wire-format sweep (#384–#391). Reproduction: snapshot → `describe @e1` fails with REF_STALE, but snapshot → any CSS-path command (e.g. `attr h1 class`, which internally calls `DOM.getDocument`) → `describe @e1` succeeds.

## Root Cause

`chrome.debugger.attach` does **not** auto-enable any CDP domains.

- `Accessibility.getFullAXTree` is a separate domain that works without `DOM.enable` and returns valid `backendDOMNodeId` values.
- `DOM.resolveNode(backendNodeId)` (which the cloud edge-server uses to materialize `@eN` refs into runtime objects) requires the DOM agent to be initialized — otherwise it rejects every backend ID as unknown.

The "works after a CSS command" behavior is because `DOM.getDocument` lazy-enables the DOM agent as a side effect, after which all previously-issued backendDOMNodeIds become resolvable.

## Solution

Add `ensureDomEnabled(tabId)` helper and call it after every successful `chrome.debugger.attach` in:

- `Extension.attachTab`
- `Extension.createTab`
- `Extension.activateTab`

Helper sends a single `DOM.enable` CDP command. Idempotent (Chrome no-ops repeat enables) and fail-open (logs but does not throw — many cloud commands like `Runtime.evaluate` and `Page.*` work fine without DOM enabled).

`DOM.enable` is already on the L1 allowlist (line 43 of `background.js`), so no allowlist change needed.

## Testing

- `node --check background.js` passes
- `pnpm package` builds the extension zip cleanly (34.5 KB sideload + 34.1 KB CWS)
- No unit tests exist in `packages/actionbook-extension/`
- Live cloud-mode verification deferred to a manual check after extension prerelease

## Risk

Low. `DOM.enable` is a read-only signal that begins streaming `DOM.*` mutation events — no behavior change for existing callers. The cloud edge-server's event router drops unknown methods, so the extra event traffic is silently absorbed.

## Related

- actionbook-cloud #384–#391 — wire-format sweep across snapshot, locator, and 30+ CDP handlers. This PR is the companion root-cause fix on the extension side.

## Notes

Per user direction, **do not merge** until the extension exits prerelease. Cloud side requires no further changes.