### PR TITLE
[root]docs: replace deprecated CLI install with remote MCP connector + extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ https://github.com/user-attachments/assets/35079a19-7236-47a8-87ed-3edf6436c2bf
 
 Actionbook runs as a **remote MCP connector** paired with the **Actionbook Chrome extension** — no CLI install required. Your AI agent connects to the hosted MCP endpoint, and the extension drives your real Chrome so agents reuse your logged-in sessions.
 
+> 👉 **For the full step-by-step setup — with per-client instructions and screenshots — visit the [dashboard](https://actionbook.dev/dashboard).** The three steps below are the quick overview.
+
 **1. Install the Chrome extension** from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo).
 
 **2. Add Actionbook as a connector in your AI app.** Open your app's connector settings — **Claude** (Settings → Connectors → Add custom connector), **ChatGPT** (Settings → Connectors), **Perplexity**, **Hermes**, **OpenClaw**, or any other MCP-compatible app — and paste the Actionbook endpoint:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 10x Faster &nbsp; | &nbsp; 90% Token Saving &nbsp; | &nbsp; 30 Actions at Once
 
-![GitHub last commit](https://img.shields.io/github/last-commit/actionbook/actionbook) [![skills](https://img.shields.io/badge/skills-ready-blue)](https://skills.sh/actionbook/actionbook/actionbook)
+![GitHub last commit](https://img.shields.io/github/last-commit/actionbook/actionbook)
 
 [Website](https://actionbook.dev) · [GitHub](https://github.com/actionbook/actionbook) · [X](https://x.com/ActionbookHQ) · [Discord](https://actionbook.dev/discord)
 
@@ -19,7 +19,6 @@ Actionbook turns the websites you work in every day into something your AI agent
 - [Why Actionbook?](#why-actionbook)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
-- [AI Agent Skills](#ai-agent-skills)
 - [Examples](#examples)
 - [Available Tools](#available-tools)
 - [Documentation](#documentation)
@@ -80,24 +79,6 @@ Behind the scenes the agent uses Actionbook to fetch action manuals and operate 
 ```
 Use Actionbook to understand and operate the web page.
 ```
-
-## AI Agent Skills
-
-Actionbook ships with Agent Skills that teach your AI agent how to use Actionbook.
-
-**Claude Code, Cursor, Codex, Windsurf, Antigravity, Opencode** — one command:
-
-```bash
-npx skills add actionbook/actionbook
-```
-
-**Hermes** — one command (registers the skill in `~/.hermes/skills/`):
-
-```bash
-hermes skills install skills-sh/actionbook/actionbook/actionbook -y
-```
-
-Then start a chat and say things like *"use actionbook to open google.com and search for anthropic"*. Hermes auto-activates the skill and drives Actionbook for you.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action
 
 ### Chrome Extension
 
-Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo). Once you sign in from the [dashboard](https://actionbook.dev/dashboard), it connects to the hosted MCP endpoint automatically — no local daemon required.
+Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo). Once you sign in from the [dashboard](https://actionbook.dev/dashboard), it connects to the hosted MCP endpoint automatically.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -48,19 +48,11 @@ Actionbook runs as a **remote MCP connector** paired with the **Actionbook Chrom
 
 **1. Install the Chrome extension** from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo).
 
-**2. Connect your AI client** to the Actionbook MCP endpoint:
+**2. Add Actionbook as a connector in your AI app.** Open your app's connector settings — **Claude** (Settings → Connectors → Add custom connector), **ChatGPT** (Settings → Connectors), **Perplexity**, **Hermes**, **OpenClaw**, or any other MCP-compatible app — and paste the Actionbook endpoint:
 
 ```
 https://edge.actionbook.dev/mcp
 ```
-
-For Claude Code:
-
-```bash
-claude mcp add --transport http actionbook https://edge.actionbook.dev/mcp
-```
-
-For other MCP clients (ChatGPT, Perplexity, Hermes, OpenClaw, or any other MCP-compatible app), add a custom connector pointing at the same URL.
 
 **3. Finish setup from the [dashboard](https://actionbook.dev/dashboard)** — it walks you through connecting your client and confirms the extension is linked.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 10x Faster &nbsp; | &nbsp; 90% Token Saving &nbsp; | &nbsp; 30 Actions at Once
 
-![GitHub last commit](https://img.shields.io/github/last-commit/actionbook/actionbook) [![NPM Downloads](https://img.shields.io/npm/d18m/%40actionbookdev%2Fcli)](https://www.npmjs.com/package/@actionbookdev/cli) [![npm version](https://img.shields.io/npm/v/%40actionbookdev%2Fcli)](https://www.npmjs.com/package/@actionbookdev/cli) [![skills](https://img.shields.io/badge/skills-ready-blue)](https://skills.sh/actionbook/actionbook/actionbook)
+![GitHub last commit](https://img.shields.io/github/last-commit/actionbook/actionbook) [![skills](https://img.shields.io/badge/skills-ready-blue)](https://skills.sh/actionbook/actionbook/actionbook)
 
 [Website](https://actionbook.dev) · [GitHub](https://github.com/actionbook/actionbook) · [X](https://x.com/ActionbookHQ) · [Discord](https://actionbook.dev/discord)
 
@@ -45,52 +45,45 @@ https://github.com/user-attachments/assets/35079a19-7236-47a8-87ed-3edf6436c2bf
 
 ## Installation
 
-Install via npm:
+Actionbook runs as a **remote MCP connector** paired with the **Actionbook Chrome extension** — no CLI install required. Your AI agent connects to the hosted MCP endpoint, and the extension drives your real Chrome so agents reuse your logged-in sessions.
 
-```bash
-npm install -g @actionbookdev/cli
+**1. Install the Chrome extension** from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo).
+
+**2. Connect your AI client** to the Actionbook MCP endpoint:
+
+```
+https://edge.actionbook.dev/mcp
 ```
 
-Or build from source:
+For Claude Code:
 
 ```bash
-cargo install --git https://github.com/actionbook/actionbook --path packages/cli --locked
+claude mcp add --transport http actionbook https://edge.actionbook.dev/mcp
 ```
 
-The Rust-based CLI uses your existing system browser (Chrome, Brave, Edge, Arc, Chromium). Reuse your logged-in sessions for convenience, or launch a clean profile for privacy.
+For other MCP clients (Cursor, ChatGPT, Perplexity, …), add a custom connector pointing at the same URL.
+
+**3. Finish setup from the [dashboard](https://actionbook.dev/dashboard)** — it walks you through connecting your client and confirms the extension is linked.
+
+> **Note:** The standalone `@actionbookdev/cli` package is deprecated. Use the remote connector + Chrome extension above.
 
 ## Quick Start
 
-```bash
-actionbook browser start
+Once the extension is installed and your client is connected (see [Installation](#installation)), just talk to your agent — Actionbook handles the rest:
 
-# Open tabs
-actionbook browser open https://stripe.com --session s1
-actionbook browser open https://linear.app --session s1
-actionbook browser open https://vercel.com --session s1
-
-# Operate all tabs concurrently
-actionbook browser snapshot --session s1 --tab t1 &
-actionbook browser snapshot --session s1 --tab t2 &
-actionbook browser snapshot --session s1 --tab t3 &
-
-# Interact with each tab using refs from its snapshot
-actionbook browser click @e5 --session s1 --tab t1
-actionbook browser fill @e3 "hello" --session s1 --tab t2
-actionbook browser click @e8 --session s1 --tab t3
+```
+Open stripe.com, linear.app, and vercel.com, then grab the pricing from each.
 ```
 
-When working with any AI coding assistant (Claude Code, Cursor, etc.), add this to your prompt:
+Behind the scenes the agent uses Actionbook to fetch action manuals and operate your real Chrome — opening tabs, reading snapshots, clicking, and filling forms across pages concurrently. To nudge it explicitly, add this to your prompt:
 
 ```
 Use Actionbook to understand and operate the web page.
 ```
 
-The agent will automatically use the CLI to fetch action manuals and execute browser operations.
-
 ## AI Agent Skills
 
-Actionbook ships with Agent Skills that teach your AI agent how to use the CLI.
+Actionbook ships with Agent Skills that teach your AI agent how to use Actionbook.
 
 **Claude Code, Cursor, Codex, Windsurf, Antigravity, Opencode** — one command:
 
@@ -104,7 +97,7 @@ npx skills add actionbook/actionbook
 hermes skills install skills-sh/actionbook/actionbook/actionbook -y
 ```
 
-Then start a chat and say things like *"use actionbook to open google.com and search for anthropic"*. Hermes auto-activates the skill and drives the CLI for you.
+Then start a chat and say things like *"use actionbook to open google.com and search for anthropic"*. Hermes auto-activates the skill and drives Actionbook for you.
 
 ## Examples
 
@@ -113,20 +106,11 @@ Explore real-world examples in the [Examples Documentation](https://actionbook.d
 
 ## Available Tools
 
-Actionbook provides tools for searching and retrieving action manuals. See the [CLI Reference](https://actionbook.dev/docs/api-reference/cli) for the full command list. If you're using the MCP integration, see the [MCP Tools Reference](https://actionbook.dev/docs/api-reference/mcp-tools).
+Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action lookup (`search`, `manual`) and browser control (`goto`, `snapshot`, `click`, `fill`, …). See the [MCP Tools Reference](https://actionbook.dev/docs/api-reference/mcp-tools) for the full command list.
 
-### Extension & Daemon
+### Chrome Extension
 
-The recommended way to install the Chrome extension is via the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo) (current version: 0.4.0). `actionbook extension install` is a local fallback — after running it, you must manually load the unpacked extension in Chrome (`chrome://extensions` > Developer mode > Load unpacked).
-
-```bash
-actionbook extension status          # Bridge status + extension connection state
-actionbook extension ping            # Measure bridge RTT
-actionbook extension install         # Fallback: install to ~/Actionbook/extension/ (requires manual Chrome load)
-actionbook extension uninstall       # Remove extension
-actionbook extension path            # Print install path, status, and version
-actionbook daemon restart            # Stop the running daemon (next CLI call respawns)
-```
+Install the extension from the [Chrome Web Store](https://chromewebstore.google.com/detail/actionbook/bebchpafpemheedhcdabookaifcijmfo). Once you sign in from the [dashboard](https://actionbook.dev/dashboard), it connects to the hosted MCP endpoint automatically — no local daemon required.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For Claude Code:
 claude mcp add --transport http actionbook https://edge.actionbook.dev/mcp
 ```
 
-For other MCP clients (Cursor, ChatGPT, Perplexity, …), add a custom connector pointing at the same URL.
+For other MCP clients (ChatGPT, Perplexity, Hermes, OpenClaw, or any other MCP-compatible app), add a custom connector pointing at the same URL.
 
 **3. Finish setup from the [dashboard](https://actionbook.dev/dashboard)** — it walks you through connecting your client and confirms the extension is linked.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Explore real-world examples in the [Examples Documentation](https://actionbook.d
 
 ## Available Tools
 
-Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action lookup (`search`, `manual`) and browser control (`goto`, `snapshot`, `click`, `fill`, …). See the [MCP Tools Reference](https://actionbook.dev/docs/api-reference/mcp-tools) for the full command list.
+Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action lookup (`search`, `manual`) and browser control (`goto`, `snapshot`, `click`, `fill`, …). Your agent discovers the full command set from the tool description once connected.
 
 ### Chrome Extension
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Explore real-world examples in the [Examples Documentation](https://actionbook.d
 
 ## Available Tools
 
-Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action lookup (`search`, `manual`) and browser control (`goto`, `snapshot`, `click`, `fill`, …). Your agent discovers the full command set from the tool description once connected.
+Actionbook exposes a single `actionbook` MCP tool whose subcommands cover action lookup (`search`, `manual`) and browser control (`goto`, `snapshot`, `click`, `type`, …). Your agent discovers the full command set from the tool description once connected.
 
 ### Chrome Extension
 


### PR DESCRIPTION
## Why

The standalone `@actionbookdev/cli` package is deprecated, but the README still led with `npm install -g @actionbookdev/cli` / `cargo install … packages/cli` and a Quick Start full of `actionbook browser …` shell commands. AI agents asked to "install actionbook" read this README and copy those, landing on the dead CLI path instead of the hosted MCP connector + Chrome extension.

## What

Rewrote every CLI-facing section of the README to point at the canonical setup:

- **Installation** — 3-step flow: install the Chrome extension → connect your client to `https://edge.actionbook.dev/mcp` (with the `claude mcp add --transport http` command) → finish from the dashboard. Plus an explicit deprecation note for `@actionbookdev/cli`.
- **Quick Start** — dropped the `actionbook browser start/open/snapshot/click/fill` shell commands in favor of prompt-driven usage.
- **AI Agent Skills** — reworded "use the CLI" / "drives the CLI" → "Actionbook" (skills install commands unchanged).
- **Available Tools** — describes the single `actionbook` MCP tool (`search` / `manual` / `browser` subcommands); dropped the CLI Reference link.
- **Extension & Daemon → Chrome Extension** — removed the local `actionbook extension …` / `actionbook daemon …` commands and the daemon concept (no local daemon in connector mode).
- Removed the two `@actionbookdev/cli` npm badges from the header.

This is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)