### PR TITLE
fix(cli): detach Unix daemon on autostart

### DIFF
--- a/packages/cli/Cargo.toml
+++ b/packages/cli/Cargo.toml
@@ -68,6 +68,9 @@ windows-sys = { version = "0.59", features = [
     "Win32_System_Threading",
 ] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 assert_cmd = "2"
 ctor = "0.2"
@@ -75,9 +78,6 @@ tempfile = "3"
 serde_json = "1"
 tokio = { version = "1", features = ["test-util"] }
 wiremock = "0.6"
-
-[target.'cfg(unix)'.dev-dependencies]
-libc = "0.2"
 
 [[test]]
 name = "e2e"

--- a/packages/cli/src/utils/client.rs
+++ b/packages/cli/src/utils/client.rs
@@ -345,6 +345,8 @@ fn cleanup_stale_files() {
 
 #[cfg(unix)]
 fn auto_start_daemon() -> Result<(), CliError> {
+    use std::os::unix::process::CommandExt;
+
     let exe = std::env::current_exe().map_err(|e| CliError::Internal(e.to_string()))?;
 
     // Redirect daemon stderr to a log file for diagnostics.
@@ -357,7 +359,8 @@ fn auto_start_daemon() -> Result<(), CliError> {
         .map(std::process::Stdio::from)
         .unwrap_or_else(|_| std::process::Stdio::null());
 
-    std::process::Command::new(&exe)
+    let mut command = std::process::Command::new(&exe);
+    command
         .arg("__daemon")
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
@@ -365,7 +368,20 @@ fn auto_start_daemon() -> Result<(), CliError> {
         .env(
             "RUST_LOG",
             std::env::var("RUST_LOG").unwrap_or_else(|_| "info".to_string()),
-        )
+        );
+
+    // Put the daemon in its own session/process group so shell supervisors that
+    // clean up child process groups do not kill it when the short-lived CLI exits.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    command
         .spawn()
         .map_err(|e| CliError::Internal(format!("failed to start daemon: {e}")))?;
 


### PR DESCRIPTION
## Summary
- start the Unix daemon in a new session/process group with `setsid()` before exec
- keep the existing Windows detached-process behavior unchanged
- move `libc` from Unix dev-dependency to Unix dependency because daemon spawn now uses it in production code

## Why
Some agent/sandbox supervisors clean up the process group used by each short-lived CLI command. Without detaching the auto-started Unix daemon, the daemon can be killed after `actionbook browser start`, so a following command sees no sessions.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo test --lib`
- local process-group smoke: launched the CLI in a throwaway Unix session, killed the parent process group, verified the daemon remained alive and a follow-up `browser list-sessions` returned ok
