### PR TITLE
[root]chore: disable Discord notification for extension releases

### DIFF
--- a/.github/workflows/discord-release-notify.yml
+++ b/.github/workflows/discord-release-notify.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   notify-discord:
     name: Notify Discord
-    if: ${{ !contains(github.event.release.tag_name, '-alpha') }}
+    if: ${{ !contains(github.event.release.tag_name, '-alpha') && !startsWith(github.event.release.tag_name, 'actionbook-extension-v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Determine release type metadata


### PR DESCRIPTION
## Summary
- Extension releases (`actionbook-extension-v*`) no longer trigger the Discord `notify-discord` job
- CLI / Dify Plugin / other release notifications are unaffected
- Only one line changed in `.github/workflows/discord-release-notify.yml`; the `elif` branch for Extension meta is intentionally left in place so the channel can be re-enabled by reverting the guard

## Test plan
- [ ] Next `actionbook-extension-v*` release: confirm the `Notify Discord` job is skipped on the Actions run
- [ ] Next `actionbook-cli-v*` release: confirm Discord still receives the embed