### PR TITLE
[packages/actionbook-extension]fix: cap Runtime.evaluate result size at 50k chars (ACT-1044)

### DIFF
--- a/packages/actionbook-extension/background.js
+++ b/packages/actionbook-extension/background.js
@@ -15,6 +15,13 @@ const BRIDGE_PROBE_TIMEOUT_MS = 750;
 const HANDSHAKE_TIMEOUT_MS = 2000;
 const L3_CONFIRM_TIMEOUT_MS = 30000;
 
+// Caps the serialized size of Runtime.evaluate / Runtime.callFunctionOn results.
+// Agent-authored expressions can accidentally return huge payloads (e.g.
+// `document.documentElement.outerHTML`) that blow up token budgets and the WS
+// channel. Other CDP methods are not capped — their large returns (screenshots,
+// outerHTML) are intentional.
+const MAX_EVAL_RESULT_CHARS = 50000;
+
 // Protocol version reported in the hello frame. Bumped to 0.5.0 for cloud mode.
 const PROTOCOL_VERSION = "0.5.0";
 
@@ -1204,6 +1211,20 @@ async function handleCdpCommand(id, method, params, tabId, sessionId) {
       method,
       params
     );
+
+    if (method === "Runtime.evaluate" || method === "Runtime.callFunctionOn") {
+      const size = JSON.stringify(result || {}).length;
+      if (size > MAX_EVAL_RESULT_CHARS) {
+        return {
+          id,
+          error: {
+            code: -32000,
+            message: `${method} result too large: ${size} chars exceeds ${MAX_EVAL_RESULT_CHARS} char limit. Reduce output size in your expression (e.g. .slice(0, N), select fewer fields, or paginate).`,
+          },
+        };
+      }
+    }
+
     return { id, result: result || {} };
   } catch (err) {
     const errorMessage = err.message || String(err);


### PR DESCRIPTION
## Summary

- Cap `Runtime.evaluate` / `Runtime.callFunctionOn` results at 50,000 chars (`MAX_EVAL_RESULT_CHARS`) inside `handleCdpCommand`. Size is measured as `JSON.stringify(result).length`.
- When the cap is exceeded, return a structured `{code: -32000, message}` error instead of forwarding the oversized payload. The message includes the actual size, the limit, and concrete remediation hints (slice, select fewer fields, paginate) so the agent can self-correct.
- Other CDP methods (`Page.captureScreenshot`, `DOM.getOuterHTML`, etc.) are intentionally unaffected — their large returns are explicit user choices.

Why: agent-authored expressions like `document.documentElement.outerHTML` can return multi-MB payloads that blow up token budgets and the WS channel. `Runtime.evaluate` / `Runtime.callFunctionOn` are the wildcard surface where this most often happens.

Linear: [ACT-1044](https://linear.app/actionbook/issue/ACT-1044)

## Test plan

No automated tests (the package only ships a `package` script). Verified manually after reloading the extension:

- [x] **Small result** — `Runtime.evaluate { expression: "1 + 1" }` → returns `2` normally.
- [x] **Oversized result** — `Runtime.evaluate { expression: "'x'.repeat(51000)" }` → returns error: `Runtime.evaluate result too large: 51039 chars exceeds 50000 char limit. Reduce output size in your expression (e.g. .slice(0, N), select fewer fields, or paginate).`
- [x] **Boundary** — `Runtime.evaluate { expression: "'x'.repeat(40000)" }` → returns the full 40k string, not capped.
- [x] **Regression** — `DOM.getOuterHTML` on example.com still returns the full 718-byte HTML (cap does not apply to other methods).
- [ ] `Runtime.callFunctionOn` not exercised directly through the CLI surface, but it shares the exact same code branch as `Runtime.evaluate` (one `if` covers both).